### PR TITLE
[BUGFIX] Translated content elements within FCEs

### DIFF
--- a/Classes/ViewHelpers/Be/ContentAreaViewHelper.php
+++ b/Classes/ViewHelpers/Be/ContentAreaViewHelper.php
@@ -99,22 +99,44 @@ class ContentAreaViewHelper extends AbstractViewHelper {
 		}
 
 		$modSettings = $GLOBALS['SOBE']->MOD_SETTINGS;
-		$modMenu = $GLOBALS['SOBE']->MOD_MENU;
 
 		// Initializes page languages and icons so they are available in PageLayoutView if languageMode is set.
 		$dblist->initializeLanguages();
 		// Fetch current page localizations from MOD_MENU['language'] to use in condition.
-		$modMenuLanguages = is_array($modMenu['language']) ? implode(',', array_keys($modMenu['language'])) : '0';
+		$modLanguage = $GLOBALS['FLUX']['tt_content-LP'] ?: (integer) $modSettings['language'];
 
 		if (2 === intval($modSettings['function'])) {
 			$dblist->tt_contentConfig['single'] = 0;
 			$dblist->tt_contentConfig['languageMode'] = 1;
 			$dblist->tt_contentConfig['languageCols'] = array(0 => $GLOBALS['LANG']->getLL('m_default'));
-			$dblist->tt_contentConfig['languageColsPointer'] = $modSettings['language'];
+			$dblist->tt_contentConfig['languageColsPointer'] = $modLanguage;
+		}
+
+		$condition = 'colPos = "' . ContentService::COLPOS_FLUXCONTENT . '" AND deleted = 0';
+		$languageCondition = 'sys_language_uid IN (-1,' . $modLanguage . ')';
+		$fluxParentCondition = ' tx_flux_parent = ' . (integer) $row['uid'] . ' AND tx_flux_column = "' . $area . '"';
+
+		if (0 >= $modLanguage) {
+			$condition = implode(' AND ', array($condition, $languageCondition, $fluxParentCondition));
+		} else {
+			$uidCondition = implode(' AND ', array($condition, 'sys_language_uid = 0', $fluxParentCondition));
+
+			$uids = array();
+			$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('uid', 'tt_content', $uidCondition);
+			while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+				$uids[] = (integer) $row['uid'];
+			}
+
+			if (0 >= count($uids)) {
+				$parentCondition = $fluxParentCondition;
+			} else {
+				$languageParentCondition = 'l18n_parent IN (' . implode(',', $uids) . ')';
+				$parentCondition = '((' . $fluxParentCondition . ') OR (' . $languageParentCondition . '))';
+			}
+			$condition = implode(' AND ', array($condition, $languageCondition, $parentCondition));
 		}
 
 		$showHidden = $modSettings['tt_content_showHidden'] ? '' : BackendUtility::BEenableFields('tt_content');
-		$condition = "tx_flux_parent = '" . $row['uid'] . "' AND tx_flux_column = '" . $area . "' AND colPos = '" . ContentService::COLPOS_FLUXCONTENT . "' AND deleted = 0 AND sys_language_uid IN (-1," . $modMenuLanguages . ')';
 		$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'tt_content', $condition . $showHidden, 'uid', 'sorting ASC');
 		$records = $dblist->getResult($res);
 


### PR DESCRIPTION
Translated content elements within FCEs should be displayed without having a relation themselfs

I recreated this PR, because i've updated it to the latest changes in the repo.
The PR https://github.com/FluidTYPO3/flux/pull/633 does not work, it only shows ALL languages in languageMode, cause in $GLOBALS['SOBE']->MOD_MENU every available language is listed, not only the selected one.

Please test the Pull Request(s).
It seems like mine get rejected only because my code does'nt look as pretty and nobody seems to appreciate my efforts here. The changes work, they work pretty well and not as bad as the other "fixes", that were not really testet and only causes me to spend more and more time which is not resulting in anything.
