### PR TITLE
[BUGFIX] Remove doubly declared abstract functions.

### DIFF
--- a/Classes/Form/RelationFieldInterface.php
+++ b/Classes/Form/RelationFieldInterface.php
@@ -152,17 +152,6 @@ interface RelationFieldInterface extends MultiValueFieldInterface {
 	public function getForeignUnique();
 
 	/**
-	 * @param string $itemListStyle
-	 * @return RelationFieldInterface
-	 */
-	public function setItemListStyle($itemListStyle);
-
-	/**
-	 * @return string
-	 */
-	public function getItemListStyle();
-
-	/**
 	 * @param string $localizationMode
 	 * @return RelationFieldInterface
 	 */
@@ -183,17 +172,6 @@ interface RelationFieldInterface extends MultiValueFieldInterface {
 	 * @return boolean
 	 */
 	public function getLocalizeChildrenAtParentLocalization();
-
-	/**
-	 * @param string $selectedListStyle
-	 * @return RelationFieldInterface
-	 */
-	public function setSelectedListStyle($selectedListStyle);
-
-	/**
-	 * @return string
-	 */
-	public function getSelectedListStyle();
 
 	/**
 	 * @param string $symmetricField


### PR DESCRIPTION
The interface "MultiValueFieldInterface" already declares some
functions that are redeclared in its child interface
"RelationFieldInterface". This is causes a fatal error in older PHP
versions.
