### PR TITLE
[BUGFIX] Show label and name in original container

### DIFF
--- a/Classes/ViewHelpers/Form/ContentViewHelper.php
+++ b/Classes/ViewHelpers/Form/ContentViewHelper.php
@@ -99,6 +99,9 @@ class ContentViewHelper extends AbstractFormViewHelper {
 				$column->setName($this->arguments['name']);
 				$column->setLabel($this->arguments['label']);
 			}
+		} else {
+			$originalContainer->setName($this->arguments['name']);
+			$originalContainer->setLabel($this->arguments['label']);
 		}
 	}
 


### PR DESCRIPTION
This is related to https://github.com/FluidTYPO3/fluidcontent_bootstrap/issues/116
