### PR TITLE
[BUGFIX] Extend DataHandler override from TCEmain for compatibility

### DIFF
--- a/Classes/Override/Core/DataHandling/DataHandler.php
+++ b/Classes/Override/Core/DataHandling/DataHandler.php
@@ -30,7 +30,7 @@
  * @package Flux
  * @subpackage Override\Core\DataHandling
  */
-class Tx_Flux_Override_Core_DataHandling_DataHandler extends \TYPO3\CMS\Core\DataHandling\DataHandler {
+class Tx_Flux_Override_Core_DataHandling_DataHandler extends t3lib_TCEmain {
 
 	/**
 	 * Evaluates 'flex' type values.


### PR DESCRIPTION
This change should allow the overrides to work on installs using hook processors which needlessly define a required class name on the fourth parameter of most TCEmain hook call dispatching functions.

Although this adds yet another class inheritance layer it's preferable to allowing unpatched third-party extensions such as TemplaVoila to fail.

Fixes: #22
