### PR TITLE
[BUGFIX]  manipulateWizardItems matching colPos / name fails

### DIFF
--- a/Classes/Form/Container/Column.php
+++ b/Classes/Form/Container/Column.php
@@ -97,7 +97,7 @@ class Column extends AbstractFormContainer implements ContainerInterface {
 	 * @return Column
 	 */
 	public function setColumnPosition($columnPosition) {
-		$this->columnPosition = $columnPosition;
+		$this->columnPosition = (integer) $columnPosition;
 		return $this;
 	}
 

--- a/Classes/Hooks/WizardItemsHookSubscriber.php
+++ b/Classes/Hooks/WizardItemsHookSubscriber.php
@@ -144,10 +144,8 @@ class WizardItemsHookSubscriber implements NewContentElementWizardHookInterface 
 				}
 				foreach ($grid->getRows() as $row) {
 					foreach ($row->getColumns() as $column) {
-						foreach ($column->getAreas() as $area) {
-							if ($area->getName() === $fluxAreaName) {
-								list ($whitelist, $blacklist) = $this->appendToWhiteAndBlacklistFromComponent($area, $whitelist, $blacklist);
-							}
+						if ($column->getName() === $fluxAreaName) {
+							list ($whitelist, $blacklist) = $this->appendToWhiteAndBlacklistFromComponent($column, $whitelist, $blacklist);
 						}
 					}
 				}


### PR DESCRIPTION
manipulateWizardItems matching colPos / name (int <-> string comparison fails with ===)

e.q:
$column->getColumnPosition()  = "3" (string)
$parentObject->colPos = 3 (integer)
