### PR TITLE
[TASK] Enable inline usage of flux:form.data

### DIFF
--- a/Classes/ViewHelpers/Form/DataViewHelper.php
+++ b/Classes/ViewHelpers/Form/DataViewHelper.php
@@ -76,6 +76,9 @@ class DataViewHelper extends AbstractViewHelper {
 	 * @throws Exception
 	 */
 	public function render($table, $field, $uid = NULL, $record = NULL, $as = NULL) {
+		if (NULL === $record && NULL === $as) {
+			$record = $this->renderChildren();
+		}
 		if (NULL === $uid && NULL !== $record && TRUE === isset($record['uid'])) {
 			$uid = $record['uid'];
 		}

--- a/Tests/Unit/ViewHelpers/Form/DataViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Form/DataViewHelperTest.php
@@ -104,6 +104,22 @@ class DataViewHelperTest extends AbstractViewHelperTestCase {
 	/**
 	 * @test
 	 */
+	public function canUseChildNodeAsRecord() {
+		$arguments = array(
+			'table' => 'tt_content',
+			'field' => 'pi_flexform',
+			'uid' => 1
+		);
+		$record = Records::$contentRecordWithoutParentAndWithoutChildren;
+		$content = $this->createNode('Array', $record);
+		$viewHelper = $this->buildViewHelperInstance($arguments, array(), $content);
+		$output = $viewHelper->initializeArgumentsAndRender();
+		$this->assertIsArray($output);
+	}
+
+	/**
+	 * @test
+	 */
 	public function canExecuteViewHelperWithUnregisteredTableAndReturnEmptyArray() {
 		$arguments = array(
 			'table' => 'be_users',


### PR DESCRIPTION
Useful in combination with `v:content.get` or other situations where raw records (arrays) are available.
