### PR TITLE
Add support for `foreignMatchFields` parameter for FAL ( `flexform.field.inline.fal` )

### DIFF
--- a/Classes/ViewHelpers/Flexform/Field/AbstractInlineFieldViewHelper.php
+++ b/Classes/ViewHelpers/Flexform/Field/AbstractInlineFieldViewHelper.php
@@ -49,6 +49,7 @@ abstract class Tx_Flux_ViewHelpers_Flexform_Field_AbstractInlineFieldViewHelper 
 		$this->registerArgument('showSynchronizationLink', 'boolean', "Defines whether to show a 'synchronize' link to update to a 1:1 translation with the original language.", FALSE, FALSE);
 		$this->registerArgument('enabledControls', 'array', "Associative array with the keys 'info', 'new', 'dragdrop', 'sort', 'hide', delete' and 'localize'. Set either one to TRUE or FALSE to show or hide it.", FALSE, FALSE);
 		$this->registerArgument('headerThumbnail', 'array', 'Associative array with header thumbnail.', FALSE, FALSE);
+		$this->registerArgument('foreignMatchFields', 'array', 'The fields and values of the child record which have to match. For FAL the field/key is "fieldname" and the value has to be defined.', FALSE, FALSE);
 		$this->registerArgument('levelLinksPosition', 'string', 'Level links position.', FALSE, NULL);
 	}
 
@@ -83,6 +84,9 @@ abstract class Tx_Flux_ViewHelpers_Flexform_Field_AbstractInlineFieldViewHelper 
 		}
 		if (TRUE === is_array($this->arguments['headerThumbnail'])) {
 			$component->setHeaderThumbnail($this->arguments['headerThumbnail']);
+		}
+		if (TRUE === is_array($this->arguments['foreignMatchFields'])) {
+			$component->setForeignMatchFields($this->arguments['foreignMatchFields']);
 		}
 		$component->setLevelLinksPosition($this->arguments['levelLinksPosition']);
 		return $component;

--- a/Classes/ViewHelpers/Flexform/Field/Inline/FalViewHelper.php
+++ b/Classes/ViewHelpers/Flexform/Field/Inline/FalViewHelper.php
@@ -67,6 +67,11 @@ class Tx_Flux_ViewHelpers_Flexform_Field_Inline_FalViewHelper extends Tx_Flux_Vi
 		$disallowedExtensions = $this->arguments['disallowedExtensions'];
 
 		$component = $this->getPreparedComponent('Inline/Fal');
+		if (FALSE === is_array($this->arguments['foreignMatchFields'])) {
+			$component->setForeignMatchFields(array(
+				'fieldname' => $this->arguments['name']
+			));
+		}
 		$component->setForeignSelectorFieldTcaOverride(array(
 			'config' => array(
 				'appearance' => array(


### PR DESCRIPTION
This commit adds support for `foreignMatchFields` parameter.

``` xml
<flux:flexform.field.inline.fal label="Image" localizationMode="keep" foreignMatchFields="{fieldname : 'myimage1'}" name="myimage" multiple="TRUE" maxItems="5"/>
<flux:flexform.field.inline.fal label="Image" localizationMode="keep" foreignMatchFields="{fieldname : 'myimage2'}" name="myimage2" multiple="TRUE" maxItems="5"/>
```

Without this parameter it is not possible to have more than one `flexform.field.inline.fal` field in one element. Without it the translation mode `localizationMode="keep"` also is buggy.

I am not sure if the `foreignMatchFields` should be required if using `flexform.field.inline.fal`. What is your opinion?
In a comment i proposed that the default `foreignMatchFields` for `flexform.field.inline.fal` should be derived from the elements name. But i am not sure how to implement that and it is not part of this commit.
