### PR TITLE
[TASK] Convert underscore action names to paths for template filenames

### DIFF
--- a/Classes/View/ExposedTemplateView.php
+++ b/Classes/View/ExposedTemplateView.php
@@ -154,12 +154,10 @@ class ExposedTemplateView extends TemplateView implements ViewInterface {
 	 * @throws Exception
 	 */
 	public function getTemplatePathAndFilename($actionName = NULL) {
-		if (NULL !== $this->templatePathAndFilename) {
-			return $this->templatePathAndFilename;
-		}
 		if (TRUE === empty($actionName)) {
 			$actionName = $this->controllerContext->getRequest()->getControllerActionName();
 		}
+		$actionName = str_replace('_', '/', $actionName);
 		$actionName = ucfirst($actionName);
 		$paths = $this->expandGenericPathPattern($this->templatePathAndFilenamePattern, FALSE, FALSE);
 		foreach ($paths as &$templatePathAndFilename) {


### PR DESCRIPTION
With the introduction of 110e358 view overlays would no longer work. However to support versions in fluidcontent_core we need a way to get a folder deeper in the templates path. What i figured now is that we could use `_` in action names (so they are still valid php function names) and interpret that as a slash when trying to get the template file. I dont know if this is the right approach, but it fixes the problem with view overlays and allows fcc versions through underscore action names. Please consider this carefully before you merge.
