### PR TITLE
[BUGFIX] Unintended removal of template variable in <flux:content.get />

### DIFF
--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -110,15 +110,10 @@ class Tx_Flux_ViewHelpers_Content_GetViewHelper extends Tx_Fluid_Core_ViewHelper
 		} else {
 			$as = $this->arguments['as'];
 			if (TRUE === $this->templateVariableContainer->exists($as)) {
-				$backup = $this->templateVariableContainer->get($as);
 				$this->templateVariableContainer->remove($as);
 			}
 			$this->templateVariableContainer->add($as, $elements);
 			$content = $this->renderChildren();
-			$this->templateVariableContainer->remove($as);
-			if (TRUE === isset($backup)) {
-				$this->templateVariableContainer->add($as, $backup);
-			}
 		}
 		if ($loadRegister) {
 			$this->configurationManager->getContentObject()->cObjGetSingle('RESTORE_REGISTER', '');


### PR DESCRIPTION
When argument `as` is configured a possibly existing template variable of the same name is backed up and  restored after `renderChildren()` is invoked. Plus the desired template variable is always removed from the template variable container. I also removed the backup part because `as` IMHO should always override an existing value.
