### PR TITLE
Store compiled templates if they are compilable.

### DIFF
--- a/Classes/View/ExposedTemplateView.php
+++ b/Classes/View/ExposedTemplateView.php
@@ -160,6 +160,9 @@ class ExposedTemplateView extends TemplateView implements ViewInterface {
 			$parsedTemplate = $this->templateCompiler->get($templateIdentifier);
 		} else {
 			$parsedTemplate = $this->templateParser->parse($source);
+			if ($parsedTemplate->isCompilable()) {
+				$this->templateCompiler->store($templateIdentifier, $parsedTemplate);
+			}
 		}
 		return $parsedTemplate;
 	}


### PR DESCRIPTION
This improves rendering performance on our site massively;
page rendering times go down from 9s to 3s.