### PR TITLE
[FEATURE] Make flux:flexform.grid.column name localizable

### DIFF
--- a/Classes/Form/AbstractFormComponent.php
+++ b/Classes/Form/AbstractFormComponent.php
@@ -228,6 +228,8 @@ abstract class Tx_Flux_Form_AbstractFormComponent {
 			$prefix = 'sections';
 		} elseif (TRUE === $this instanceof Tx_Flux_Form_Container_Container) {
 			$prefix = 'containers';
+		} elseif (TRUE === $this instanceof Tx_Flux_Form_Container_Column) {
+			$prefix = 'columns';
 		} elseif (TRUE === $this instanceof Tx_Flux_Form_Container_Content) {
 			$prefix = 'areas';
 		} elseif (TRUE === $this instanceof Tx_Flux_Form_Container_Object) {

--- a/Classes/ViewHelpers/Flexform/Grid/ColumnViewHelper.php
+++ b/Classes/ViewHelpers/Flexform/Grid/ColumnViewHelper.php
@@ -37,7 +37,7 @@ class Tx_Flux_ViewHelpers_Flexform_Grid_ColumnViewHelper extends Tx_Flux_ViewHel
 	 */
 	public function initializeArguments() {
 		$this->registerArgument('name', 'string', 'Optional column name', FALSE, 'column');
-		$this->registerArgument('label', 'string', 'Optional column label', FALSE, 'Column');
+		$this->registerArgument('label', 'string', 'Optional column label', FALSE, NULL);
 		$this->registerArgument('colPos', 'integer', 'Optional column position. If you do not specify this it will be automatically assigned - so specify it if your template is dynamic and the output relies on this, as page rendering does for example!', FALSE, -1);
 		$this->registerArgument('colspan', 'integer', 'Column span');
 		$this->registerArgument('rowspan', 'integer', 'Row span');


### PR DESCRIPTION
Currently a `flux:flexform.grid.column` name is not localizable like all the other containers. This adds the ability to localize the name:

``` xml
flux.FlexformID.columns.YourColumnName
```

For this to work the optional label for the view helper has to be `NULL` on default. (Which doesn't matter much because it will fallback to `name` if no `label` is present).
