### PR TITLE
[BUGFIX] Correct structure array for sections

### DIFF
--- a/Classes/Form/Container/Section.php
+++ b/Classes/Form/Container/Section.php
@@ -29,4 +29,16 @@
  */
 class Tx_Flux_Form_Container_Section extends Tx_Flux_Form_Container_Container {
 
+	/**
+	 * @return array
+	 */
+	public function build() {
+		$structureArray = array(
+			'type' => 'array',
+			'section' => 1,
+			'el' => $this->buildChildren()
+		);
+		return $structureArray;
+	}
+
 }


### PR DESCRIPTION
The current implementation treats sections and containers equally which leads to incorrect rendering of either of the two in BE.
