### PR TITLE
Fix uniqid php-bug under windows

### DIFF
--- a/Classes/ViewHelpers/Grid/RowViewHelper.php
+++ b/Classes/ViewHelpers/Grid/RowViewHelper.php
@@ -50,7 +50,7 @@ class RowViewHelper extends AbstractFormViewHelper {
 	 * @return string
 	 */
 	public function render() {
-		$name = ('row' === $this->arguments['name'] ? uniqid('row') : $this->arguments['name']);
+		$name = ('row' === $this->arguments['name'] ? uniqid('row', TRUE) : $this->arguments['name']);
 		$row = $this->getForm()->createContainer('Row', $name, $this->arguments['label']);
 		$row->setVariables($this->arguments['variables']);
 		$container = $this->getContainer();


### PR DESCRIPTION
This is not a bug of flux but php under windows.

My backend layout had more that one `grid.row` and only in 1 of 10 requests i got all of them rendered as expected - sometimes with "no edit access", sometimes the area was simply blank.

It turned out that there is a known bug in php on windows where `uniqid()` is NOT unique if calling it  fast enough multiple times. http://samjlevy.com/php-uniqid-not-unique-on-iis-7-5/

The function is used in `RowViewHelper:53` so the grid rows often/sometimes get the same name.

I simply added the `more_entropy` parameter.
