### PR TITLE
[FEATURE] Enable sheet compacting in individual Flux forms

### DIFF
--- a/Classes/Provider/Structure/FlexFormStructureProvider.php
+++ b/Classes/Provider/Structure/FlexFormStructureProvider.php
@@ -56,7 +56,9 @@ class Tx_Flux_Provider_Structure_FlexFormStructureProvider extends Tx_Flux_Provi
 				'langDisable' => 1
 			),
 		);
-		if ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup']['compact'] && count($sheets) < 2) {
+		$compactExtensionToggleOn = 0 < $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup']['compact'];
+		$compactConfigurationToggleOn = 0 < $configuration['compact'];
+		if (($compactExtensionToggle || $compactConfigurationToggleOn) && count($sheets) < 2) {
 			$dataStructArray['ROOT'] = array(
 				'type' => 'array',
 				'el' => array(),

--- a/Classes/ViewHelpers/FlexformViewHelper.php
+++ b/Classes/ViewHelpers/FlexformViewHelper.php
@@ -43,6 +43,7 @@ class Tx_Flux_ViewHelpers_FlexformViewHelper extends Tx_Flux_Core_ViewHelper_Abs
 		$this->registerArgument('mergeValues', 'boolean', 'If TRUE, enables overriding of record values with corresponding values from this FlexForm', FALSE, FALSE);
 		$this->registerArgument('enabled', 'boolean', 'If FALSE, makes the FCE inactive', FALSE, TRUE);
 		$this->registerArgument('wizardTab', 'string', 'Optional tab name (usually extension key) in which to place the content element in the new content element wizard', FALSE, 'FCE');
+		$this->registerArgument('compact', 'boolean', 'If TRUE, disables sheet usage in the form. WARNING! AVOID DYNAMIC VALUES AT ALL COSTS! Toggling this option is DESTRUCTIVE to variables currently saved in the database!', FALSE, FALSE);
 	}
 
 	/**
@@ -58,6 +59,7 @@ class Tx_Flux_ViewHelpers_FlexformViewHelper extends Tx_Flux_Core_ViewHelper_Abs
 			'label' => $this->arguments['label'],
 			'description' => $this->arguments['description'],
 			'icon' => $icon,
+			'compact' => $this->arguments['compact'],
 			'enabled' => $this->arguments['enabled'],
 			'wizardTab' => $this->arguments['wizardTab'],
 			'mergeValues' => $this->arguments['mergeValues'],


### PR DESCRIPTION
WARNING: DO NOT USE DYNAMIC VARIABLES!
WARNING: IS DESTRUCTIVE WHEN CHANGED IN AN EXISTING ELEMENT!

Be very careful about this new toggle. Only use it in absolutely fresh content element templates - once data has been saved in either state, toggling the state destroys the database content; it can even potentially cause "invalid argument type for foreach" errors when using section objects in Flux forms.

In short: there are some pitfalls but using it on all new content templates is completely safe.
