### PR TITLE
[TASK] Remove tidy requirement and add XML validation

### DIFF
--- a/Classes/Core/ViewHelper/AbstractFlexformViewHelper.php
+++ b/Classes/Core/ViewHelper/AbstractFlexformViewHelper.php
@@ -205,9 +205,9 @@ abstract class Tx_Flux_Core_ViewHelper_AbstractFlexformViewHelper extends Tx_Flu
 		$file = substr($file, 4);
 		$filePathAndFilename = t3lib_div::getFileAbsFileName($file);
 		$dom = new DOMDocument('1.0', 'utf-8');
-		$dom->preserveWhiteSpace = false;
+		$dom->preserveWhiteSpace = FALSE;
 		$dom->load($filePathAndFilename);
-		$dom->formatOutput = true;
+		$dom->formatOutput = TRUE;
 		foreach ($dom->getElementsByTagName('languageKey') as $languageNode) {
 			$nodes = array();
 			foreach ($languageNode->getElementsByTagName('label') as $labelNode) {
@@ -229,9 +229,15 @@ abstract class Tx_Flux_Core_ViewHelper_AbstractFlexformViewHelper extends Tx_Flu
 				$languageNode->appendChild($labelNode);
 			}
 		}
-		$this->debugService->message('Rewrote "' . $file . '" by adding placeholder label for "' . $identifier . '"',
-			t3lib_div::SYSLOG_SEVERITY_INFO, $debugTitle);
-		$dom->save($filePathAndFilename);
+		$xml = $dom->saveXML();
+		if (FALSE === $xml) {
+			$this->debugService->message('Skipping LLL file saving due to an error while generating the XML.',
+				t3lib_div::SYSLOG_SEVERITY_FATAL);
+		} else {
+			$this->debugService->message('Rewrote "' . $file . '" by adding placeholder label for "' . $identifier . '"',
+				t3lib_div::SYSLOG_SEVERITY_INFO, $debugTitle);
+			file_put_contents($filePathAndFilename, $xml);
+		}
 	}
 
 


### PR DESCRIPTION
Simplifies the formatting of generated XML for label translations and validates generated XML before saving.
