### PR TITLE
[BUGFIX] Nested records are not copied right

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -85,16 +85,18 @@ class ContentService implements SingletonInterface {
 					$record['CType'] = 'shortcut';
 					$record['records'] = $id;
 				}
-
 				$mappingArray[$copyFromUid] = $record;
 			}
 		}
-
 		foreach ($mappingArray as $copyFromUid => $record) {
 			if (0 > $relativeUid) {
 				$relativeRecord = $this->loadRecordFromDatabase(abs($relativeUid), $record['sys_language_uid']);
 			}
-
+			if ('copy' !== $command) {
+				$record['colPos'] = '';
+				$record['tx_flux_parent'] = 0;
+				$record['tx_flux_column'] = '';
+			}
 			if (FALSE === empty($possibleArea) || FALSE === empty($record['tx_flux_column'])) {
 				if ($copyFromUid === $parentUid) {
 					$record['tx_flux_parent'] = $parentUid;
@@ -113,6 +115,9 @@ class ContentService implements SingletonInterface {
 						$record['tx_flux_parent'] = $parentRecord['uid'];
 					} else {
 						$record['tx_flux_parent'] = '';
+						if (FALSE === empty($possibleArea)) {
+							$record['tx_flux_parent'] = $parentUid;
+						}
 					}
 				}
 				if (FALSE === empty($possibleArea)) {
@@ -134,16 +139,17 @@ class ContentService implements SingletonInterface {
 			if (TRUE === isset($pid) && FALSE === isset($relativeRecord['pid'])) {
 				$record['pid'] = $pid;
 			}
-			if ((FALSE === empty($possibleColPos) || 0 === $possibleColPos || '0' === $possibleColPos)) {
+			if ((FALSE === empty($possibleColPos) || 0 === $possibleColPos || '0' === $possibleColPos) && TRUE === empty($parentRecord)) {
 				$record['colPos'] = $possibleColPos;
 			}
-			if (self::COLPOS_FLUXCONTENT !== intval($possibleColPos)) {
+			if (self::COLPOS_FLUXCONTENT !== intval($possibleColPos) && TRUE === empty($parentRecord)) {
 				$record['tx_flux_parent'] = 0;
 				$record['tx_flux_column'] = '';
 			}
 			$record['tx_flux_parent'] = intval($record['tx_flux_parent']);
 			$this->updateRecordInDatabase($record, NULL, $tceMain);
 			$tceMain->registerDBList['tt_content'][$record['uid']];
+			unset($parentRecord,$relativeRecord);
 		}
 	}
 


### PR DESCRIPTION
If you copy an row element with nested content elements the information of the the column of the nested elements is lost and the nested elements are displayed beside the row element and not inside any more.

This happens because tx_flux_column of nested records is emptied as well. During my fix i encountered a few more problems with copying and moving of nested elements and i think i found a solution for them all.
