### PR TITLE
[BUG] Switch to new colPos value uncomplete

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -42,6 +42,6 @@ t3lib_extMgm::addTCAcolumns('tt_content', array(
 	)
 );
 
-$TCA['tt_content']['columns']['colPos']['config']['items'][] = array('LLL:EXT:flux/locallang.xml:tt_content.tx_flux_container', '-42');
+$TCA['tt_content']['columns']['colPos']['config']['items'][] = array('LLL:EXT:flux/locallang.xml:tt_content.tx_flux_container', '18181');
 
 Tx_Flux_Core::registerConfigurationProvider('Tx_Flux_Provider_Configuration_ContentObjectConfigurationProvider');


### PR DESCRIPTION
Don't know if 'colPos' => -42 (two times), in /html/typo3/typo3conf/ext/flux/Tests/Fixtures/Data/Records.php should also get changed.
Unfortunatelly I'm still getting the error 'invalid Value ("18181") in backend when creating a new element inside a fluid content element like the bootstrap row.
