### PR TITLE
[BUGFIX] Tx_Flux_Form_Container_Object should extend Tx_Flux_Form_AbstractFormContainer

### DIFF
--- a/Classes/Form/Container/Object.php
+++ b/Classes/Form/Container/Object.php
@@ -27,7 +27,7 @@
  * @package Flux
  * @subpackage Form\Container
  */
-class Tx_Flux_Form_Container_Object extends Tx_Flux_Form_Container_Container implements Tx_Flux_Form_ContainerInterface, Tx_Flux_Form_FieldContainerInterface {
+class Tx_Flux_Form_Container_Object extends Tx_Flux_Form_AbstractFormContainer implements Tx_Flux_Form_ContainerInterface, Tx_Flux_Form_FieldContainerInterface {
 
 	/**
 	 * @return array


### PR DESCRIPTION
This has a implication for l18n. If `Tx_Flux_Form_Container_Object` were to extend `Tx_Flux_Form_Container_Container` then the `name` argument would transform to:

``` xml
flux.ID.containers.ObjectID
```

but it should actually transform to:

``` xml
flux.ID.objects.ObjectID
```

as per `Tx_Flux_Form_AbstractFormComponent::getLabel()`
