### PR TITLE
[FEATURE] Thin API to add global, static TypoScript includes

### DIFF
--- a/Classes/Backend/TypoScriptTemplate.php
+++ b/Classes/Backend/TypoScriptTemplate.php
@@ -1,0 +1,48 @@
+<?php
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2013 Claus Due <claus@wildside.dk>, Wildside A/S
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+/**
+ * @package Flux
+ * @subpackage Backend
+ */
+class Tx_Flux_Backend_TypoScriptTemplate {
+
+	/**
+	 * Includes static template from extensions
+	 *
+	 * @param array $params
+	 * @param t3lib_TStemplate $pObj
+	 * @return void
+	 */
+	public function preprocessIncludeStaticTypoScriptSources(array $params, $pObj) {
+		if (TRUE === isset($params['row']['root']) && TRUE === (boolean) $params['row']['root']) {
+			$existingTemplates = t3lib_div::trimExplode(',', $params['row']['include_static_file']);
+			$globalStaticTemplates = Tx_Flux_Core::getStaticTypoScriptLocations();
+			$staticTemplates = array_merge($globalStaticTemplates, $existingTemplates);
+			$params['row']['include_static_file'] = implode(',', array_unique($staticTemplates));
+		}
+	}
+
+}

--- a/Classes/Core.php
+++ b/Classes/Core.php
@@ -52,6 +52,36 @@ class Tx_Flux_Core {
 	private static $extensions = array();
 
 	/**
+	 * Contains all programatically added TypoScript configuration files for auto-inclusion
+	 * @var array
+	 */
+	private static $staticTypoScriptFiles = array();
+
+	/**
+	 * @return array
+	 */
+	public static function getStaticTypoScriptLocations() {
+		return self::$staticTypoScriptFiles;
+	}
+
+	/**
+	 * @param mixed $locationOrLocations
+	 * @return void
+	 */
+	public static function addGlobalTypoScript($locationOrLocations) {
+		if (TRUE === is_array($locationOrLocations) || TRUE === $locationOrLocations instanceof Traversable) {
+			foreach ($locationOrLocations as $location) {
+				self::addGlobalTypoScript($location);
+			}
+			return;
+		} else {
+			if (FALSE === in_array($locationOrLocations, self::$staticTypoScriptFiles)) {
+				array_push(self::$staticTypoScriptFiles, $locationOrLocations);
+			}
+		}
+	}
+
+	/**
 	 * @param string $extensionKey
 	 * @param string $providesControllerName
 	 * @return void

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -58,6 +58,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['proc
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass']['flux'] = 'EXT:flux/Classes/Backend/TceMain.php:Tx_Flux_Backend_TceMain';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['moveRecordClass']['flux'] = 'EXT:flux/Classes/Backend/TceMain.php:Tx_Flux_Backend_TceMain';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'EXT:flux/Classes/Backend/TceMain.php:&Tx_Flux_Backend_TceMain->clearCacheCommand';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tstemplate.php']['includeStaticTypoScriptSources'][] = 'EXT:flux/Classes/Backend/TypoScriptTemplate.php:Tx_Flux_Backend_TypoScriptTemplate->preprocessIncludeStaticTypoScriptSources';
+
 
 /*
  * The following code fixes the following issue:


### PR DESCRIPTION
These inclusions do not show up in the static TypoScript template selector - and thus should only be used for truly global TypoScript which is 1) not susceptible to inclusion order and 2) never needs to or is allowed to be removed by an integrator.

Integrators can still change the TypoScript values included this way - but cannot remove the entire inclusion.

Example usages:

```
Tx_Flux_Core::addGlobalTypoScript('EXT:myext/Configuration/TypoScript/');
Tx_Flux_Core::addGlobalTypoScript(array(
    'EXT:myext/Configuration/TypoScript/',
    'EXT:myext/Configuration/OtherTypoScript/'
));
```

...which will load `setup.txt` and if it exists, `constants.txt` from the provided location or locations, same as when including traditional static TS.

Since there is no display in the static TS template selector, inclusions do not require a name - just the location or locations to be included.
