### PR TITLE
[BUGFIX] Do not set drawItem variable in Preview

### DIFF
--- a/Classes/Backend/Preview.php
+++ b/Classes/Backend/Preview.php
@@ -93,7 +93,6 @@ class Preview implements PageLayoutViewDrawItemHookInterface {
 	 * @return NULL
 	 */
 	public function renderPreview(&$headerContent, &$itemContent, array &$row, &$drawItem) {
-		$drawItem = TRUE;
 		$fieldName = NULL; // every provider for tt_content will be asked to get a preview
 		if ('shortcut' === $row['CType'] && FALSE === strpos($row['records'], ',')) {
 			$itemContent = $this->createShortcutIcon($row) . $itemContent;


### PR DESCRIPTION
The tt_content_drawItem function of TYPO3\CMS\Backend\View\PageLayoutView.php already set this variable to TRUE. If it is FALSE, it means another hook modified it because it already rendered the preview of the current item. Therefore, there is no need to set it to TRUE here.

I have an extension with a custom CType that render the preview for its content objects and set drawItem to FALSE, to prevent the default rendering of the preview. However, Flux set it back to TRUE, event if the CType of the content object does not belong to it. Because of this, I saw both the rendered preview of my extension and the default rendered preview from TYPO3, while I'd expect to only see my rendered preview.