### PR TITLE
[BUGFIX] Incorrect placement of child elements on paste and localize into flux column

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -126,7 +126,10 @@ class ContentService implements SingletonInterface {
 		if ('copy' !== $command) {
 			$mappingArray[$id] = $row;
 		} else {
-			foreach ($tceMain->copyMappingArray['tt_content'] as $copyFromUid => $copyToUid) {
+			// Only override values from content elements in cmdmap to prevent that child elements "inherits"
+			// tx_flux_parent and tx_flux_column which would position them outside their tx_flux_parent.
+			foreach ($tceMain->cmdmap['tt_content'] as $copyFromUid => $cmdMapValues) {
+				$copyToUid = $tceMain->copyMappingArray['tt_content'][$copyFromUid];
 				$record = $this->loadRecordFromDatabase($copyToUid);
 				if ('reference' === $subCommand) {
 					$record['CType'] = 'shortcut';
@@ -234,16 +237,6 @@ class ContentService implements SingletonInterface {
 				$sortbyFieldName => $tceMain->resorting('tt_content', $row['pid'], $sortbyFieldName, $oldUid)
 			);
 			$this->updateRecordInDatabase($overrideValues, $newUid, $tceMain);
-
-			// Perform localization on all children, since this is not handled by the TCA field which otherwise cascades changes
-			$children = $this->loadRecordsFromDatabase($oldUid);
-			foreach ($children as $child) {
-				$overrideValues = array(
-					'tx_flux_parent' => $newUid
-				);
-				$childUid = $tceMain->localize('tt_content', $child['uid'], $newLanguageUid);
-				$this->updateRecordInDatabase($overrideValues, $childUid, $tceMain);
-			}
 		}
 	}
 

--- a/Tests/Unit/Service/ContentServiceTest.php
+++ b/Tests/Unit/Service/ContentServiceTest.php
@@ -74,26 +74,6 @@ class ContentServiceTest extends AbstractTestCase {
 	/**
 	 * @test
 	 */
-	public function canInitializeBlankRecordWithLanguage() {
-		$methods = array('loadRecordsFromDatabase', 'loadRecordFromDatabase', 'updateRecordInDatabase');
-		$mock = $this->createMock($methods);
-		$oldRecord = array(
-			'sys_language_uid' => 0
-		);
-		$mock->expects($this->once())->method('loadRecordFromDatabase')->with(999999999999)->will($this->returnValue($oldRecord));
-		$mock->expects($this->once())->method('loadRecordsFromDatabase')->will($this->returnValue(array(
-			Records::$contentRecordWithParentAndChildren,
-			Records::$contentRecordWithParentAndWithoutChildren
-		)));
-		$row = array('uid' => 1, 't3_origuid' => 999999999999, 'sys_language_uid' => 1);
-		$tceMain = $this->getMock('TYPO3\CMS\Core\DataHandling\DataHandler');
-		$tceMain->substNEWwithIDs = array('NEW12345' => 1);
-		$mock->initializeRecord('NEW12345', $row, $tceMain);
-	}
-
-	/**
-	 * @test
-	 */
 	public function moveRecordWithNegativeRelativeToValueLoadsRelativeRecordFromDatabaseAndCopiesValuesToRecordAndSetsColumnPositionAndUpdatesRelativeToValue() {
 		$methods = array('loadRecordFromDatabase', 'updateRecordInDatabase');
 		$mock = $this->createMock($methods);
@@ -146,6 +126,7 @@ class ContentServiceTest extends AbstractTestCase {
 	public function pasteAfterAsReferenceRelativeToRecord() {
 		$methods = array('loadRecordFromDatabase', 'updateRecordInDatabase');
 		$mock = $this->createMock($methods);
+
 		$command = 'copy';
 		$row = array(
 			'uid' => 1
@@ -161,8 +142,15 @@ class ContentServiceTest extends AbstractTestCase {
 			1,
 			'1-reference-2-2-0'
 		);
+		$cmdMap = array(
+			'tt_content' => array(
+				$copiedRow['uid'] => array(
+					$row['uid'] => 'copy'),
+			),
+		);
 		$tceMain = new DataHandler();
 		$tceMain->copyMappingArray['tt_content'][1] = $copiedRow['uid'];
+		$tceMain->cmdmap = $cmdMap;
 		$mock->expects($this->any())->method('loadRecordFromDatabase')->will($this->returnValue($copiedRow));
 		$mock->pasteAfter($command, $row, $parameters, $tceMain);
 	}

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -28,7 +28,8 @@ $TCA['tt_content']['columns']['colPos']['config']['items'][] = array(
 			'label' => 'LLL:EXT:flux/Resources/Private/Language/locallang.xlf:tt_content.tx_flux_parent',
 			'displayCond' => 'FIELD:tx_flux_parent:>:0',
 			'config' => array (
-				'type' => 'none',
+				'type' => 'input',
+				'readOnly' => TRUE,
 				'foreign_table' => 'tt_content',
 				'foreign_table_where' => "AND tt_content.pid = '###CURRENT_PID###'",
 				'default' => 0,
@@ -54,7 +55,11 @@ $TCA['tt_content']['columns']['colPos']['config']['items'][] = array(
 						'sort' => FALSE,
 						'hide' => TRUE
 					)
-				)
+				),
+				'behaviour' => array(
+					'localizationMode' => 'select',
+					'localizeChildrenAtParentLocalization' => TRUE,
+				),
 			)
 		),
 	)


### PR DESCRIPTION
Changed so TYPO3 handles IRRE records in tx_flux_children. Only set tx_flux_parent and tx_flux_column on the copied element in tceMain->cmdmap. Changed tx_flux_parent to a readOnly input so the field is writable according to TCA.

Non solved issues found when testing:
- When moving a localized content element into a flux column, the localized content elements isn't correctly placed.
- When 'Paste in this position' of a localized content element, the localized content elements isn't correctly placed.
- When 'Paste as reference in this position' of a element with child's, the children are also copied.
