### PR TITLE
Relates to issue #532 (Problems with YAG extension)

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -44,9 +44,7 @@ if (TRUE === class_exists('FluidTYPO3\Flux\Core')) {
 }
 
 /** @var $extbaseObjectContainer \TYPO3\CMS\Extbase\Object\Container\Container */
-
 $extbaseObjectContainer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\Container\Container');
 $extbaseObjectContainer->registerImplementation('TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager', 'FluidTYPO3\Flux\Configuration\BackendConfigurationManager');
 unset($extbaseObjectContainer);
-
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms']['db_new_content_el']['wizardItemsHook']['flux'] = 'FluidTYPO3\Flux\Hooks\WizardItemsHookSubscriber';


### PR DESCRIPTION
Instead of the implementation of ConfigurationManager, implement BackendConfigurationManager directly. This prevents problems with the backend of the YAG extension.
