### PR TITLE
[FEATURE] Add ViewHelper to convert raw FlexForm XML into an array

### DIFF
--- a/Classes/ViewHelpers/Flexform/DataViewHelper.php
+++ b/Classes/ViewHelpers/Flexform/DataViewHelper.php
@@ -66,7 +66,7 @@ class Tx_Flux_ViewHelpers_Flexform_DataViewHelper extends Tx_Fluid_Core_ViewHelp
 		$row = $GLOBALS['TYPO3_DB']->exec_SELECTgetSingleRow($field, $table, sprintf('uid=%d', $uid));
 
 		if (NULL === $row) {
-			$dataArray = array();
+			throw new Tx_Fluid_Core_ViewHelper_Exception(sprintf('Either table "%s", field "%s" or record with uid %d do not exist.', $table, $field, $uid), 1358679983);
 		} else {
 			$dataArray = $this->flexFormService->convertFlexFormContentToArray($row[$field]);
 		}


### PR DESCRIPTION
This viewhelper converts raw FlexForm XML data into an associative array for the provided uid, table and field. Table defaults to 'pages', field defaults to 'tx_fed_page_flexform'. Converted data is cached statically.
