### PR TITLE
[TASK] Switch from NULL field name in default ContentConfigurationProvider

### DIFF
--- a/Classes/Provider/Configuration/ContentObjectConfigurationProvider.php
+++ b/Classes/Provider/Configuration/ContentObjectConfigurationProvider.php
@@ -49,7 +49,7 @@ class Tx_Flux_Provider_Configuration_ContentObjectConfigurationProvider extends 
 	/**
 	 * @var string
 	 */
-	protected $fieldName = NULL;
+	protected $fieldName = 'pi_flexform';
 
 	/**
 	 * @param array $row


### PR DESCRIPTION
There are already measures in place to view this field name as NULL in the proper places when running on 4.x which is the only time a NULL field value applies. The Flux core _should_ be better suited with having an actual field name for this particular Provider.

Note: You'll want to test this one on a site that uses EXT:fluidcontent to be sure it executes all BE hooks properly still; this could have an effect on the prioritising of Providers.
