### PR TITLE
[BUGFIX] Style attribute in columns is not set

### DIFF
--- a/Resources/Private/Templates/ViewHelpers/Widget/Grid/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Widget/Grid/Index.html
@@ -16,7 +16,7 @@
 		<f:for each="{grid.rows}" as="gridrow" iteration="rowIteration">
 			<tr>
 				<f:for each="{gridrow.columns}" as="area" iteration="columnIteration">
-					<td colspan="{area.colspan}" rowspan="{area.rowspan}" style="{gridcolumn.style}">
+					<td colspan="{area.colspan}" rowspan="{area.rowspan}" style="{area.style}">
 						<flux:be.contentArea area="{area.name}" row="{row}">
 							<div class="fce-header t3-row-header t3-page-colHeader t3-page-colHeader-label">
 								<div>{area.label}</div>


### PR DESCRIPTION
The style information was referenced with gridcolumn instead of area.
