### PR TITLE
[BUGFIX] Fix inheritance of field values

### DIFF
--- a/Classes/Form/AbstractFormContainer.php
+++ b/Classes/Form/AbstractFormContainer.php
@@ -48,12 +48,12 @@ abstract class AbstractFormContainer extends AbstractFormComponent implements Co
 	/**
 	 * @var boolean
 	 */
-	protected $inheritEmpty = FALSE;
+	protected $inherit = TRUE;
 
 	/**
 	 * @var boolean
 	 */
-	protected $stopInheritance = FALSE;
+	protected $inheritEmpty = FALSE;
 
 	/**
 	 * CONSTRUCTOR
@@ -111,7 +111,7 @@ abstract class AbstractFormContainer extends AbstractFormComponent implements Co
 	}
 
 	/**
-	 * @param array|Traversable $children
+	 * @param array|\Traversable $children
 	 * @return FormInterface
 	 */
 	public function addAll($children) {
@@ -219,6 +219,22 @@ abstract class AbstractFormContainer extends AbstractFormComponent implements Co
 	}
 
 	/**
+	 * @param boolean $inherit
+	 * @return ContainerInterface
+	 */
+	public function setInherit($inherit) {
+		$this->inherit = (boolean) $inherit;
+		return $this;
+	}
+
+	/**
+	 * @return boolean
+	 */
+	public function getInherit() {
+		return (boolean) $this->inherit;
+	}
+
+	/**
 	 * @param boolean $inheritEmpty
 	 * @return ContainerInterface
 	 */
@@ -232,22 +248,6 @@ abstract class AbstractFormContainer extends AbstractFormComponent implements Co
 	 */
 	public function getInheritEmpty() {
 		return (boolean) $this->inheritEmpty;
-	}
-
-	/**
-	 * @param boolean $stopInheritance
-	 * @return ContainerInterface
-	 */
-	public function setStopInheritance($stopInheritance) {
-		$this->stopInheritance = (boolean) $stopInheritance;
-		return $this;
-	}
-
-	/**
-	 * @return boolean
-	 */
-	public function getStopInheritance() {
-		return (boolean) $this->stopInheritance;
 	}
 
 }

--- a/Classes/Form/AbstractFormField.php
+++ b/Classes/Form/AbstractFormField.php
@@ -61,19 +61,14 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
 	protected $requestUpdate = FALSE;
 
 	/**
-	 * @var integer
+	 * @var boolean
 	 */
-	protected $inherit = 0;
+	protected $inherit = TRUE;
 
 	/**
 	 * @var boolean
 	 */
 	protected $inheritEmpty = FALSE;
-
-	/**
-	 * @var boolean
-	 */
-	protected $stopInheritance = FALSE;
 
 	/**
 	 * @var boolean
@@ -344,11 +339,11 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
 	}
 
 	/**
-	 * @param integer $inherit
+	 * @param boolean $inherit
 	 * @return FieldInterface
 	 */
 	public function setInherit($inherit) {
-		$this->inherit = $inherit;
+		$this->inherit = (boolean) $inherit;
 		return $this;
 	}
 
