### PR TITLE
[TASK] Remove obsolete icon classes

### DIFF
--- a/Classes/Utility/MiscellaneousUtility.php
+++ b/Classes/Utility/MiscellaneousUtility.php
@@ -46,8 +46,7 @@ class MiscellaneousUtility {
 	* @return string
 	*/
 	public static function getIcon($icon) {
-		$configuration = array('class' => 't3-icon-actions t3-icon-document-new');
-		return IconUtility::getSpriteIcon($icon, $configuration);
+		return IconUtility::getSpriteIcon($icon);
 	}
 
 	/**


### PR DESCRIPTION
Should resolve https://github.com/FluidTYPO3/flux/issues/728
In 6.2 the icon classes duplicated insert. Please test this before merging it. New content also copy icon and reference are using this function.