### PR TITLE
[BUGFIX] BackendConfigurationManager retrieves wrong pageId

### DIFF
--- a/Classes/Configuration/BackendConfigurationManager.php
+++ b/Classes/Configuration/BackendConfigurationManager.php
@@ -184,7 +184,11 @@ class BackendConfigurationManager extends CoreBackendConfigurationManager implem
 	 * @return integer
 	 */
 	protected function getPageIdFromRecord(array $record) {
-		return (integer) (FALSE === isset($record['pid']) ? : $record['pid']);
+		if (FALSE === isset($record['pid'])) {
+			return 0;
+		}
+
+		return (integer) $record['pid'];
 	}
 
 }


### PR DESCRIPTION
If given an empty array, the function getPageIdFromRecord casts
TRUE to (int) 1 resulting in configuration not loading in
BE/CLI context.

Fixes #705
