### PR TITLE
[BUGFIX] Fix PHP error because of missing method "injectPageService"

### DIFF
--- a/Classes/Provider/Configuration/Fallback/PluginConfigurationProvider.php
+++ b/Classes/Provider/Configuration/Fallback/PluginConfigurationProvider.php
@@ -30,6 +30,13 @@
 class Tx_Flux_Provider_Configuration_Fallback_PluginConfigurationProvider extends Tx_Flux_Provider_Configuration_Fallback_ConfigurationProvider implements Tx_Flux_Provider_PluginConfigurationProviderInterface {
 
 	/**
+	 * @param Tx_Fed_Service_Page $pageLayout
+	 */
+	public function injectPageService(Tx_Fed_Service_Page $pageService) {
+		$this->pageService = $pageService;
+	}
+
+	/**
 	 * @var string|NULL
 	 */
 	protected $listType = NULL;


### PR DESCRIPTION
I got this PHP error:

```
Call to undefined method
Tx_Flux_Provider_Configuration_Fallback_PluginConfigurationProvider::injectPageService() 
in t3core/typo3_src-4.5.git/typo3/sysext/extbase/Classes/Object/Container/Container.php on line 187
```

Version: 
- TYPO3 4.5 latest
- Flux and Fed master

The patch solves the problem although I am not sure if it is the optimal one.
