### PR TITLE
[TASK] Deprecate wizardTab and icon attributes on Form

### DIFF
--- a/Classes/Backend/TableConfigurationPostProcessor.php
+++ b/Classes/Backend/TableConfigurationPostProcessor.php
@@ -101,26 +101,26 @@ class TableConfigurationPostProcessor implements TableConfigurationPostProcessin
 		$extensionKey = ExtensionNamingUtility::getExtensionKey($extensionName);
 		$tableConfiguration = self::$tableTemplate;
 		$fields = array();
-		$labelFields = $form->getOption('labels');
+		$labelFields = $form->getOption(Form::OPTION_TCA_LABELS);
 		$enableColumns = array();
 		foreach ($form->getFields() as $field) {
 			$name = $field->getName();
 			// note: extracts the TCEforms sub-array from the configuration, as required in TCA.
 			$fields[$name] = array_pop($field->build());
 		}
-		if (TRUE === $form->getOption('hide')) {
+		if (TRUE === $form->getOption(Form::OPTION_TCA_HIDE)) {
 			$enableColumns['disabled'] = 'hidden';
 		}
-		if (TRUE === $form->getOption('start')) {
+		if (TRUE === $form->getOption(Form::OPTION_TCA_START)) {
 			$enableColumns['start'] = 'starttime';
 		}
-		if (TRUE === $form->getOption('end')) {
+		if (TRUE === $form->getOption(Form::OPTION_TCA_END)) {
 			$enableColumns['end'] = 'endtime';
 		}
-		if (TRUE === $form->getOption('frontendUserGroup')) {
+		if (TRUE === $form->getOption(Form::OPTION_TCA_FEGROUP)) {
 			$enableColumns['fe_group'] = 'fe_group';
 		}
-		$tableConfiguration['iconfile'] = ExtensionManagementUtility::extRelPath($extensionKey) . $form->getIcon();
+		$tableConfiguration['iconfile'] = ExtensionManagementUtility::extRelPath($extensionKey) . $form->getOption(Form::OPTION_ICON);
 		$tableConfiguration['enablecolumns'] = $enableColumns;
 		$showRecordsFieldList = $this->buildShowItemList($form);
 		$GLOBALS['TCA'][$table] = array(
@@ -136,7 +136,7 @@ class TableConfigurationPostProcessor implements TableConfigurationPostProcessin
 				)
 			)
 		);
-		if (TRUE === $form->getOption('delete')) {
+		if (TRUE === $form->getOption(Form::OPTION_TCA_DELETE)) {
 			$GLOBALS['TCA'][$table]['ctrl']['delete'] = 'deleted';
 		}
 		if (NULL === $labelFields) {

--- a/Classes/Form.php
+++ b/Classes/Form.php
@@ -34,6 +34,14 @@ use FluidTYPO3\Flux\Outlet\OutletInterface;
  */
 class Form extends Form\AbstractFormContainer implements Form\FieldContainerInterface {
 
+	const OPTION_GROUP = 'group';
+	const OPTION_ICON = 'icon';
+	const OPTION_TCA_LABELS = 'labels';
+	const OPTION_TCA_HIDE = 'hide';
+	const OPTION_TCA_START = 'start';
+	const OPTION_TCA_END = 'end';
+	const OPTION_TCA_DELETE = 'delete';
+	const OPTION_TCA_FEGROUP = 'frontendUserGroup';
 	const POSITION_TOP = 'top';
 	const POSITION_BOTTOM = 'bottom';
 	const POSITION_BOTH = 'both';
@@ -59,20 +67,6 @@ class Form extends Form\AbstractFormContainer implements Form\FieldContainerInte
 	 * @var string
 	 */
 	protected $id;
-
-	/**
-	 * Optional icon which represents the form.
-	 *
-	 * @var string
-	 */
-	protected $icon;
-
-	/**
-	 * Logical, human-readable or LLL group name this Form belongs to.
-	 *
-	 * @var string
-	 */
-	protected $group;
 
 	/**
 	 * Should be set to contain the extension name in UpperCamelCase of
@@ -269,7 +263,8 @@ class Form extends Form\AbstractFormContainer implements Form\FieldContainerInte
 	 * @return Form\FormInterface
 	 */
 	public function setGroup($group) {
-		$this->group = $group;
+		GeneralUtility::logDeprecatedFunction();
+		$this->setOption(self::OPTION_GROUP, $group);
 		return $this;
 	}
 
@@ -277,23 +272,28 @@ class Form extends Form\AbstractFormContainer implements Form\FieldContainerInte
 	 * @return string
 	 */
 	public function getGroup() {
-		return $this->group;
+		GeneralUtility::logDeprecatedFunction();
+		return $this->getOption(self::OPTION_GROUP);
 	}
 
 	/**
 	 * @param string $icon
 	 * @return Form\FormInterface
+	 * @deprecated
 	 */
 	public function setIcon($icon) {
-		$this->icon = $icon;
+		GeneralUtility::logDeprecatedFunction();
+		$this->setOption(self::OPTION_ICON, $icon);
 		return $this;
 	}
 
 	/**
 	 * @return string
+	 * @deprecated
 	 */
 	public function getIcon() {
-		$icon = $this->icon;
+		GeneralUtility::logDeprecatedFunction();
+		$icon = $this->getOption(self::OPTION_ICON);
 		if (0 === strpos($icon, 'EXT:')) {
 			$icon = GeneralUtility::getFileAbsFileName($icon);
 		}

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -43,11 +43,11 @@ class FormViewHelper extends AbstractFormViewHelper {
 		$this->registerArgument('label', 'string', 'Label for the FlexForm, can be LLL: value. Optional - if not specified, Flux ' .
 			'tries to detect an LLL label named "flux.fluxFormId", in scope of extension rendering the Flux form.', FALSE, NULL);
 		$this->registerArgument('description', 'string', 'Short description of this content element', FALSE, NULL);
-		$this->registerArgument('icon', 'string', 'Optional icon file to use when displaying this content element in the new content element wizard', FALSE, '../typo3conf/ext/flux/Resources/Public/Icons/Plugin.png');
+		$this->registerArgument('icon', 'string', 'DEPRECATED: Use `options="{icon: \'iconreference\'}"`. Optional icon file to use when displaying this content element in the new content element wizard', FALSE, '../typo3conf/ext/flux/Resources/Public/Icons/Plugin.png');
 		$this->registerArgument('mergeValues', 'boolean', 'DEPRECATED AND IGNORED. To cause value merging, simly prefix your field names with the table name, e.g. ' .
 			'"tt_content.header" will overwrite the "header" column in the record with the FlexForm field value when saving the record.', FALSE, FALSE);
 		$this->registerArgument('enabled', 'boolean', 'If FALSE, makes the FCE inactive', FALSE, TRUE);
-		$this->registerArgument('wizardTab', 'string', 'Optional tab name (usually extension key) in which to place the content element in the new content element wizard', FALSE, 'FCE');
+		$this->registerArgument('wizardTab', 'string', 'DEPRECATED: Use `options="{group: \'GroupName\'}". Optional tab name (usually extension key) in which to place the content element in the new content element wizard', FALSE, 'FCE');
 		$this->registerArgument('compact', 'boolean', 'If TRUE, disables sheet usage in the form. WARNING! AVOID DYNAMIC VALUES ' .
 			'AT ALL COSTS! Toggling this option is DESTRUCTIVE to variables currently saved in the database!', FALSE, FALSE);
 		$this->registerArgument('variables', 'array', 'Freestyle variables which become assigned to the resulting Component - ' .
@@ -68,11 +68,11 @@ class FormViewHelper extends AbstractFormViewHelper {
 		$form->setName($this->arguments['id']);
 		$form->setLabel($this->arguments['label']);
 		$form->setDescription($this->arguments['description']);
-		$form->setIcon($this->arguments['icon']);
 		$form->setEnabled($this->arguments['enabled']);
 		$form->setCompact($this->arguments['compact']);
-		$form->setGroup($this->arguments['wizardTab']);
 		$form->setExtensionName($this->controllerContext->getRequest()->getControllerExtensionName());
+		$form->setOption(Form::OPTION_ICON, $this->arguments['icon']);
+		$form->setOption(Form::OPTION_GROUP, $this->arguments['wizardTab']);
 		if (FALSE === empty($this->arguments['localLanguageFileRelativePath'])) {
 			$form->setLocalLanguageFileRelativePath($this->arguments['localLanguageFileRelativePath']);
 		}


### PR DESCRIPTION
This change:
- Marks as deprecated in code and rendered documentation, the arguments `wizardTab` and `icon` on `flux:form` in favour of the `options` attribute which is an array that can contain a `group` (equivalent of `wizardTab`) and an `icon` member.
- Removes properties on `FluidTYPO3\Flux\Form` but leaves in place getter and setter with deprecation logging, redirects storage to `options` class member.
- Introduces `OPTION_*` constants on `FluidTYPO3\Flux\Form` which define supported options. Other extensions are expected to either use what is provided here or introduce own constants (as constants in their own extension's namespace).
