### PR TITLE
Fixed registerFluidFlexFormPlugin not working in Typo3 6.1

### DIFF
--- a/Classes/Core.php
+++ b/Classes/Core.php
@@ -203,7 +203,7 @@ class Tx_Flux_Core {
 		/** @var $provider Tx_Flux_Provider_ProviderInterface */
 		$provider = $objectManager->get('Tx_Flux_Provider_ContentProvider');
 		$provider->setTableName('tt_content');
-		$provider->setFieldName('');
+		$provider->setFieldName('pi_flexform');
 		$provider->setExtensionKey($extensionKey);
 		$provider->setListType($pluginSignature);
 		$provider->setTemplatePathAndFilename($templateFilename);


### PR DESCRIPTION
In the ContentProvider created in registerFluidFlexFormPlugin the FieldName was set to an empty string, however, this has to be 'pi_flexform' in order to get the Fluid Flexform loaded.
