### PR TITLE
[TASK] Add examples how to get file references

### DIFF
--- a/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
+++ b/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
@@ -31,6 +31,18 @@ use TYPO3\CMS\Core\Resource\File;
 /**
  * Repeats rendering of children with a typical for loop: starting at index $from it will loop until the index has reached $to.
  *
+ * To get the file references, assigned with that field in a flux form, you will have to use EXT:vhs but there are two different ViewHelpers for fluidpages templates and fluidcontent elements.
+ * 
+ * Example how to get the first file reference from a fluidcontent element, for the flux field named "settings.files":
+ * 	{v:content.resources.fal(field: 'settings.files') 
+ * 		-> v:iterator.first() 
+ * 		-> v:var.set(name: 'settings.files')}
+ * 
+ * And now the example how to get the first file reference from a fluidpages template, for the flux field named "settings.files":
+ * 	{v:resource.record.fal(record: page, field: 'settings.files', table: 'pages') 
+ * 		-> v:iterator.first() 
+ * 		-> v:var.set(name: 'settings.files')}
+ * 
  * @author Danilo Bürger <danilo.buerger@hmspl.de>, Heimspiel GmbH
  * @author Johannes Pieper <pieper@dlrg.de> DLRG e.V.
  * @package Flux


### PR DESCRIPTION
Add some documentation and examples how to get file references assigned to the field created with this ViewHelper - one for pages and fluid content elements each because its different.
