### PR TITLE
[BUGFIX] Set Ucfirst field names to lowercase

### DIFF
--- a/Classes/ViewHelpers/Flexform/Field/FileViewHelper.php
+++ b/Classes/ViewHelpers/Flexform/Field/FileViewHelper.php
@@ -48,7 +48,7 @@ class Tx_Flux_ViewHelpers_Flexform_Field_FileViewHelper extends Tx_Flux_ViewHelp
 	 */
 	public function render() {
 		$config = $this->getFieldConfig();
-		$config['type'] = 'Group';
+		$config['type'] = 'group';
 		$config['internal_type'] = $this->arguments['internalType'];
 		$config['allowed'] = $this->arguments['allowed'];
 		$config['uploadfolder'] = $this->arguments['uploadFolder'];

--- a/Classes/ViewHelpers/Flexform/Field/SelectViewHelper.php
+++ b/Classes/ViewHelpers/Flexform/Field/SelectViewHelper.php
@@ -79,7 +79,7 @@ class Tx_Flux_ViewHelpers_Flexform_Field_SelectViewHelper extends Tx_Flux_ViewHe
 	 */
 	protected function getFieldConfig() {
 		$config = $this->getBaseConfig();
-		$config['type'] = 'Select';
+		$config['type'] = 'select';
 		if ($this->arguments['commaSeparatedItems']) {
 			$config['items'] = array();
 			$itemNames = t3lib_div::trimExplode(',', $this->arguments['commaSeparatedItems']);


### PR DESCRIPTION
Although this does not appear to affect the rendering in any way, the proper format for a TCEforms field is in lowercase characters so classifying as bug fix even if this "bug" had no real world impact.
