### PR TITLE
[BUGFIX] Added missing form

### DIFF
--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -339,7 +339,8 @@ class Tx_Flux_Provider_AbstractProvider implements Tx_Flux_Provider_ProviderInte
 			return self::$cache[$cacheKey];
 		}
 		$fieldName = $this->getFieldName($row);
-		$immediateConfiguration = $this->configurationService->convertFlexFormContentToArray($row[$fieldName], NULL, NULL, NULL);
+		$form = $this->getForm($row);
+		$immediateConfiguration = $this->configurationService->convertFlexFormContentToArray($row[$fieldName], $form, NULL, NULL);
 		$tree = $this->getInheritanceTree($row);
 		if (0 === count($tree)) {
 			self::$cache[$cacheKey] = $immediateConfiguration;


### PR DESCRIPTION
`convertFlexFormContentToArray` requires a form to be set for `transformAccordingToConfiguration` to be executed.
