### PR TITLE
[BUGFIX] Nested records are not copied right

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -89,7 +89,6 @@ class ContentService implements SingletonInterface {
 				$mappingArray[$copyFromUid] = $record;
 			}
 		}
-		
 		foreach ($mappingArray as $copyFromUid => $record) {
 			if (0 > $relativeUid) {
 				$relativeRecord = $this->loadRecordFromDatabase(abs($relativeUid), $record['sys_language_uid']);
@@ -99,7 +98,6 @@ class ContentService implements SingletonInterface {
 				$record['tx_flux_parent'] = 0;
 				$record['tx_flux_column'] = '';
 			}
-			
 			if (FALSE === empty($possibleArea) || FALSE === empty($record['tx_flux_column'])) {
 				if ($copyFromUid === $parentUid) {
 					$record['tx_flux_parent'] = $parentUid;


### PR DESCRIPTION
If you copy an Row Element with nested Content Elements the information of the the column of the nested Elements is lost and the nested Elements are displayed beside the Row Element and not inside any more.

This happens because tx_flux_column of nested records is emptied as well. During my fix i encountered a few more problems with copying and moving of nested Elements and i think i found a solution for them all.

Please check this commit! =)
