### PR TITLE
[TASK] Restore Travis builds for CMS7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,28 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
 
 env:
-  - DB=mysql TYPO3=master INTEGRATION=master
-  - DB=mysql TYPO3=TYPO3_6-1 INTEGRATION=master
+  - DB=mysql TYPO3=master INTEGRATION=master INTRODUCTION=TYPO3_6-1
+  - DB=mysql TYPO3=TYPO3_6-2 INTEGRATION=master INTRODUCTION=TYPO3_6-1
 
 matrix:
    include:
-     - php: 5.6
-       env: DB=mysql TYPO3=master INTEGRATION=master
+     - php: 5.3
+       env: DB=mysql TYPO3=TYPO3_6-2 INTEGRATION=master INTRODUCTION=TYPO3_6-1
 
 before_script:
+  - composer self-update
   - cd ..
   - git clone --single-branch --branch $INTEGRATION --depth 1 git://github.com/typo3-ci/TYPO3-Travis-Integration.git build-environment
   - git clone --depth 1 git://github.com/FluidTYPO3/FluidTYPO3-CodingStandards.git build-environment/FluidTYPO3-CodingStandards
   - git clone git://github.com/squizlabs/PHP_CodeSniffer.git build-environment/CodeSniffer
   - git clone --single-branch --branch $TYPO3 --depth 1 https://github.com/TYPO3/TYPO3.CMS.git core
   - source build-environment/install-helper.sh
-  - git clone --single-branch --branch $TYPO3 --depth 1 git://git.typo3.org/TYPO3CMS/Distributions/Introduction.git build-environment/Introduction
+  - git clone --single-branch --branch $INTRODUCTION --depth 1 git://git.typo3.org/TYPO3CMS/Distributions/Introduction.git build-environment/Introduction
   - mv core/typo3 .
   - if [[ -d core/t3lib ]]; then mv core/t3lib . ; fi
   - mv build-environment/typo3conf .
@@ -30,7 +31,17 @@ before_script:
   - mkdir typo3temp
   - mkdir -p flux/build/logs
 
-  - git clone --depth 1 git://git.typo3.org/TYPO3CMS/Extensions/phpunit.git typo3conf/ext/phpunit
+  - >
+    if [[ "$TYPO3" == "master" ]]; then
+        echo;
+        echo "Copying composer.json to working dir. - Installing composer deps";
+        cp core/composer.json .
+        composer --dev install;
+    else
+        echo "Need to install ext phpunit. Wait..";
+        git clone --depth 1 git://git.typo3.org/TYPO3CMS/Extensions/phpunit.git typo3conf/ext/phpunit
+    fi
+
   - git clone --single-branch --branch development --depth 1 git://github.com/FluidTYPO3/builder.git typo3conf/ext/builder
   - ln -s ../../flux ./typo3conf/ext/flux
 
@@ -41,9 +52,22 @@ before_script:
   # post core schema import of extension schemas and state file from this and dependency extensions
   - if [[ "$DB" == "mysql" && -f typo3conf/ext/builder/Build/ImportSchema.sql ]]; then mysql -uroot typo3_test < typo3conf/ext/builder/Build/ImportSchema.sql; fi
   - if [[ "$DB" == "mysql" && -f typo3conf/ext/flux/Build/ImportSchema.sql ]]; then mysql -uroot typo3_test < typo3conf/ext/flux/Build/ImportSchema.sql; fi
-  - if [[ -f typo3conf/LocalConfiguration.php && -f typo3conf/ext/flux/Build/LocalConfiguration.php ]]; then cp typo3conf/ext/flux/Build/LocalConfiguration.php typo3conf/LocalConfiguration.php; fi
-  - if [[ -f typo3conf/ext/flux/Build/PackageStates.php ]]; then cp typo3conf/ext/flux/Build/PackageStates.php typo3conf/PackageStates.php; fi
-  - if [[ -f typo3conf/ext/flux/Tests/phpunit.xml ]]; then cp typo3conf/ext/flux/Tests/phpunit.xml phpunit.xml; fi
+
+  # On CMS 6 we need EXT:phpunit, on CMS 7 we can get away with a custom bootstrap.
+  # Other than that, the phpunit.xml slightly differs
+  - >
+    echo "Copying configuration..";
+    if [[ -f typo3conf/ext/flux/Tests/phpunit7.xml && "$TYPO3" == "master" ]]; then
+      # CMS 7 / master
+      cp typo3conf/ext/flux/Build/LocalConfiguration7.php typo3conf/LocalConfiguration.php;
+      cp typo3conf/ext/flux/Build/PackageStates7.php typo3conf/PackageStates.php;
+      cp typo3conf/ext/flux/Tests/phpunit7.xml phpunit.xml;
+    elif [[ -f typo3conf/ext/flux/Tests/phpunit.xml && "$TYPO3" != "master" ]]; then
+      # CMS 6
+      cp typo3conf/ext/flux/Build/LocalConfiguration.php typo3conf/LocalConfiguration.php;
+      cp typo3conf/ext/flux/Build/PackageStates.php typo3conf/PackageStates.php;
+      cp typo3conf/ext/flux/Tests/phpunit.xml phpunit.xml;
+    fi
 
 script:
 # phplint checking on all PHP source files in extension
