### PR TITLE
[BUGFIX] Consider all children to check if a sheet is empty

### DIFF
--- a/Classes/Form/Container/Sheet.php
+++ b/Classes/Form/Container/Sheet.php
@@ -51,9 +51,6 @@ class Tx_Flux_Form_Container_Sheet extends Tx_Flux_Form_AbstractFormContainer im
 	public function getFields() {
 		$fields = array();
 		foreach ($this->children as $child) {
-			if (FALSE === $child instanceof Tx_Flux_Form_FieldInterface) {
-				continue;
-			}
 			$name = $child->getName();
 			$fields[$name] = $child;
 		}


### PR DESCRIPTION
This patch considers all kinds of a sheet's children to determine if it is empty or not. Before, a sheet that didn't contain at least one field was considered empty thus sections vanished. Fixes #265. 
