### PR TITLE
[WIP][FEATURE] Permissions

### DIFF
--- a/Classes/Form.php
+++ b/Classes/Form.php
@@ -25,6 +25,7 @@ namespace FluidTYPO3\Flux;
  *****************************************************************/
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use FluidTYPO3\Flux\Outlet\OutletInterface;
 
@@ -157,6 +158,9 @@ class Form extends Form\AbstractFormContainer implements Form\FieldContainerInte
 	 * @return array
 	 */
 	public function build() {
+		if (FALSE === $this->isPermitted()) {
+			return array();
+		}
 		$dataStructArray = array(
 			'meta' => array(
 				'langDisable' => 1
@@ -171,7 +175,7 @@ class Form extends Form\AbstractFormContainer implements Form\FieldContainerInte
 		$sheets = $copy->getSheets();
 		$compactExtensionToggleOn = 0 < $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup']['compact'];
 		$compactConfigurationToggleOn = 0 < $copy->getCompact();
-		if (($compactExtensionToggleOn || $compactConfigurationToggleOn) && 1 === count($sheets)) {
+		if (($compactExtensionToggleOn || $compactConfigurationToggleOn) && 1 === count($sheets) && TRUE === $copy->last()->isPermitted()) {
 			$dataStructArray['ROOT'] = array(
 				'type' => 'array',
 				'el' => $copy->last()->build(),

--- a/Classes/Form/AbstractFormContainer.php
+++ b/Classes/Form/AbstractFormContainer.php
@@ -28,6 +28,7 @@ use FluidTYPO3\Flux\Form\ContainerInterface;
 use FluidTYPO3\Flux\Form\FieldInterface;
 use FluidTYPO3\Flux\Form\FormInterface;
 use FluidTYPO3\Flux\Form\WizardInterface;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
 /**
  * @package Flux
@@ -179,6 +180,9 @@ abstract class AbstractFormContainer extends AbstractFormComponent implements Co
 		/** @var FormInterface[] $children */
 		$children = $this->children;
 		foreach ($children as $child) {
+			if (FALSE === $child->isPermitted()) {
+				continue;
+			}
 			$name = $child->getName();
 			$structure[$name] = $child->build();
 		}

--- a/Classes/Form/Container/Sheet.php
+++ b/Classes/Form/Container/Sheet.php
@@ -59,6 +59,9 @@ class Sheet extends AbstractFormContainer implements ContainerInterface, FieldCo
 		/** @var \FluidTYPO3\Flux\Form\FormInterface[] $children */
 		$children = $this->getFields();
 		foreach ($children as $child) {
+			if (FALSE === $child->isPermitted()) {
+				continue;
+			}
 			$name = $child->getName();
 			$structure[$name] = $child->build();
 		}

--- a/Classes/Form/FormInterface.php
+++ b/Classes/Form/FormInterface.php
@@ -24,6 +24,8 @@ namespace FluidTYPO3\Flux\Form;
  *  This copyright notice MUST APPEAR in all copies of the script!
  *****************************************************************/
 
+use FluidTYPO3\Flux\Permission\PermissionInterface;
+
 /**
  * @package Flux
  * @subpackage Form
@@ -99,6 +101,29 @@ interface FormInterface {
 	 * @return array
 	 */
 	public function getVariables();
+
+
+	/**
+	 * @param PermissionInterface[] $permissions
+	 * @return FormInterface
+	 */
+	public function setPermissions(array $permissions);
+
+	/**
+	 * @return PermissionInterface[]
+	 */
+	public function getPermissions();
+
+	/**
+	 * @param PermissionInterface $permission
+	 * @return FormInterface
+	 */
+	public function requirePermission(PermissionInterface $permission);
+
+	/**
+	 * @return boolean
+	 */
+	public function isPermitted();
 
 	/**
 	 * @param string $name

--- a/Classes/Permission/AbstractPermission.php
+++ b/Classes/Permission/AbstractPermission.php
@@ -1,0 +1,43 @@
+<?php
+namespace FluidTYPO3\Flux\Permission;
+/*****************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+/**
+ * @package Flux
+ * @subpackage Permission
+ */
+abstract class AbstractPermission implements PermissionInterface {
+
+	/**
+	 * Returns FALSE if this Permission is not granted.
+	 * Grant of permission is arbitraty - decided by implementation.
+	 *
+	 * @return boolean
+	 */
+	public function granted() {
+		return TRUE;
+	}
+
+}

--- a/Classes/Permission/Compound/AbstractCompoundPermission.php
+++ b/Classes/Permission/Compound/AbstractCompoundPermission.php
@@ -1,0 +1,51 @@
+<?php
+namespace FluidTYPO3\Flux\Permission\Compound;
+/*****************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\Permission\AbstractPermission;
+use FluidTYPO3\Flux\Permission\PermissionInterface;
+
+/**
+ * @package Flux
+ * @subpackage Permission
+ */
+abstract class AbstractCompoundPermission extends AbstractPermission {
+
+	/**
+	 * @var PermissionInterface[]
+	 */
+	protected $permissions = array();
+
+	/**
+	 * @param PermissionInterface $permission
+	 * @return PermissionInterface
+	 */
+	public function requirePermission(PermissionInterface $permission) {
+		$hash = spl_object_hash($permission);
+		$this->permissions[$hash] = $permission;
+		return $this;
+	}
+
+}

--- a/Classes/Permission/Compound/All.php
+++ b/Classes/Permission/Compound/All.php
@@ -1,0 +1,53 @@
+<?php
+namespace FluidTYPO3\Flux\Permission\Compound;
+/*****************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\Permission\PermissionInterface;
+
+/**
+ * Permission: Compound, requires all sub-Permissions
+ * to be granted for this Compound Permission to be
+ * considered granted.
+ *
+ * @package Flux
+ * @subpackage Permission
+ */
+class All extends AbstractCompoundPermission implements PermissionInterface {
+
+	/**
+	 * Returns FALSE if at least one of the sub-Permissions is NOT granted.
+	 *
+	 * @return boolean
+	 */
+	public function granted() {
+		foreach ($this->permissions as $permission) {
+			if (FALSE === $permission->granted()) {
+				return FALSE;
+			}
+		}
+		return TRUE;
+	}
+
+}

--- a/Classes/Permission/Compound/CompoundPermissionInterface.php
+++ b/Classes/Permission/Compound/CompoundPermissionInterface.php
@@ -1,0 +1,44 @@
+<?php
+namespace FluidTYPO3\Flux\Permission\Compound;
+/*****************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\Permission\PermissionInterface;
+
+/**
+ * @package Flux
+ * @subpackage Permission
+ */
+interface CompoundPermissionInterface extends PermissionInterface {
+
+	/**
+	 * Adds a Permission to the stack. The implementation then
+	 * decides how to reach the stack's cumulative verdict.
+	 *
+	 * @param PermissionInterface $permission
+	 * @return PermissionInterface
+	 */
+	public function requirePermission(PermissionInterface $permission);
+
+}

--- a/Classes/Permission/PermissionInterface.php
+++ b/Classes/Permission/PermissionInterface.php
@@ -1,0 +1,41 @@
+<?php
+namespace FluidTYPO3\Flux\Permission;
+/*****************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+/**
+ * @package Flux
+ * @subpackage Permission
+ */
+interface PermissionInterface {
+
+	/**
+	 * Returns FALSE if this Permission is not granted.
+	 * Grant of permission is arbitraty - decided by implementation.
+	 *
+	 * @return boolean
+	 */
+	public function granted();
+
+}

--- a/Classes/Permission/Role/AbstractRolePermission.php
+++ b/Classes/Permission/Role/AbstractRolePermission.php
@@ -1,0 +1,35 @@
+<?php
+namespace FluidTYPO3\Flux\Permission\Role;
+/*****************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\Permission\AbstractPermission;
+
+/**
+ * @package Flux
+ * @subpackage Permission
+ */
+abstract class AbstractRolePermission extends AbstractPermission {
+
+}

--- a/Classes/Permission/Role/Admin.php
+++ b/Classes/Permission/Role/Admin.php
@@ -1,0 +1,44 @@
+<?php
+namespace FluidTYPO3\Flux\Permission\Role;
+/*****************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\Permission\PermissionInterface;
+
+/**
+ * @package Flux
+ * @subpackage Permission
+ */
+class Admin extends AbstractRolePermission implements PermissionInterface {
+
+	/**
+	 * Returns TRUE if the current user does not have administrator privileges
+	 *
+	 * @return boolean
+	 */
+	public function granted() {
+		return (boolean) $GLOBALS['BE_USER']->user['admin'];
+	}
+
+}

--- a/Classes/Permission/Role/Group.php
+++ b/Classes/Permission/Role/Group.php
@@ -1,0 +1,72 @@
+<?php
+namespace FluidTYPO3\Flux\Permission\Role;
+/*****************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\Permission\PermissionInterface;
+
+/**
+ * @package Flux
+ * @subpackage Permission
+ */
+class Group extends AbstractRolePermission implements PermissionInterface {
+
+	/**
+	 * @var integer
+	 */
+	protected $group;
+
+	/**
+	 * @param integer $groupUid
+	 */
+	public function __construct($groupUid) {
+		$this->setGroup($groupUid);
+	}
+
+	/**
+	 * @param integer $group
+	 * @return PermissionInterface
+	 */
+	public function setGroup($group) {
+		$this->group = $group;
+		return $this;
+	}
+
+	/**
+	 * @return integer
+	 */
+	public function getGroup() {
+		return $this->group;
+	}
+
+	/**
+	 * Returns TRUE if the current user is a member of $this->group
+	 *
+	 * @return boolean
+	 */
+	public function granted() {
+		return (boolean) $GLOBALS['BE_USER']->user['admin'];
+	}
+
+}

--- a/Classes/Permission/Role/NonAdmin.php
+++ b/Classes/Permission/Role/NonAdmin.php
@@ -1,0 +1,44 @@
+<?php
+namespace FluidTYPO3\Flux\Permission\Role;
+/*****************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\Permission\PermissionInterface;
+
+/**
+ * @package Flux
+ * @subpackage Permission
+ */
+class NonAdmin extends AbstractRolePermission implements PermissionInterface {
+
+	/**
+	 * Returns TRUE if the current user has administrator privileges
+	 *
+	 * @return boolean
+	 */
+	public function granted() {
+		return (FALSE === (boolean) $GLOBALS['BE_USER']->user['admin']);
+	}
+
+}

--- a/Classes/ViewHelpers/Permission/AbstractPermissionViewHelper.php
+++ b/Classes/ViewHelpers/Permission/AbstractPermissionViewHelper.php
@@ -1,0 +1,84 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Permission;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\Form\ContainerInterface;
+use FluidTYPO3\Flux\Permission\PermissionInterface;
+use FluidTYPO3\Flux\ViewHelpers\AbstractFormViewHelper;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+
+/**
+ * Base Permission-instance ViewHelper
+ *
+ * Creates Permissions which can be attached to FormInterface
+ * implementers - e.g. parent nodes of the PermissionViewHelper
+ * node. Permission is then assigned to the parent.
+ *
+ * @package Flux
+ * @subpackage ViewHelpers/Permission
+ */
+abstract class AbstractPermissionViewHelper extends AbstractFormViewHelper {
+
+	/**
+	 * @return void
+	 */
+	public function render() {
+		$container = $this->getContainer();
+		$permission = $this->getPermissionInstance();
+		$container->requirePermission($permission);
+	}
+
+	/**
+	 * @return ContainerInterface
+	 */
+	protected function getContainer() {
+		if (TRUE === $this->viewHelperVariableContainer->exists('FluidTYPO3\Flux\ViewHelpers\Permission\AbstractPermissionViewHelper', 'permission')) {
+			return $this->viewHelperVariableContainer->get('FluidTYPO3\Flux\ViewHelpers\Permission\AbstractPermissionViewHelper', 'permission');
+		}
+		return parent::getContainer();
+	}
+
+
+	/**
+	 * @return PermissionInterface
+	 */
+	protected function getPermissionInstance() {
+		$permissionClassName = $this->getPermissionClassName();
+		/** @var PermissionInterface $permission */
+		$permission = $this->objectManager->get($permissionClassName);
+		return $permission;
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function getPermissionClassName() {
+		$viewHelperClassName = get_class($this);
+		$permissionClassName = str_replace('\ViewHelpers\Permission\\', '\Permission\\', $viewHelperClassName);
+		$permissionClassName = substr($permissionClassName, 0, -10);
+		return $permissionClassName;
+	}
+
+}

--- a/Classes/ViewHelpers/Permission/Compound/AbstractCompoundPermissionViewHelper.php
+++ b/Classes/ViewHelpers/Permission/Compound/AbstractCompoundPermissionViewHelper.php
@@ -1,0 +1,54 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Permission\Compound;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\ViewHelpers\Permission\AbstractPermissionViewHelper;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+
+/**
+ * Base Permission-instance ViewHelper
+ *
+ * Creates Permissions which can be attached to FormInterface
+ * implementers - e.g. parent nodes of the PermissionViewHelper
+ * node. Permission is then assigned to the parent.
+ *
+ * @package Flux
+ * @subpackage ViewHelpers/Permission
+ */
+abstract class AbstractCompoundPermissionViewHelper extends AbstractPermissionViewHelper {
+
+	/**
+	 * @return void
+	 */
+	public function render() {
+		$permission = $this->getPermissionInstance();
+		$container = $this->getContainer();
+		$container->requirePermission($permission);
+		$this->viewHelperVariableContainer->addOrUpdate('FluidTYPO3\Flux\ViewHelpers\Permission\AbstractPermissionViewHelper', 'permission', $permission);
+		$this->renderChildren();
+		$this->viewHelperVariableContainer->remove('FluidTYPO3\Flux\ViewHelpers\Permission\AbstractPermissionViewHelper', 'permission');
+	}
+
+}

--- a/Classes/ViewHelpers/Permission/Compound/AllViewHelper.php
+++ b/Classes/ViewHelpers/Permission/Compound/AllViewHelper.php
@@ -1,0 +1,37 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Permission\Compound;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\ViewHelpers\Permission\AbstractPermissionViewHelper;
+
+/**
+ * ViewHelper version of the All CompoundPermission class.
+ *
+ * @package Flux
+ * @subpackage ViewHelpers/Permission
+ */
+class AllViewHelper extends AbstractCompoundPermissionViewHelper {
+
+}

--- a/Classes/ViewHelpers/Permission/Role/AdminViewHelper.php
+++ b/Classes/ViewHelpers/Permission/Role/AdminViewHelper.php
@@ -1,0 +1,37 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Permission\Role;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\ViewHelpers\Permission\AbstractPermissionViewHelper;
+
+/**
+ * Base class for all FlexForm fields.
+ *
+ * @package Flux
+ * @subpackage ViewHelpers/Permission
+ */
+class AdminViewHelper extends AbstractPermissionViewHelper {
+
+}

--- a/Classes/ViewHelpers/Permission/Role/NonAdminViewHelper.php
+++ b/Classes/ViewHelpers/Permission/Role/NonAdminViewHelper.php
@@ -1,0 +1,37 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Permission\Role;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Claus Due <claus@namelesscoder.net>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\ViewHelpers\Permission\AbstractPermissionViewHelper;
+
+/**
+ * Base class for all FlexForm fields.
+ *
+ * @package Flux
+ * @subpackage ViewHelpers/Permission
+ */
+class NonAdminViewHelper extends AbstractPermissionViewHelper {
+
+}


### PR DESCRIPTION
# WIP - DO NOT MERGE YET

Collection of Permission checkers which can be easily assigned to any object using a simple property and checked with a simple routine.

Usage examples:

``` xml
<!-- Simple Permission usage - require at least one of the listed Permissions (|| strategy) -->
<flux:field.input name="simple">
    <flux:permission.role.nonAdmin />
    <flux:permission.role.group uid="{settings.allowedGroupUid}" />
</flux:field.input>

<!-- Compound permission "all" - require every listed Permission (&& strategy) -->
<flux:field.input name="complex">
    <flux:permission.compound.all>
        <flux:permission.role.admin />
        <flux:permission.role.group uid="{settings.allowedGroupUid}" />
    </flux:permission.compound.all>
</flux:field.input>
```

``` php
$groupUid = 123;
$mustBeAdmin = new \FluidTYPO3\Flux\Permission\Role\Admin();
$mustBeInGroup = new \FluidTYPO3\Flux\Permission\Role\Group($groupUid);
$form = \FluidTYPO3\Flux\Form::create();
// Create a Sheet that only Admin may access
$sheet = $form->createContainer('Sheet', 'options')
    ->requirePermission($mustBeAdmin);
// Create a Field which only a specific be_group member may access
$sheet->createField('groupProtectedField')
    ->requirePermission($mustBeInGroup);

// Using a Compound Permission like the "All" CompoundPermission
// to require every Permission to be granted in order for the Compound
// Permission to be considered granted (AND strategy)
$mustBeAdminMemberOfSpecifiedGroup = new \FluidTYPO3\Flux\Permission\Compound\All();
$mustBeAdminMemberOfSpecifiedGroup
    ->requirePermission($mustBeAdmin)
    ->requirePermission($mustBeInGroup);
$form->createSheet('otherSheet')
    ->requirePermission($mustBeAdminMemberOfSpecifiedGroup);
```
