### PR TITLE
[FEATURE] Added label LLL: shortcut

### DIFF
--- a/Classes/Form/AbstractFormComponent.php
+++ b/Classes/Form/AbstractFormComponent.php
@@ -218,9 +218,14 @@ abstract class Tx_Flux_Form_AbstractFormComponent {
 			$extensionName = $root->getExtensionName();
 		}
 		$extensionKey = t3lib_div::camelCaseToLowerCaseUnderscored($extensionName);
-		if (TRUE === isset($label) && FALSE === empty($label)) {
-			return $label;
-		} elseif ((TRUE === empty($extensionKey) || FALSE === t3lib_extMgm::isLoaded($extensionKey)) && TRUE === empty($label)) {
+		if (FALSE === empty($label)) {
+			if (0 === strpos($label, 'LLL:') && 0 !== strpos($label, 'LLL:EXT:')) {
+				$name = substr($label, 4);
+			} else {
+				return $label;
+			}
+		}
+		if ((TRUE === empty($extensionKey) || FALSE === t3lib_extMgm::isLoaded($extensionKey))) {
 			return $name;
 		}
 		$prefix = '';


### PR DESCRIPTION
Adds the possibility to use the `label` argument of form components with a `LLL:` shortcut that gets expanded like the `name` argument:

``` xml
<flux:flexform.content name="content.{iteration.index}-left" label="LLL:content-left" />
-> flux.ID.areas.content-left
```
