### PR TITLE
[BUGFIX] Add getTransform method to Form Container interface

### DIFF
--- a/Classes/Form/AbstractFormContainer.php
+++ b/Classes/Form/AbstractFormContainer.php
@@ -35,6 +35,11 @@ abstract class Tx_Flux_Form_AbstractFormContainer extends Tx_Flux_Form_AbstractF
 	protected $children;
 
 	/**
+	 * @var string
+	 */
+	protected $transform;
+
+	/**
 	 * CONSTRUCTOR
 	 */
 	public function __construct() {
@@ -179,5 +184,21 @@ abstract class Tx_Flux_Form_AbstractFormContainer extends Tx_Flux_Form_AbstractF
 	 */
 	public function hasChildren() {
 		return 0 < $this->children->count();
+	}
+
+	/**
+	 * @param string $transform
+	 * @return Tx_Flux_Form_FieldInterface
+	 */
+	public function setTransform($transform) {
+		$this->transform = $transform;
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getTransform() {
+		return $this->transform;
 	}
 }

--- a/Classes/Form/FieldContainerInterface.php
+++ b/Classes/Form/FieldContainerInterface.php
@@ -34,4 +34,9 @@ interface Tx_Flux_Form_FieldContainerInterface extends Tx_Flux_Form_FormInterfac
 	 */
 	public function getFields();
 
+	/**
+	 * @return string
+	 */
+	public function getTransform();
+
 }


### PR DESCRIPTION
It appears call of method getTransform in class
Tx_Flux_Service_FluxService can also be made against
a container object. Since the method is not defined in
the PHP interface, a fatal error is raised with message:

```
Call to undefined method
Tx_Flux_Form_Container_Object::getTransform() in
flux/Classes/Service/FluxService.php on line 478
```
