### PR TITLE
[BUGFIX] Fix var export return value, prevent output

### DIFF
--- a/Classes/Service/Configuration.php
+++ b/Classes/Service/Configuration.php
@@ -75,7 +75,7 @@ class Tx_Flux_Service_Configuration implements t3lib_Singleton {
 		list ($extensionKey, $action) = explode('->', $reference);
 		$action{0} = strtolower($action{0});
 		$extensionName = ucfirst(t3lib_div::underscoredToLowerCamelCase($extensionKey));
-		$potentialControllerClassName = 'Tx_' . $extensionName . '_Controllers_' . $controllerObjectShortName . 'Controller';
+		$potentialControllerClassName = 'Tx_' . $extensionName . '_Controller_' . $controllerObjectShortName . 'Controller';
 		if (FALSE === class_exists($potentialControllerClassName)) {
 			if (TRUE === $failHardClass) {
 				throw new Exception('Class ' . $potentialControllerClassName . ' does not exist. It was build from: ' . var_export($reference, TRUE) .


### PR DESCRIPTION
Fixes an unintentional output variable dump which should be returned as a string.
