### PR TITLE
[BUGFIX] Respect Tempplate Path and Filename when already set

### DIFF
--- a/Classes/View/ExposedTemplateView.php
+++ b/Classes/View/ExposedTemplateView.php
@@ -154,6 +154,9 @@ class ExposedTemplateView extends TemplateView implements ViewInterface {
 	 * @throws Exception
 	 */
 	public function getTemplatePathAndFilename($actionName = NULL) {
+		if (NULL !== $this->templatePathAndFilename) {
+			return $this->templatePathAndFilename;
+		}
 		if (TRUE === empty($actionName)) {
 			$actionName = $this->controllerContext->getRequest()->getControllerActionName();
 		}


### PR DESCRIPTION
The `AbstractFluxController` initializes a view object by setting its template path and filename if the provider can provide one. The View should then respect this setting instead of "recalculating" it.
