### PR TITLE
[TASK] Fix invalid argument warning in BE for fluidpages

### DIFF
--- a/Classes/Core.php
+++ b/Classes/Core.php
@@ -73,7 +73,7 @@ class Tx_Flux_Core {
 		if (TRUE === isset(self::$extensions[$forControllerName])) {
 			return self::$extensions[$forControllerName];
 		}
-		return NULL;
+		return array();
 	}
 
 


### PR DESCRIPTION
Tx_Flux_Core::getRegisteredProviderExtensionKeys() should always return arrays.
