### PR TITLE
[TASK] Remove all inheritance support from Provider

### DIFF
--- a/Classes/Provider/ProviderInterface.php
+++ b/Classes/Provider/ProviderInterface.php
@@ -377,15 +377,6 @@ interface ProviderInterface {
 	public function getControllerActionReferenceFromRecord(array $row);
 
 	/**
-	 * Gets an inheritance tree (ordered parent -> ... -> this record)
-	 * of record arrays containing raw values.
-	 *
-	 * @param array $row
-	 * @return array
-	 */
-	public function getInheritanceTree(array $row);
-
-	/**
 	 * @param Form $form
 	 */
 	public function setForm(Form $form);

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -86,18 +86,6 @@ abstract class AbstractProviderTest extends AbstractTestCase {
 	/**
 	 * @test
 	 */
-	public function getInheritanceTreeReturnsEmptyArrayIfFieldNameIsNull() {
-		$className = str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4));
-		$instance = $this->getMock($className, array('getFieldName'));
-		$instance->expects($this->once())->method('getFieldName')->will($this->returnValue(NULL));
-		$returned = $instance->getInheritanceTree(array('uid' => rand(999999, 99999999)));
-		$this->assertIsArray($returned);
-		$this->assertEmpty($returned);
-	}
-
-	/**
-	 * @test
-	 */
 	public function canGetAndSetListType() {
 		$record = Records::$contentRecordIsParentAndHasChildren;
 		/** @var ProviderInterface $instance */
@@ -180,59 +168,17 @@ abstract class AbstractProviderTest extends AbstractTestCase {
 	 * @test
 	 */
 	public function canGetFlexformValues() {
-		$provider = $this->getConfigurationProviderInstance();
-		$provider->setTemplatePathAndFilename($this->getAbsoluteFixtureTemplatePathAndFilename(self::FIXTURE_TEMPLATE_ABSOLUTELYMINIMAL));
-		$provider->reset();
 		$record = $this->getBasicRecord();
-		$values1 = $provider->getFlexformValues($record);
-		$values2 = $provider->getFlexformValues($record);
-		$this->assertIsArray($values1);
-		$this->assertSame($values1, $values2);
-	}
-
-	/**
-	 * @test
-	 */
-	public function canGetFlexformValuesUnderDirectConditions() {
-		$tree = array(
-			$this->getBasicRecord(),
-			$this->getBasicRecord()
-		);
-		$record = $this->getBasicRecord();
-		$provider = $this->getMock(str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4)), array('getForm', 'getInheritanceTree', 'getMergedConfiguration'));
+		$provider = $this->getMock(str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4)), array('getForm'));
 		$mockConfigurationService = $this->getMock('FluidTYPO3\Flux\Service\FluxService', array('convertFlexFormContentToArray'));
 		$mockConfigurationService->expects($this->once())->method('convertFlexFormContentToArray')->will($this->returnValue(array('test' => 'test')));
 		$provider->expects($this->once())->method('getForm')->will($this->returnValue(Form::create()));
-		$provider->expects($this->once())->method('getInheritanceTree')->will($this->returnValue($tree));
-		$provider->expects($this->once())->method('getMergedConfiguration')->with($tree)->will($this->returnValue(array('test' => 'test')));
-		ObjectAccess::setProperty($provider, 'configurationService', $mockConfigurationService, TRUE);
+		$provider->injectConfigurationService($mockConfigurationService);
 		$provider->setTemplatePathAndFilename($this->getAbsoluteFixtureTemplatePathAndFilename(self::FIXTURE_TEMPLATE_ABSOLUTELYMINIMAL));
 		$provider->reset();
 		$values = $provider->getFlexformValues($record);
 		$this->assertIsArray($values);
 		$this->assertEquals($values, array('test' => 'test'));
-	}
-
-	/**
-	 * @test
-	 */
-	public function canGetFlexformValuesUnderInheritanceConditions() {
-		$tree = array(
-			$this->getBasicRecord(),
-			$this->getBasicRecord()
-		);
-		$record = $this->getBasicRecord();
-		$provider = $this->getMock(str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4)), array('getForm', 'getInheritanceTree', 'getMergedConfiguration'));
-		$mockConfigurationService = $this->getMock('FluidTYPO3\Flux\Service\FluxService', array('convertFlexFormContentToArray'));
-		$mockConfigurationService->expects($this->once())->method('convertFlexFormContentToArray')->will($this->returnValue(array()));
-		$provider->expects($this->once())->method('getForm')->will($this->returnValue(Form::create()));
-		$provider->expects($this->once())->method('getInheritanceTree')->will($this->returnValue($tree));
-		$provider->expects($this->once())->method('getMergedConfiguration')->with($tree)->will($this->returnValue(array()));
-		$provider->setTemplatePathAndFilename($this->getAbsoluteFixtureTemplatePathAndFilename(self::FIXTURE_TEMPLATE_ABSOLUTELYMINIMAL));
-		ObjectAccess::setProperty($provider, 'configurationService', $mockConfigurationService, TRUE);
-		$provider->reset();
-		$values = $provider->getFlexformValues($record);
-		$this->assertEquals($values, array());
 	}
 
 	/**
@@ -587,22 +533,6 @@ abstract class AbstractProviderTest extends AbstractTestCase {
 	/**
 	 * @test
 	 */
