### PR TITLE
[BUGFIX] Accessing configuration of fields

### DIFF
--- a/Classes/Provider/AbstractConfigurationProvider.php
+++ b/Classes/Provider/AbstractConfigurationProvider.php
@@ -478,9 +478,10 @@ class Tx_Flux_Provider_AbstractConfigurationProvider implements Tx_Flux_Provider
 			$values = $this->getFlexFormValues($branch);
 			$variables = $this->getTemplateVariables($branch);
 			foreach ($variables['fields'] as $field) {
-				$name = $field['configuration']['name'];
-				$stop = (TRUE === isset($field['configuration']['stopInheritance']));
-				$inherit = (TRUE === isset($field['configuration']['inheritEmpty']));
+				$configuration = $field->renderConfiguration();
+				$name = $configuration['name'];
+				$stop = (TRUE === isset($configuration['stopInheritance']));
+				$inherit = (TRUE === isset($configuration['inheritEmpty']));
 				$empty = (TRUE === empty($values[$name]) && $values[$name] !== '0' && $values[$name] !== 0);
 				if (TRUE === $stop) {
 					unset($values[$name]);


### PR DESCRIPTION
after 94e10ead516ceb02032f3b88cd1afd0d94160189 the configuration is protected and cannot be accessed from outside. So renderConfiguration have to be used. 

This PR fixes the related code...
