### PR TITLE
[FEATURE] Introducing Form Option ViewHelpers

### DIFF
--- a/Classes/ViewHelpers/Form/Option/GroupViewHelper.php
+++ b/Classes/ViewHelpers/Form/Option/GroupViewHelper.php
@@ -1,0 +1,50 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Form\Option;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Göran Bodenschatz <coding@46halbe.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\Form;
+use FluidTYPO3\Flux\ViewHelpers\Form\OptionViewHelper;
+
+/**
+ * Form group option ViewHelper
+ *
+ * @package Flux
+ * @subpackage ViewHelpers/Form
+ */
+class GroupViewHelper extends OptionViewHelper {
+
+	/**
+	 * @var string
+	 */
+	protected $option = Form::OPTION_GROUP;
+
+	/**
+	 * Initialize arguments
+	 * @return void
+	 */
+	public function initializeArguments() {
+		$this->registerArgument('value', 'string', 'Name of the group (fx: shown as label of WizardTab)', FALSE, NULL);
+	}
+}

--- a/Classes/ViewHelpers/Form/Option/IconViewHelper.php
+++ b/Classes/ViewHelpers/Form/Option/IconViewHelper.php
@@ -1,0 +1,50 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Form\Option;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Göran Bodenschatz <coding@46halbe.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\Form;
+use FluidTYPO3\Flux\ViewHelpers\Form\OptionViewHelper;
+
+/**
+ * Form icon option ViewHelper
+ *
+ * @package Flux
+ * @subpackage ViewHelpers/Form
+ */
+class IconViewHelper extends OptionViewHelper {
+
+	/**
+	 * @var string
+	 */
+	protected $option = Form::OPTION_ICON;
+
+	/**
+	 * Initialize arguments
+	 * @return void
+	 */
+	public function initializeArguments() {
+		$this->registerArgument('value', 'string', 'Path and name of the icon file', FALSE, NULL);
+	}
+}

--- a/Classes/ViewHelpers/Form/OptionViewHelper.php
+++ b/Classes/ViewHelpers/Form/OptionViewHelper.php
@@ -1,0 +1,62 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Form;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Göran Bodenschatz <coding@46halbe.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ *****************************************************************/
+
+use FluidTYPO3\Flux\Form;
+use FluidTYPO3\Flux\ViewHelpers\AbstractFormViewHelper;
+
+/**
+ * Form option ViewHelper
+ *
+ * @package Flux
+ * @subpackage ViewHelpers/Form
+ */
+class OptionViewHelper extends AbstractFormViewHelper {
+
+	/**
+	 * @var string
+	 */
+	protected $option;
+
+	/**
+	 * Initialize arguments
+	 * @return void
+	 */
+	public function initializeArguments() {
+		$this->registerArgument('name', 'string', 'Name of the option to be set', TRUE, NULL);
+		$this->registerArgument('value', 'string', 'Option value', FALSE, NULL);
+	}
+
+	/**
+	 * Render method
+	 * @return void
+	 */
+	public function render() {
+		$option = $this->hasArgument('name') ? $this->arguments['name'] : $this->option;
+		$value = NULL === $this->arguments['value'] ? $this->renderChildren() : $this->arguments['value'];
+
+		$this->getForm()->setOption($option, $value);
+	}
+}

--- a/Tests/Unit/ViewHelpers/Form/Option/GroupViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Form/Option/GroupViewHelperTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Form\Option;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Göran Bodenschatz <coding@46halbe.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use FluidTYPO3\Flux\Tests\Unit\ViewHelpers\AbstractFormViewHelperTestCase;
+
+/**
+ * @package Flux
+ */
+class GroupViewHelperTest extends AbstractFormViewHelperTestCase {
+
+}

--- a/Tests/Unit/ViewHelpers/Form/Option/IconViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Form/Option/IconViewHelperTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Form\Option;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Göran Bodenschatz <coding@46halbe.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use FluidTYPO3\Flux\Tests\Unit\ViewHelpers\AbstractFormViewHelperTestCase;
+
+/**
+ * @package Flux
+ */
+class IconViewHelperTest extends AbstractFormViewHelperTestCase {
+
+}

--- a/Tests/Unit/ViewHelpers/Form/OptionViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Form/OptionViewHelperTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Form;
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2014 Göran Bodenschatz <coding@46halbe.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
+
+use FluidTYPO3\Flux\Tests\Unit\ViewHelpers\AbstractFormViewHelperTestCase;
+
+/**
+ * @package Flux
+ */
+class IconViewHelperTest extends AbstractFormViewHelperTestCase {
+
+}


### PR DESCRIPTION
Introducing a new way of setting Form options via ViewHelper.

Included:
- generic `<flux:form.option name="foo" value="bar" />`
- icon  `<flux:form.option.icon value="path/to/iconFile" />`
- group  `<flux:form.option.group value="groupName" />`

In case of more than one element of the same special type (icon/group) or of the same name attribute in a single `<flux:form/>` the last one wins.

This viewHelpers may replace the current way of setting form options via attribute.