-	public function canUseInheritanceTree() {
-		$provider = $this->getConfigurationProviderInstance();
-		$provider->setFieldName('pi_flexform');
-		$provider->setTemplatePathAndFilename($this->getAbsoluteFixtureTemplatePathAndFilename(self::FIXTURE_TEMPLATE_PREVIEW_EMPTY));
-		$record = $this->getBasicRecord();
-		$byPathExists = $this->callInaccessibleMethod($provider, 'getInheritedPropertyValueByDottedPath', $record, 'settings');
-		$byDottedPathExists = $this->callInaccessibleMethod($provider, 'getInheritedPropertyValueByDottedPath', $record, 'settings.input');
-		$byPathDoesNotExist = $this->callInaccessibleMethod($provider, 'getInheritedPropertyValueByDottedPath', $record, 'void.doesnotexist');
-		$this->assertEmpty($byPathDoesNotExist);
-		$this->assertEmpty($byPathExists);
-		$this->assertEmpty($byDottedPathExists);
-	}
-
-	/**
-	 * @test
-	 */
 	public function canLoadRecordFromDatabase() {
 		$backup = $GLOBALS['TYPO3_DB'];
 		$row = Records::$contentRecordWithoutParentAndWithoutChildren;
@@ -617,35 +547,6 @@ abstract class AbstractProviderTest extends AbstractTestCase {
 	/**
 	 * @test
 	 */
-	public function canLoadRecordTreeFromDatabase() {
-		$record = $this->getBasicRecord();
-		$provider = $this->getMock(str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4)), array('loadRecordFromDatabase', 'getParentFieldName', 'getParentFieldValue'));
-		$provider->expects($this->exactly(2))->method('getParentFieldName')->will($this->returnValue('somefield'));
-		$provider->expects($this->exactly(1))->method('getParentFieldValue')->will($this->returnValue(1));
-		$provider->expects($this->exactly(1))->method('loadRecordFromDatabase')->will($this->returnValue($record));
-		$output = $this->callInaccessibleMethod($provider, 'loadRecordTreeFromDatabase', $record);
-		$expected = array($record);
-		$this->assertEquals($expected, $output);
-	}
-
-	/**
-	 * @test
-	 */
-	public function setsDefaultValueInFieldsBasedOnInheritedValue() {
-		$row = array();
-		$className = str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4));
-		$service = $this->getMock($className, array('getInheritedPropertyValueByDottedPath'));
-		$service->expects($this->once())->method('getInheritedPropertyValueByDottedPath')->with($row, 'input')->will($this->returnValue('default'));
-		$form = Form::create();
-		$field = $form->createField('Input', 'input');
-		$returnedForm = $this->callInaccessibleMethod($service, 'setDefaultValuesInFieldsWithInheritedValues', $form, $row);
-		$this->assertSame($form, $returnedForm);
-		$this->assertEquals('default', $field->getDefault());
-	}
-
-	/**
-	 * @test
-	 */
 	public function canCallPreProcessCommand() {
 		$provider = $this->getConfigurationProviderInstance();
 		$command = 'dummy';
@@ -654,111 +555,6 @@ abstract class AbstractProviderTest extends AbstractTestCase {
 		$relativeTo = 1;
 		$reference = new DataHandler();
 		$provider->preProcessCommand($command, $id, $record, $relativeTo, $reference);
-	}
-
-	/**
-	 * @test
-	 */
-	public function canGetMergedConfiguration() {
-		$form = Form::create();
-		$form->createContainer('Grid', 'grid');
-		$form->createField('Input', 'test');
-		$form->createContainer('Object', 'testobject');
-		$record = $this->getBasicRecord();
-		$tree = array($record);
-		$instance = $this->getMock(str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4)), array('getForm', 'getFlexFormValues'));
-		$instance->reset();
-		$instance->expects($this->once())->method('getForm')->will($this->returnValue($form));
-		$output = $this->callInaccessibleMethod($instance, 'getMergedConfiguration', $tree);
-		$this->assertEquals(array(), $output);
-	}
-
-	/**
-	 * @test
-	 */
-	public function canGetMergedConfigurationAndMergeToCache() {
-		$form = Form::create();
-		$form->createContainer('Grid', 'grid');
-		$form->createField('Input', 'test');
-		$form->createContainer('Object', 'testobject');
-		$record = $this->getBasicRecord();
-		$tree = array($record);
-		$instance = $this->getMock(str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4)), array('getForm', 'getFlexFormValues', 'hasCacheForMergedConfiguration'));
-		$instance->reset();
-		$instance->expects($this->once())->method('getForm')->will($this->returnValue($form));
-		$instance->expects($this->once())->method('hasCacheForMergedConfiguration')->will($this->returnValue(TRUE));
-		$this->callInaccessibleMethod($instance, 'getMergedConfiguration', $tree, 'testing', TRUE);
-	}
-
-	/**
-	 * @test
-	 */
-	public function getMergedConfigurationReturnsEmptyArrayIfFormIsNull() {
-		$record = $this->getBasicRecord();
-		$tree = array($record);
-		$instance = $this->getMock(str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4)), array('getForm'));
-		$instance->reset();
-		$instance->expects($this->once())->method('getForm')->will($this->returnValue(NULL));
-		$output = $this->callInaccessibleMethod($instance, 'getMergedConfiguration', $tree);
-		$this->assertEquals(array(), $output);
-	}
-
-	/**
-	 * @test
-	 */
-	public function canAssertHasCachedMergedConfiguration() {
-		$instance = $this->createInstance();
-		$instance->reset();
-		$this->assertFalse($this->callInaccessibleMethod($instance, 'hasCacheForMergedConfiguration', 'test'));
-	}
-
-	/**
-	 * @test
-	 */
-	public function canGetCacheKeyForMergedConfiguration() {
-		$instance = $this->createInstance();
-		$instance->reset();
-		$tree = array(
-			array(
-				'test' => 'test'
-			)
-		);
-		$expected = 'merged_' . md5(json_encode($tree));
-		$this->assertEquals($expected, $this->callInaccessibleMethod($instance, 'getCacheKeyForMergedConfiguration', $tree));
-	}
-
-	/**
-	 * @test
-	 * @dataProvider getRemoveInheritedTestValues
-	 * @param mixed $testValue
-	 * @param boolean $inherit
-	 * @param boolean $inheritEmpty
-	 * @param boolean $expectsOverride
-	 */
-	public function removesInheritedValuesFromFields($testValue, $inherit, $inheritEmpty, $expectsOverride) {
-		$instance = $this->createInstance();
-		$field = Form\Field\Input::create(array('type' => 'Input'));
-		$field->setName('test');
-		$field->setInherit($inherit);
-		$field->setInheritEmpty($inheritEmpty);
-		$values = array('foo' => 'bar', 'test' => $testValue);
-		$result = $this->callInaccessibleMethod($instance, 'unsetInheritedValues', $field, $values);
-		if (TRUE === $expectsOverride) {
-			$this->assertEquals($values, $result);
-		} else {
-			$this->assertEquals(array('foo' => 'bar'), $result);
-		}
-	}
-
-	/**
-	 * @return array
-	 */
-	public function getRemoveInheritedTestValues() {
-		return array(
-			array('test', TRUE, TRUE, TRUE),
-			array('', TRUE, FALSE, TRUE),
-			array('', TRUE, TRUE, FALSE),
-		);
 	}
 
 	/**

--- a/Tests/Unit/Provider/ProviderTest.php
+++ b/Tests/Unit/Provider/ProviderTest.php
@@ -135,20 +135,5 @@ class ProviderTest extends AbstractProviderTest {
 		$grid = $provider->getGrid($record);
 		$this->assertInstanceOf('FluidTYPO3\Flux\Form\Container\Grid', $grid);
 	}
-	/**
-	 * @test
-	 */
-	public function getParentFieldValueLoadsRecordFromDatabaseIfRecordLacksParentFieldValue() {
-		$row = Records::$contentRecordWithoutParentAndWithoutChildren;
-		$row['uid'] = 2;
-		$rowWithPid = $row;
-		$rowWithPid['pid'] = 1;
-		$className = str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4));
-		$instance = $this->getMock($className, array('getParentFieldName', 'getTableName', 'loadRecordFromDatabase'));
-		$instance->expects($this->once())->method('loadRecordFromDatabase')->with($row['uid'])->will($this->returnValue($rowWithPid));
-		$instance->expects($this->once())->method('getParentFieldName')->with($row)->will($this->returnValue('pid'));
-		$result = $this->callInaccessibleMethod($instance, 'getParentFieldValue', $row);
-		$this->assertEquals($rowWithPid['pid'], $result);
-	}
 
 }


### PR DESCRIPTION
This is sub-task 1 from https://github.com/FluidTYPO3/flux/issues/760. The commit will break `fluidpages` until that extension has assimilated (most of) the code removed in this commit, into the PageProvider.