### PR TITLE
Cache refresh performance optimization

### DIFF
--- a/Classes/Backend/TceMain.php
+++ b/Classes/Backend/TceMain.php
@@ -42,7 +42,7 @@ class Tx_Flux_Backend_TceMain {
 	/**
 	 * @var boolean
 	 */
-	private $cachesCleared = FALSE;
+	static private $cachesCleared = FALSE;
 
 	/**
 	 * CONSTRUCTOR
@@ -175,7 +175,7 @@ class Tx_Flux_Backend_TceMain {
 	 * @return void
 	 */
 	public function clearCacheCommand($command) {
-		if (TRUE === $this->cachesCleared) {
+		if (TRUE === self::$cachesCleared) {
 			return;
 		}
 		$manifestCacheFiles = glob(t3lib_div::getFileAbsFileName('typo3temp/*-manifest.cache'));
@@ -192,7 +192,7 @@ class Tx_Flux_Backend_TceMain {
 				$provider->clearCacheCommand($command);
 			}
 		}
-		$this->cachesCleared = TRUE;
+		self::$cachesCleared = TRUE;
 	}
 
 }


### PR DESCRIPTION
Resolves #348

Changing $cachesCleared to static variable, so multiple Tx_Flux_Backend_TceMain::clearCacheCommand requests will not provoke multiple clear refreshes in single runtime.

Tested :
Environment : TYPO3 4.5.30
Flux : current master (87123492789a7c61b0db0b95ace69b8560b778ce)
News
DAM
