### PR TITLE
[TASK] Update object type in return annotation.

### DIFF
--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -280,7 +280,7 @@ class AbstractProvider implements ProviderInterface {
 
 	/**
 	 * @param array $row
-	 * @return FluidTYPO3\Flux\Form\Container\Grid
+	 * @return Grid
 	 */
 	public function getGrid(array $row) {
 		if (NULL !== $this->grid) {


### PR DESCRIPTION
Current annotation is not recoganise by the IDE. It must be either prepended
by a "\" or simply the class alias.
