### PR TITLE
[TASK] Implement own method building default view configuration for ext key

### DIFF
--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -278,7 +278,7 @@ class FluxService implements SingletonInterface {
 	 * @param string $extensionKey
 	 * @return array
 	 */
-	public function getDefaultViewConfigurationForExtensionKey($extensionKey) {
+	protected function getDefaultViewConfigurationForExtensionKey($extensionKey) {
 		return array(
 			'templateRootPath' => 'EXT:' . $extensionKey . '/Resources/Private/Templates',
 			'partialRootPath' => 'EXT:' . $extensionKey . '/Resources/Private/Partials',


### PR DESCRIPTION
Implement an own method building the default view configuration of the
given extension key, so it can be better extended by sub-services like
fluidpages or fluidcontent, which can provide by default a deeper folder
structure. (e.g "Templates/Page" for fluidpages or "Templates/Content"
for fluidcontent).