@@ -52,8 +76,18 @@ script:
   - typo3/cli_dispatch.phpsh extbase builder:fluidsyntax --extension flux
 # PHPCodeSniffer code inspection with only errors displayed (no warnings)
   - build-environment/CodeSniffer/scripts/phpcs -n --standard=$PWD/build-environment/FluidTYPO3-CodingStandards/ruleset.xml $PWD/typo3conf/ext/flux
-# PHPUnit tests from overridden phpunit tests configuration file
-  - if [[ -f typo3conf/ext/flux/Tests/phpunit.xml ]]; then typo3/cli_dispatch.phpsh phpunit -c phpunit.xml --coverage-clover flux/build/logs/clover.xml; fi
+# PHPUnit tests from overridden phpunit tests configuration file - CMS 6
+  - >
+    if [[ -f typo3conf/ext/flux/Tests/phpunit.xml && "$TYPO3" != "master" ]]; then
+      echo "Running unit tests for EXT:flux (CMS 6)";
+      typo3/cli_dispatch.phpsh phpunit -c phpunit.xml --coverage-clover flux/build/logs/clover.xml;
+    fi
+# PHPUnit tests from overridden phpunit tests configuration file - CMS 7
+  - >
+    if [[ -f typo3conf/ext/flux/Tests/phpunit7.xml && "$TYPO3" == "master" ]]; then
+      echo "Running unit tests for EXT:flux (CMS 7)";
+      ./bin/phpunit --colors -c typo3conf/ext/flux/Tests/phpunit7.xml --coverage-clover flux/build/logs/clover.xml;
+    fi
 
 after_script:
   - cd flux

--- a/Build/LocalConfiguration7.php
+++ b/Build/LocalConfiguration7.php
@@ -1,0 +1,57 @@
+<?php
+return array(
+	'BE' => array(
+		'disable_exec_function' => 0,
+		'fileCreateMask' => '0664',
+		'folderCreateMask' => '2774',
+		'forceCharset' => 'utf-8',
+		'installToolPassword' => 'bacb98acf97e0b6112b1d1b650b84971',
+		'versionNumberInFilename' => '0',
+	),
+	'DB' => array(
+		'database' => 'typo3_test',
+		'host' => 'localhost',
+		'password' => '',
+		'username' => 'root',
+	),
+	'EXT' => array(
+		'extConf' => array(
+			'workspaces' => 'a:0:{}',
+			'compatibility6' => 'a:0:{}',
+		),
+	),
+	'FE' => array(
+		'addRootLineFields' => 'backend_layout',
+		'lifetime' => '604800',
+		'logfile_dir' => 'localsettings/logs/',
+		'pageNotFound_handling' => '/404/',
+	),
+	'GFX' => array(
+		'gdlib_png' => '1',
+		'im_noScaleUp' => '1',
+		'im_path' => '/usr/bin/',
+		'im_version_5' => 'im6',
+		'TTFdpi' => '96',
+		'thumbnails_png' => '1',
+		'jpg_quality' => '80',
+	),
+	'INSTALL' => array(
+		'wizardDone' => array(),
+	),
+	'SYS' => array(
+		'devIPmask' => ',192.168.1.*',
+		'displayErrors' => '1',
+		'doNotCheckReferer' => '1',
+		'enable_DLOG' => 'enable_DLOG',
+		'enableDeprecationLog' => 'file',
+		'encryptionKey' => 'Travis Tests',
+		'forceReturnPath' => '1',
+		'setDBinit' => 'SET NAMES utf8',
+		'sitename' => 'New TYPO3 site',
+		'sqlDebug' => '1',
+		'UTF8filesystem' => '1',
+		'debugExceptionHandler' => '',
+		'setMemoryLimit' => 1024,
+	),
+);
+?>

