### PR TITLE
[BUGFIX] Fix wrong test in method registerProviderExtensionKey

### DIFF
--- a/Classes/Core.php
+++ b/Classes/Core.php
@@ -60,7 +60,8 @@ class Tx_Flux_Core {
 		if (FALSE === isset(self::$extensions[$providesControllerName])) {
 			self::$extensions[$providesControllerName] = array();
 		}
-		if (FALSE === in_array($extensionKey[$providesControllerName], self::$extensions)) {
+
+		if (FALSE === in_array($extensionKey, self::$extensions[$providesControllerName])) {
 			array_push(self::$extensions[$providesControllerName], $extensionKey);
 		}
 	}


### PR DESCRIPTION
According to the method definition $extensionKey is given as string.
Assuming, the logic is to search an extension key from an array of
extensions, the test must be fixed solving a warning on the FE.
