### PR TITLE
[BUGFIX] Use raw flux field name where required and NULL must be avoided

### DIFF
--- a/Classes/Provider/AbstractConfigurationProvider.php
+++ b/Classes/Provider/AbstractConfigurationProvider.php
@@ -390,13 +390,7 @@ class Tx_Flux_Provider_AbstractConfigurationProvider implements Tx_Flux_Provider
 	 */
 	public function getFlexFormValues(array $row) {
 		try {
-			$className = get_class($this);
-			$fieldName = $this->getFieldName($row);
-			if (NULL === $fieldName) {
-				$this->configurationService->message('Returning empty array from ' . $className .
-					' - detected field name NULL and parent getFlexFormValues method is being inherited and used.');
-				return array();
-			}
+			$fieldName = $this->fieldName;
 			$stored = $this->getTemplateVariables($row);
 			$immediateConfiguration = $this->configurationService->convertFlexFormContentToArray($row[$fieldName], $stored);
 			$tree = $this->getInheritanceTree($row);


### PR DESCRIPTION
This fixes an issue on 4.x branches when retrieving flexform variables; before this patch the internal getFieldName() was being used which would return NULL on 4.x branches, making getFlexFormValues() return too early.
