### PR TITLE
[BUGFIX] Only clear cache when "Clear configuration cache" is pressed

### DIFF
--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -662,6 +662,10 @@ class AbstractProvider implements ProviderInterface {
 	 * @return void
 	 */
 	public function clearCacheCommand($command = array()) {
+		// only empty the cache when "clear configuration cache is pressed"
+		if ('temp_cached' !== $command['cacheCmd'])) {
+			return;
+		}
 		if (TRUE === isset($command['uid'])) {
 			return;
 		}


### PR DESCRIPTION
Hey,

these caches should generally only be cleared. The more important patch is the one in the fluidcontent repository (will be added soon). Otherwise the rebuilding of typo3temp/.FEDCONTENT takes up to two minutes on our system, which is rebuilt every time a cache is cleared (e.g. "clear TypoScript cache" / "clear pages cache" / "clear all caches").

In general, I suggest to use the Caching Framework for this process.

Sincerely,
Benni.