--- a/Build/PackageStates7.php
+++ b/Build/PackageStates7.php
@@ -1,0 +1,593 @@
+<?php
+
+return array (
+  'packages' =>
+  array (
+    'builder' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'fluidtypo3/builder',
+      'state' => 'active',
+      'packagePath' => 'typo3conf/ext/builder/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'core' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-core',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/core/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'about' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-about',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/about/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'aboutmodules' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-aboutmodules',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/aboutmodules/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'adodb' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-adodb',
+      'state' => 'inactive',
+      'packagePath' => 'typo3/sysext/adodb/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'backend' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-backend',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/backend/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'belog' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-belog',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/belog/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'beuser' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-beuser',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/beuser/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'cms' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-cms',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/cms/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'context_help' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-context-help',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/context_help/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'cshmanual' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-cshmanual',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/cshmanual/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'css_styled_content' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-css-styled-content',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/css_styled_content/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'dbal' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-dbal',
+      'state' => 'inactive',
+      'packagePath' => 'typo3/sysext/dbal/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'documentation' =>
+    array (
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/documentation/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'extbase' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-extbase',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/extbase/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'extensionmanager' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-extensionmanager',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/extensionmanager/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'extra_page_cm_options' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-extra-page-cm-options',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/extra_page_cm_options/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'feedit' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-feedit',
+      'state' => 'inactive',
+      'packagePath' => 'typo3/sysext/feedit/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'felogin' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-felogin',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/felogin/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'filelist' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-filelist',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/filelist/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'fluid' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-fluid',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/fluid/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'flux' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'fluidtypo3/flux',
+      'state' => 'active',
+      'packagePath' => 'typo3conf/ext/flux/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'form' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-form',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/form/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'frontend' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-frontend',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/frontend/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'func' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-func',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/func/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'func_wizards' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-func-wizards',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/func_wizards/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'impexp' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-impexp',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/impexp/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'indexed_search' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-indexed-search',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/indexed_search/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'indexed_search_mysql' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-indexed-search-mysql',
+      'state' => 'inactive',
+      'packagePath' => 'typo3/sysext/indexed_search_mysql/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'info' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-info',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/info/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'info_pagetsconfig' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-info-pagetsconfig',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/info_pagetsconfig/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'install' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-install',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/install/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'lang' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-lang',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/lang/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'linkvalidator' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-linkvalidator',
+      'state' => 'inactive',
+      'packagePath' => 'typo3/sysext/linkvalidator/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'lowlevel' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-lowlevel',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/lowlevel/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'opendocs' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-opendocs',
+      'state' => 'inactive',
+      'packagePath' => 'typo3/sysext/opendocs/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'openid' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-openid',
+      'state' => 'inactive',
+      'packagePath' => 'typo3/sysext/openid/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'perm' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-perm',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/perm/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'recordlist' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-recordlist',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/recordlist/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'recycler' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-recycler',
+      'state' => 'inactive',
+      'packagePath' => 'typo3/sysext/recycler/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'reports' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-reports',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/reports/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'rsaauth' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-rsaauth',
+      'state' => 'inactive',
+      'packagePath' => 'typo3/sysext/rsaauth/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'rtehtmlarea' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-rtehtmlarea',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/rtehtmlarea/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'saltedpasswords' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-saltedpasswords',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/saltedpasswords/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'scheduler' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-scheduler',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/scheduler/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'setup' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-setup',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/setup/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'sv' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-sv',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/sv/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'sys_action' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-sys-action',
+      'state' => 'inactive',
+      'packagePath' => 'typo3/sysext/sys_action/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'sys_note' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-sys-note',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/sys_note/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    't3editor' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-t3editor',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/t3editor/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    't3skin' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-t3skin',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/t3skin/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'taskcenter' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-taskcenter',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/taskcenter/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'tstemplate' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-tstemplate',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/tstemplate/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'version' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-version',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/version/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'viewpage' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-viewpage',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/viewpage/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'wizard_crpages' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-wizard-crpages',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/wizard_crpages/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'wizard_sortpages' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-wizard-sortpages',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/wizard_sortpages/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'workspaces' =>
+    array (
+      'manifestPath' => '',
+      'composerName' => 'typo3/cms-workspaces',
+      'state' => 'active',
+      'packagePath' => 'typo3/sysext/workspaces/',
+      'classesPath' => 'Classes/',
+      'suggestions' => array(),
+      'dependencies' => array(),
+    ),
+    'compatibility6' =>
+     array (
+       'state' => 'active',
+       'packagePath' => 'typo3/sysext/compatibility6/',
+       'classesPath' => 'Classes/',
+       'suggestions' => array (),
+     ),
+  ),
+  'version' => 4,
+);

--- a/Tests/phpunit7.xml
+++ b/Tests/phpunit7.xml
@@ -1,0 +1,26 @@
+<phpunit backupGlobals="false"
+        backupStaticAttributes="false"
+        bootstrap="../../typo3/sysext/core/Build/UnitTestsBootstrap.php"
+        colors="true"
+        convertErrorsToExceptions="true"
+        convertWarningsToExceptions="true"
+        forceCoversAnnotation="false"
+        processIsolation="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        strict="false"
+        verbose="false">
+
+        <testsuites>
+                <testsuite name="EXT:flux">
+                        <directory>typo3conf/ext/flux/Tests</directory>
+                </testsuite>
+        </testsuites>
+		<filter>
+				<whitelist>
+						<directory>typo3conf/ext/flux/Classes</directory>
+				</whitelist>
+		</filter>
+</phpunit>


### PR DESCRIPTION
CMS 7 has some cleanups going on that moves legacy code into EXT:compatibility6
This change adds it to the Build env when the branch is master.
