### PR TITLE
[BUGFIX] Test throws error if no tmpl exists

### DIFF
--- a/Tests/Unit/Backend/PreviewTest.php
+++ b/Tests/Unit/Backend/PreviewTest.php
@@ -42,7 +42,9 @@ class PreviewTest extends AbstractTestCase {
 	public function setup() {
 		$tempFiles = (array) glob(GeneralUtility::getFileAbsFileName('typo3temp/flux-preview-*.tmp'));
 		foreach ($tempFiles as $tempFile) {
-			unlink($tempFile);
+			if (TRUE === file_exists($tempFile)) {
+				unlink($tempFile);
+			}
 		}
 	}
 


### PR DESCRIPTION
Glob() gets all flux-preview with a cast array and if non found the foreach runs a empty loop with unlink('') and gets an open_basedir restriction error.
