### PR TITLE
[FEATURE] "Is reference" indicator and link to anchored original

### DIFF
--- a/Classes/Backend/AbstractPreview.php
+++ b/Classes/Backend/AbstractPreview.php
@@ -78,6 +78,18 @@ abstract class Tx_Flux_Backend_AbstractPreview implements tx_cms_layout_tt_conte
 		} else {
 			$fieldName = NULL;
 		}
+		if ('shortcut' === $row['CType'] && FALSE === strpos($row['records'], ',')) {
+			$targetRecords = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows('p.title, t.pid', 'tt_content t, pages p', "t.uid = '" . $row['records'] . "' AND p.uid = t.pid");
+			$targetRecord = array_pop($targetRecords);
+			$title = Tx_Extbase_Utility_Localization::translate('reference', 'Flux', array(
+				$targetRecord['title']
+			));
+			$targetLink = '?id=' . $targetRecord['pid'] . '#c' . $row['records'];
+			$iconClass = 't3-icon t3-icon-actions-insert t3-icon-insert-reference t3-icon-actions t3-icon-actions-insert-reference';
+			$icon = '<a title="' . $title . '" href="' . $targetLink . '"><span class="' . $iconClass . '"></spa></a>';
+			$itemContent = $icon . $itemContent;
+		}
+		$itemContent = '<a name="c' . $row['uid'] . '"></a>' . $itemContent;
 		$providers = $this->configurationService->resolveConfigurationProviders('tt_content', $fieldName, $row);
 		foreach ($providers as $provider) {
 			/** @var Tx_Flux_Provider_ConfigurationProviderInterface $provider */

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -11,6 +11,7 @@
 		<label index="tt_content.tx_flux_column">Content area of parent</label>
 		<label index="tt_content.tx_flux_options">Options</label>
 		<label index="flux.clearValue">Clear value</label>
+		<label index="reference">Reference to content on page '%s' - click to jump to original</label>
 
 		<label index="object.image">Image</label>
 		<label index="object.image.title">Image title/alt text</label>
@@ -49,6 +50,7 @@
 		<label index="tt_content.tx_flux_column">Übergeordneter Inhaltsbereich</label>
 		<label index="tt_content.tx_flux_options">Optionen</label>
 		<label index="flux.clearValue">Clear value</label>
+		<label index="reference">Reference to content on page '%s' - click to jump to original</label>
 
 		<label index="object.image">Bild</label>
 		<label index="object.image.title">Bild title/alt Text</label>


### PR DESCRIPTION
Allows straight-to-position jump to original element if current shortcut-type element is a reference to a single content element - which is how Flux stores references.

Fixes: #41
