### PR TITLE
[BUGFIX] No prefix length for integer columns

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -7,6 +7,6 @@ CREATE TABLE tt_content (
   tx_flux_children int(11) DEFAULT NULL,
 
   KEY index_fluxcolumn (tx_flux_column(12)),
-  KEY index_fluxparent (tx_flux_parent(12)),
+  KEY index_fluxparent (tx_flux_parent),
   KEY index_fluxparentcolumn (tx_flux_column(12),tx_flux_parent)
 );


### PR DESCRIPTION
Database compare fails with the current prefix length since it is an integer.
