### PR TITLE
[BUGFIX] AbstractProvider->getTemplatePaths should only return array

### DIFF
--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -57,21 +57,6 @@ class Tx_Flux_Provider_ContentProvider extends Tx_Flux_Provider_AbstractProvider
 	protected $fieldName = 'pi_flexform';
 
 	/**
-	 * @param array $row
-	 * @return array|mixed|NULL
-	 */
-	public function getTemplatePaths(array $row) {
-		if (TRUE === is_array($this->templatePaths)) {
-			$paths = $this->templatePaths;
-		} else {
-			$extensionKey = $this->getExtensionKey($row);
-			$paths = $this->configurationService->getViewConfigurationForExtensionName($extensionKey);
-		}
-		$paths = Tx_Flux_Utility_Path::translatePath($paths);
-		return $paths;
-	}
-
-	/**
 	 * @param string $operation
 	 * @param integer $id
 	 * @param array $row

--- a/Classes/Provider/ProviderInterface.php
+++ b/Classes/Provider/ProviderInterface.php
@@ -94,7 +94,7 @@ interface Tx_Flux_Provider_ProviderInterface {
 	 * layoutRootPath, templateRootPath members must be in the returned array
 	 *
 	 * @param array $row
-	 * @return array|NULL
+	 * @return array
 	 */
 	public function getTemplatePaths(array $row);
 


### PR DESCRIPTION
The return value of `AbstractProvider::getTemplatePaths(...)` must always be an array.
