### PR TITLE
[BUGFIX] Field.TextViewHelper should respect global RTE Settings by default

### DIFF
--- a/Classes/Form/Field/Text.php
+++ b/Classes/Form/Field/Text.php
@@ -109,6 +109,9 @@ class Text extends Input implements FieldInterface {
 	 */
 	public function setEnableRichText($enableRichText) {
 		$this->enableRichText = (boolean) $enableRichText;
+		if (TRUE === $enableRichText && TRUE === empty($this->defaultExtras)) {
+			$this->setDefaultExtras('richtext[]');
+		}
 		return $this;
 	}
 


### PR DESCRIPTION
If you enable the RTE and set defaultExtras to an empty string the resulting Behavior of the RTE
is to show everything. This commit changes sets the defaultExtras to "richtext[]" if the option 
enableRichText is set to true, but defaultExtras contains an empty string. "richtext[]" instructs
the Form to use the globally defined RTE Settings.
