### PR TITLE
[BUGFIX] Tx_Extbase_Object_ObjectManagerInterface::create() is deprecated

### DIFF
--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -217,7 +217,7 @@ class Tx_Flux_Controller_AbstractFluxController extends Tx_Extbase_MVC_Controlle
 				return $this->view->render();
 			}
 			/** @var $response Tx_Extbase_MVC_Web_Response */
-			$response = $this->objectManager->create('Tx_Extbase_MVC_Web_Response');
+			$response = $this->objectManager->get('Tx_Extbase_MVC_Web_Response');
 			$potentialControllerInstance = $this->objectManager->get($potentialControllerClassName);
 			$this->request->setControllerActionName($overriddenControllerActionName);
 			$this->request->setControllerExtensionName($controllerExtensionName);

--- a/Classes/Core.php
+++ b/Classes/Core.php
@@ -153,7 +153,7 @@ class Tx_Flux_Core {
 	public static function registerFluidFlexFormPlugin($extensionKey, $pluginSignature, $templateFilename, $variables=array(), $section=NULL, $paths=NULL) {
 		$objectManager = t3lib_div::makeInstance('Tx_Extbase_Object_ObjectManager');
 		/** @var $provider Tx_Flux_Provider_Configuration_Fallback_PluginConfigurationProvider */
-		$provider = $objectManager->create('Tx_Flux_Provider_Configuration_Fallback_PluginConfigurationProvider');
+		$provider = $objectManager->get('Tx_Flux_Provider_Configuration_Fallback_PluginConfigurationProvider');
 		$provider->setTableName('tt_content');
 		$provider->setFieldName('');
 		$provider->setExtensionKey($extensionKey);
@@ -182,7 +182,7 @@ class Tx_Flux_Core {
 		/** @var $objectManager Tx_Extbase_Object_ObjectManagerInterface */
 		$objectManager = t3lib_div::makeInstance('Tx_Extbase_Object_ObjectManager');
 		/** @var $provider Tx_Flux_Provider_Configuration_Fallback_ContentObjectConfigurationProvider */
-		$provider = $objectManager->create('Tx_Flux_Provider_Configuration_Fallback_ContentObjectConfigurationProvider');
+		$provider = $objectManager->get('Tx_Flux_Provider_Configuration_Fallback_ContentObjectConfigurationProvider');
 		$provider->setTableName('tt_content');
 		$provider->setFieldName('');
 		$provider->setExtensionKey($extensionKey);
@@ -211,7 +211,7 @@ class Tx_Flux_Core {
 		/** @var $objectManager Tx_Extbase_Object_ObjectManagerInterface */
 		$objectManager = t3lib_div::makeInstance('Tx_Extbase_Object_ObjectManager');
 		/** @var $provider Tx_Flux_Provider_Configuration_Fallback_ConfigurationProvider */
-		$provider = $objectManager->create('Tx_Flux_Provider_Configuration_Fallback_ConfigurationProvider');
+		$provider = $objectManager->get('Tx_Flux_Provider_Configuration_Fallback_ConfigurationProvider');
 		$provider->setTableName($table);
 		$provider->setFieldName($fieldName);
 		$provider->setTemplatePathAndFilename($templateFilename);

--- a/Classes/Provider/AbstractConfigurationProvider.php
+++ b/Classes/Provider/AbstractConfigurationProvider.php
@@ -360,7 +360,7 @@ class Tx_Flux_Provider_AbstractConfigurationProvider implements Tx_Flux_Provider
 			$templatePathAndFilename = $this->getTemplatePathAndFilename($row);
 			if (FALSE === file_exists($templatePathAndFilename)) {
 				/** @var $fallbackStructureProvider Tx_Flux_Provider_Structure_FallbackStructureProvider */
-				$fallbackStructureProvider = $this->objectManager->create('Tx_Flux_Provider_Structure_FallbackStructureProvider');
+				$fallbackStructureProvider = $this->objectManager->get('Tx_Flux_Provider_Structure_FallbackStructureProvider');
 				$config['parameters'] = array(
 					'userFunction' => 'Tx_Flux_UserFunction_NoTemplate->renderField'
 				);

--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -115,16 +115,16 @@ class Tx_Flux_Service_FluxService implements t3lib_Singleton {
 			$controllerName = 'Flux';
 		}
 		/** @var $context Tx_Extbase_MVC_Controller_ControllerContext */
-		$context = $this->objectManager->create('Tx_Extbase_MVC_Controller_ControllerContext');
+		$context = $this->objectManager->get('Tx_Extbase_MVC_Controller_ControllerContext');
 		/** @var $request Tx_Extbase_MVC_Web_Request */
-		$request = $this->objectManager->create('Tx_Extbase_MVC_Web_Request');
+		$request = $this->objectManager->get('Tx_Extbase_MVC_Web_Request');
 		/** @var $response Tx_Extbase_MVC_Web_Response */
-		$response = $this->objectManager->create('Tx_Extbase_MVC_Web_Response');
+		$response = $this->objectManager->get('Tx_Extbase_MVC_Web_Response');
 		$request->setControllerExtensionName($extensionName);
 		$request->setControllerName($controllerName);
 		$request->setDispatched(TRUE);
 		/** @var $uriBuilder Tx_Extbase_Mvc_Web_Routing_UriBuilder */
-		$uriBuilder = $this->objectManager->create('Tx_Extbase_Mvc_Web_Routing_UriBuilder');
+		$uriBuilder = $this->objectManager->get('Tx_Extbase_Mvc_Web_Routing_UriBuilder');
 		$uriBuilder->setRequest($request);
 		$context->setRequest($request);
 		$context->setResponse($response);
@@ -362,7 +362,7 @@ class Tx_Flux_Service_FluxService implements t3lib_Singleton {
 				if (TRUE === isset(self::$cache[$providerCacheKey])) {
 					$provider = &self::$cache[$providerCacheKey];
 				} else {
-					$provider = $this->objectManager->create($providerClassNameOrInstance);
+					$provider = $this->objectManager->get($providerClassNameOrInstance);
 				}
 			}
 			$priority = $provider->getPriority($row);
@@ -409,13 +409,13 @@ class Tx_Flux_Service_FluxService implements t3lib_Singleton {
 	 */
 	public function convertFlexFormConfigurationToDataStructure($config) {
 		/** @var $flexFormStructureProvider Tx_Flux_Provider_Structure_FlexFormStructureProvider */
-		$flexFormStructureProvider = $this->objectManager->create('Tx_Flux_Provider_Structure_FlexFormStructureProvider');
+		$flexFormStructureProvider = $this->objectManager->get('Tx_Flux_Provider_Structure_FlexFormStructureProvider');
 		$dataStructArray = $flexFormStructureProvider->render($config);
 		if ((FALSE === is_array($dataStructArray['ROOT']['el']) && FALSE === is_array($dataStructArray['sheets'])) || (count($dataStructArray['sheets']) < 1 && count($dataStructArray['ROOT']['el']) < 1 && count($dataStructArray['sheets'][key($dataStructArray['sheets'])]) === 0)) {
 			$config['parameters'] = array(
 				'userFunction' => 'Tx_Flux_UserFunction_NoFields->renderField'
 			);
-			$dataStructArray = $this->objectManager->create('Tx_Flux_Provider_Structure_FallbackStructureProvider')->render($config);
+			$dataStructArray = $this->objectManager->get('Tx_Flux_Provider_Structure_FallbackStructureProvider')->render($config);
 		}
 		return $dataStructArray;
 	}
@@ -441,7 +441,7 @@ class Tx_Flux_Service_FluxService implements t3lib_Singleton {
 				$config['parameters'] = array(
 					'userFunction' => 'Tx_Flux_UserFunction_NoTemplate->renderField'
 				);
-				$dataStructArray = $this->objectManager->create('Tx_Flux_Provider_Structure_FallbackStructureProvider')->render($config);
+				$dataStructArray = $this->objectManager->get('Tx_Flux_Provider_Structure_FallbackStructureProvider')->render($config);
 				return;
 			}
 			$config = $this->getFlexFormConfigurationFromFile($templateFile, $values, $section, $paths, $extensionName);
@@ -455,7 +455,7 @@ class Tx_Flux_Service_FluxService implements t3lib_Singleton {
 				'userFunction' => 'Tx_Flux_UserFunction_ErrorReporter->renderField'
 			);
 			if (FALSE === t3lib_extMgm::isLoaded('templavoila')) {
-				$dataStructArray = $this->objectManager->create('Tx_Flux_Provider_Structure_FallbackStructureProvider')->render($config);
+				$dataStructArray = $this->objectManager->get('Tx_Flux_Provider_Structure_FallbackStructureProvider')->render($config);
 			}
 		}
 	}

--- a/Classes/ViewHelpers/Flexform/Object/Controller/StandardObjectController.php
+++ b/Classes/ViewHelpers/Flexform/Object/Controller/StandardObjectController.php
@@ -87,7 +87,7 @@ class Tx_Flux_ViewHelpers_Flexform_Object_Controller_StandardObjectController ex
 		$templateFileName = $viewConfiguration['partialRootPath'] . 'Flexform/Object/' . $this->objectType . '.xml';
 		$templatePathAndFilename = Tx_Flux_Utility_Path::translatePath($templateFileName);
 		/** @var Tx_Fluid_Core_Rendering_RenderingContext $renderingContext */
-		$renderingContext = $this->objectManager->create('Tx_Fluid_Core_Rendering_RenderingContext');
+		$renderingContext = $this->objectManager->get('Tx_Fluid_Core_Rendering_RenderingContext');
 		$renderingContext->setControllerContext($this->controllerContext);
 		if (method_exists($renderingContext, 'injectViewHelperVariableContainer') === FALSE) {
 			throw new Exception('FlexForm section object Widgets are not supported on TYPO3 4.5', 1343612008);


### PR DESCRIPTION
Fixed by calling Tx_Extbase_Object_ObjectManagerInterface::get() instead.
