### PR TITLE
[BUGFIX] Prevent PHP warning when saving in BE

### DIFF
--- a/Classes/Backend/TceMain.php
+++ b/Classes/Backend/TceMain.php
@@ -191,8 +191,10 @@ class Tx_Flux_Backend_TceMain {
 			return;
 		}
 		$manifestCacheFiles = glob(t3lib_div::getFileAbsFileName('typo3temp/*-manifest.cache'));
-		foreach ($manifestCacheFiles as $manifestCacheFile) {
-			unlink($manifestCacheFile);
+		if (FALSE !== $manifestCacheFiles) {
+			foreach ($manifestCacheFiles as $manifestCacheFile) {
+				unlink($manifestCacheFile);
+			}
 		}
 		$tables = array_keys($GLOBALS['TCA']);
 		foreach ($tables as $table) {


### PR DESCRIPTION
When saving some content in the BE, the clearCacheCmd hook throws a PHP warning if no manifestCachefiles are present in the typo3temp directory.
Fixed by testing the return of glob() before entering the foreach.
