### PR TITLE
[TASK] Broaden catch statement for FAL related Exceptions

### DIFF
--- a/Classes/Override/Backend/Form/FormEngine.php
+++ b/Classes/Override/Backend/Form/FormEngine.php
@@ -214,9 +214,10 @@ class Tx_Flux_Override_Backend_Form_FormEngine extends t3lib_TCEforms {
 	public function getSingleField_SW($table, $field, $row, &$PA) {
 		try {
 			$field = parent::getSingleField_SW($table, $field, $row, $PA);
-		} catch (\TYPO3\CMS\Core\Resource\Exception\FileDoesNotExistException $error) {
-			$message = new t3lib_FlashMessage('WARNING! Removed FAL resource detected. The field "' . $field . '" has been reset to ' .
-				'an empty value in order to prevent fatal, unrecoverable errors', 'WARNING', t3lib_div::SYSLOG_SEVERITY_FATAL);
+		} catch (\TYPO3\CMS\Core\Resource\Exception $error) {
+			$message = new t3lib_FlashMessage('WARNING! FAL resource problem detected. The field "' . $field . '" has been reset to ' .
+				'an empty value in order to prevent fatal, unrecoverable errors. The actual message is a ' . get_class($error) .
+				' which states: (' . $error->getCode() . ') ' . $error->getMessage(), 'WARNING', t3lib_div::SYSLOG_SEVERITY_FATAL);
 			t3lib_FlashMessageQueue::addMessage($message);
 			$PA['itemFormElValue'] = '';
 			$field = parent::getSingleField_SW($table, $field, $row, $PA);


### PR DESCRIPTION
This change modifies the "uncaught Exception" prevention in the overridden FormEngine, thus protecting against many more types of possible errors. Which are all subclassed Exceptions of the same type of Exception.

Fixes: #187