@@ -356,7 +351,7 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
 	 * @return integer
 	 */
 	public function getInherit() {
-		return $this->inherit;
+		return (boolean) $this->inherit;
 	}
 
 	/**
@@ -373,22 +368,6 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
 	 */
 	public function getInheritEmpty() {
 		return (boolean) $this->inheritEmpty;
-	}
-
-	/**
-	 * @param boolean $stopInheritance
-	 * @return FieldInterface
-	 */
-	public function setStopInheritance($stopInheritance) {
-		$this->stopInheritance = (boolean) $stopInheritance;
-		return $this;
-	}
-
-	/**
-	 * @return boolean
-	 */
-	public function getStopInheritance() {
-		return (boolean) $this->stopInheritance;
 	}
 
 	/**

--- a/Classes/Form/FieldInterface.php
+++ b/Classes/Form/FieldInterface.php
@@ -124,17 +124,6 @@ interface FieldInterface extends FormInterface {
 	public function getInheritEmpty();
 
 	/**
-	 * @param boolean $stopInheritance
-	 * @return FieldInterface
-	 */
-	public function setStopInheritance($stopInheritance);
-
-	/**
-	 * @return boolean
-	 */
-	public function getStopInheritance();
-
-	/**
 	 * @param boolean $exclude
 	 * @return FieldInterface
 	 */

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -803,10 +803,10 @@ class AbstractProvider implements ProviderInterface {
 			$values = $this->getFlexFormValues($branch);
 			foreach ($fields as $field) {
 				$name = $field->getName();
-				$stop = (TRUE === $field->getStopInheritance());
-				$inherit = (TRUE === $field->getInheritEmpty());
+				$inherit = (TRUE === $field->getInherit());
+				$inheritEmpty = (TRUE === $field->getInheritEmpty());
 				$empty = (TRUE === empty($values[$name]) && $values[$name] !== '0' && $values[$name] !== 0);
-				if (TRUE === $stop || (FALSE === $inherit && TRUE === $empty)) {
+				if (FALSE === $inherit || (TRUE === $inheritEmpty && TRUE === $empty)) {
 					unset($values[$name]);
 				}
 			}

--- a/Classes/ViewHelpers/Field/AbstractFieldViewHelper.php
+++ b/Classes/ViewHelpers/Field/AbstractFieldViewHelper.php
@@ -52,7 +52,7 @@ abstract class AbstractFieldViewHelper extends AbstractFormViewHelper {
 		$this->registerArgument('enabled', 'boolean', 'If FALSE, disables the field in the FlexForm', FALSE, TRUE);
 		$this->registerArgument('requestUpdate', 'boolean', 'If TRUE, the form is force-saved and reloaded when field value changes', FALSE, FALSE);
 		$this->registerArgument('displayCond', 'string', 'Optional "Display Condition" (TCA style) for this particular field', FALSE, NULL);
-		$this->registerArgument('inherit', 'integer', 'If 0 (zero), prevents inheritance of the value for this particular field - if inheritance is enabled by the ConfigurationProvider', FALSE, 99);
+		$this->registerArgument('inherit', 'boolean', 'If TRUE, the value for this particular field is inherited - if inheritance is enabled by the ConfigurationProvider', FALSE, TRUE);
 		$this->registerArgument('inheritEmpty', 'boolean', 'If TRUE, allows empty values (specifically excluding the number zero!) to be inherited - if inheritance is enabled by the ConfigurationProvider', FALSE, TRUE);
 		$this->registerArgument('clear', 'boolean', 'If TRUE, a "clear value" checkbox is displayed next to the field which when checked, completely destroys the current field value all the way down to the stored XML value', FALSE, FALSE);
 		$this->registerArgument('variables', 'array', 'Freestyle variables which become assigned to the resulting Component - ' .
@@ -73,7 +73,6 @@ abstract class AbstractFieldViewHelper extends AbstractFormViewHelper {
 		$component->setDisplayCondition($this->arguments['displayCond']);
 		$component->setInherit($this->arguments['inherit']);
 		$component->setInheritEmpty($this->arguments['inheritEmpty']);
-		$component->setStopInheritance($this->arguments['stopInheritance']);
 		$component->setTransform($this->arguments['transform']);
 		$component->setClearable($this->arguments['clear']);
 		$component->setVariables($this->arguments['variables']);

--- a/Tests/Unit/Form/Container/AbstractContainerTest.php
+++ b/Tests/Unit/Form/Container/AbstractContainerTest.php
@@ -67,10 +67,10 @@ abstract class AbstractContainerTest extends AbstractFormTest {
 	/**
 	 * @test
 	 */
-	public function canGetAndSetStopInheritance() {
+	public function canGetAndSetInherit() {
 		$instance = $this->createInstance();
-		$instance->setStopInheritance(TRUE);
-		$this->assertEquals(TRUE, $instance->getStopInheritance());
+		$instance->setInherit(FALSE);
+		$this->assertEquals(FALSE, $instance->getInherit());
 	}
 
 	/**

--- a/Tests/Unit/Form/Field/AbstractFieldTest.php
+++ b/Tests/Unit/Form/Field/AbstractFieldTest.php
@@ -42,16 +42,6 @@ abstract class AbstractFieldTest extends AbstractFormTest {
 	/**
 	 * @test
 	 */
-	public function canGetAndSetStopInheritance() {
-		$instance = $this->canChainAllChainableSetters();
-		$this->assertFalse($instance->setStopInheritance(FALSE)->getStopInheritance());
-		$this->assertTrue($instance->setStopInheritance(TRUE)->getStopInheritance());
-		$this->performTestBuild($instance);
-	}
-
-	/**
-	 * @test
-	 */
 	public function canGetAndSetInheritEmpty() {
 		$instance = $this->canChainAllChainableSetters();
 		$this->assertFalse($instance->setInheritEmpty(FALSE)->getInheritEmpty());


### PR DESCRIPTION
This patch reinstalls inheritance of form fields controlled by argument `inherit`. It removes an unused property `stopInheritance` and turns argument `inherit` into a boolean, `TRUE` by default. 
Please test and feel free to enter objections ;) Fixes #526.
