### PR TITLE
added keys on tx_flux_column and tx_flux_parent

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -5,5 +5,7 @@ CREATE TABLE tt_content (
   colPos int(11) DEFAULT '0',
   tx_flux_column varchar(255) DEFAULT NULL,
   tx_flux_parent int(11) DEFAULT NULL,
-  tx_flux_children int(11) DEFAULT NULL
+  tx_flux_children int(11) DEFAULT NULL,
+  KEY flux_column (tx_flux_column),
+  KEY flux_parent (tx_flux_parent),
 );


### PR DESCRIPTION
this changed will introduce database keys on tx_flux_column and tx_flux_parent. 

While profiling a TYPO3 6.2 dev installation, we discovered quite a lot of queries for flux without using any keys:

  SELECT \* FROM tt_content WHERE ((tx_flux_column = 'S')
  OR (tx_flux_parent = 'S' AND (tx_flux_column = 'S' OR tx_flux_column = 'S')))
  AND deleted = N AND hidden = N GROUP BY uid ORDER BY sorting ASC LIMIT N,N

This change introduces the missing keys. The result ist a faster query execution and the ability to store the result in query cache
