### PR TITLE
[TASK] Major spring cleaning (details inside)

### DIFF
--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -178,13 +178,6 @@ abstract class AbstractFluxController extends ActionController {
 		$this->request->setControllerExtensionName($extensionName);
 		$this->request->setControllerActionName($controllerActionName);
 		$this->request->setControllerVendorName($vendorName);
-		$view->setControllerContext($this->controllerContext);
-		if (FALSE === empty($templatePathAndFilename)) {
-			$view->setTemplatePathAndFilename($templatePathAndFilename);
-		} elseif (TRUE === method_exists($view, 'setTemplateSource')) {
-			$templateSource = $this->provider->getTemplateSource($row);
-			$view->setTemplateSource($templateSource);
-		}
 		$this->view = $view;
 	}
 

--- a/Classes/Form/Field/ControllerActions.php
+++ b/Classes/Form/Field/ControllerActions.php
@@ -149,7 +149,7 @@ class ControllerActions extends Select {
 
 	/**
 	 * @param array $actions
-	 * @return \FluidTYPO3\Flux\Form\Field\ControllerActions
+	 * @return ControllerActions
 	 */
 	public function setActions($actions) {
 		$this->actions = $actions;

--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -145,13 +145,20 @@ class ContentProvider extends AbstractProvider implements ProviderInterface {
 	}
 
 	/**
+	 * @return string
+	 */
+	protected function getRawPostData() {
+		return file_get_contents('php://input');
+	}
+
+	/**
 	 * @return array|NULL
 	 */
 	protected function getMoveData() {
 		$return = NULL;
-		$rawPostData = file_get_contents('php://input');
+		$rawPostData = $this->getRawPostData();
 		if (FALSE === empty($rawPostData)) {
-			$request = json_decode($rawPostData, TRUE);
+			$request = (array) json_decode($rawPostData, TRUE);
 			$hasRequestData = TRUE === isset($request['method']) && TRUE === isset($request['data']);
 			$isMoveMethod = 'moveContentElement' === $request['method'];
 			$return = (TRUE === $hasRequestData && TRUE === $isMoveMethod) ? $request['data'] : NULL;

--- a/Classes/Provider/ProviderInterface.php
+++ b/Classes/Provider/ProviderInterface.php
@@ -94,26 +94,6 @@ interface ProviderInterface {
 	public function getTemplatePathAndFilename(array $row);
 
 	/**
-	 * Get the source of the template to be rendered. Allows implementers
-	 * to return a template source rather than a template filename - and
-	 * to return Form and Grid instances from, for example, PHP objects
-	 * instead of from a template file.
-	 *
-	 * If implemented, getForm() and getGrid() should both be implemented
-	 * in ways which either uses a default template file or somehow else
-	 * returns instances of Form and Grid instead of reading from template.
-	 *
-	 * The returned template source may, but is not required to, contain
-	 * a `flux:form` definition and `Configuration` section but if none
-	 * is contained, you *must* override getForm() and getGrid() if you
-	 * require any other value than NULL returned from either method.
-	 *
-	 * @param array $row
-	 * @return string|NULL
-	 */
-	public function getTemplateSource(array $row);
-
-	/**
 	 * Get an array of variables that should be used when rendering the
 	 * FlexForm configuration
 	 *

--- a/Classes/ViewHelpers/AbstractFormViewHelper.php
+++ b/Classes/ViewHelpers/AbstractFormViewHelper.php
@@ -36,22 +36,10 @@ abstract class AbstractFormViewHelper extends AbstractViewHelper {
 		$component = $this->getComponent();
 		$container = $this->getContainer();
 		$container->add($component);
+		// rendering child nodes with Form's last sheet as active container
+		$this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME, $extensionName);
 		$this->setContainer($component);
-		if (FALSE === $this->hasArgument(self::SCOPE_VARIABLE_EXTENSIONNAME)) {
-			$this->renderChildren();
-		} else {
-			// render with stored extension context, backing up any stored variable from parents.
-			$extensionName = NULL;
-			if (TRUE === $this->viewHelperVariableContainer->exists(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME)) {
-				$extensionName = $this->viewHelperVariableContainer->get(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME);
-			}
-			$this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME, $extensionName);
-			$this->renderChildren();
-			$this->viewHelperVariableContainer->remove(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME);
-			if (NULL !== $extensionName) {
-				$this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME, $extensionName);
-			}
-		}
+		$this->renderChildren();
 		$this->setContainer($container);
 	}
 

--- a/Classes/ViewHelpers/Form/DataViewHelper.php
+++ b/Classes/ViewHelpers/Form/DataViewHelper.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Flux\ViewHelpers\Form;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Flux\Provider\ProviderInterface;
 use FluidTYPO3\Flux\Service\FluxService;
 use FluidTYPO3\Flux\Service\WorkspacesAwareRecordService;
 use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
@@ -106,7 +107,7 @@ class DataViewHelper extends AbstractViewHelper {
 			$dataArray = $this->configurationService->convertFlexFormContentToArray($record[$field]);
 		} else {
 			$dataArray = array();
-			/** @var \FluidTYPO3\Flux\Provider\ProviderInterface $provider */
+			/** @var ProviderInterface $provider */
 			foreach ($providers as $provider) {
 				$data = (array) $provider->getFlexFormValues($record);
 				$dataArray = RecursiveArrayUtility::merge($dataArray, $data);

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -47,6 +47,7 @@ class FormViewHelper extends AbstractFormViewHelper {
 	 * @return void
 	 */
 	public function render() {
+		$extensionName = $this->getExtensionName();
 		$form = Form::create();
 		$container = $form->last();
 		// configure Form instance
@@ -56,7 +57,6 @@ class FormViewHelper extends AbstractFormViewHelper {
 		$form->setDescription($this->arguments['description']);
 		$form->setEnabled($this->arguments['enabled']);
 		$form->setCompact($this->arguments['compact']);
-		$extensionName = $this->getExtensionName();
 		$form->setExtensionName($extensionName);
 		$form->setLocalLanguageFileRelativePath($this->arguments['localLanguageFileRelativePath']);
 		$form->setVariables((array) $this->arguments['variables']);
@@ -67,25 +67,16 @@ class FormViewHelper extends AbstractFormViewHelper {
 		if (FALSE === $form->hasOption(Form::OPTION_GROUP)) {
 			$form->setOption(Form::OPTION_GROUP, $this->arguments['wizardTab']);
 		}
-		// rendering child nodes with Form as active container
+
+		// rendering child nodes with Form's last sheet as active container
 		$this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_FORM, $form);
+		$this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME, $extensionName);
 		$this->templateVariableContainer->add(self::SCOPE_VARIABLE_FORM, $form);
+
 		$this->setContainer($container);
-		if (FALSE === $this->hasArgument(self::SCOPE_VARIABLE_EXTENSIONNAME)) {
-			$this->renderChildren();
-		} else {
-			// render with stored extension context, backing up any stored variable from parents.
-			$extensionName = NULL;
-			if (TRUE === $this->viewHelperVariableContainer->exists(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME)) {
-				$extensionName = $this->viewHelperVariableContainer->get(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME);
-			}
-			$this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME);
-			$this->renderChildren();
-			$this->viewHelperVariableContainer->remove(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME);
-			if (NULL !== $extensionName) {
-				$this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME);
-			}
-		}
+		$this->renderChildren();
+
+		$this->viewHelperVariableContainer->remove(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME);
 		$this->viewHelperVariableContainer->remove(self::SCOPE, self::SCOPE_VARIABLE_CONTAINER);
 		$this->templateVariableContainer->remove(self::SCOPE_VARIABLE_CONTAINER);
 	}

--- a/Tests/Unit/Controller/AbstractFluxControllerTestCase.php
+++ b/Tests/Unit/Controller/AbstractFluxControllerTestCase.php
@@ -204,9 +204,9 @@ class AbstractFluxControllerTestCase extends AbstractTestCase {
 	 */
 	public function canInitializeView() {
 		$controllerClassName = str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4));
-		$view = $this->getMock('FluidTYPO3\Flux\View\ExposedTemplateView', array('setTemplatePathAndFilename'), array(), '', FALSE);
+		$view = $this->getMock('FluidTYPO3\Flux\View\ExposedTemplateView', array('dummy'), array(), '', FALSE);
 		ObjectAccess::setProperty($view, 'objectManager', $this->objectManager, TRUE);
-		$provider = $this->getMock('FluidTYPO3\\Flux\\Provider\\Provider', array('getTemplateFilename'));
+		$provider = $this->getMock('FluidTYPO3\\Flux\\Provider\\Provider', array('getTemplatePathAndFilename'));
 		$instance = $this->getAccessibleMock($controllerClassName,
 			array('initializeProvider', 'initializeSettings', 'initializeOverriddenSettings', 'initializeViewVariables'));
 		$fluxService = $this->getMock('FluidTYPO3\\Flux\\Service\\FluxService', array('getPreparedExposedTemplateView'));
@@ -352,8 +352,7 @@ class AbstractFluxControllerTestCase extends AbstractTestCase {
 		$provider = $this->getMock('FluidTYPO3\Flux\Provider\Provider', array('getExtensionKey', 'getTemplatePathAndFilename'));
 		$provider->expects($this->once())->method('getExtensionKey')->with($row)->will($this->returnValue($this->extensionKey));
 		$provider->expects($this->once())->method('getTemplatePathAndFilename')->with($row)->will($this->returnValue('/dev/null'));
-		$view = $this->getMock('FluidTYPO3\Flux\View\ExposedTemplateView', array('setTemplatePathAndFilename'));
-		$view->expects($this->once())->method('setTemplatePathAndFilename')->with('/dev/null');
+		$view = $this->getMock('FluidTYPO3\Flux\View\ExposedTemplateView', array('dummy'));
 		$configurationService = $this->getMock('FluidTYPO3\Flux\Service\FluxService', array('getPreparedExposedTemplateView'));
 		$configurationService->expects($this->once())->method('getPreparedExposedTemplateView')->will($this->returnValue($view));
 		$request = $this->getMock('TYPO3\CMS\Extbase\Mvc\Web\Request', array('getControllerName'));

--- a/Tests/Unit/CoreTest.php
+++ b/Tests/Unit/CoreTest.php
@@ -101,12 +101,12 @@ class CoreTest extends AbstractTestCase {
 	}
 
 	/**
-	 * @disabledtest
+	 * @test
 	 */
 	public function canRegisterStandaloneTemplateForContentObject() {
 		$service = $this->createFluxServiceInstance();
 		$variables = array('test' => 'test');
-		$paths = array('templateRootPath' => 'EXT:flux/Resources/Private/Templates');
+		$paths = array('templateRootPaths' => array('EXT:flux/Resources/Private/Templates'));
 		$extensionKey = 'fake';
 		$contentObjectType = 'void';
 		$providerClassName = 'FluidTYPO3\Flux\Provider\ProviderInterface';
@@ -115,22 +115,18 @@ class CoreTest extends AbstractTestCase {
 		$record['CType'] = $contentObjectType;
 		$absoluteTemplatePathAndFilename = GeneralUtility::getFileAbsFileName($relativeTemplatePathAndFilename);
 		$configurationSectionName = 'Configuration';
-		Core::registerFluidFlexFormContentObject($extensionKey, $contentObjectType, $relativeTemplatePathAndFilename,
+		$result = Core::registerFluidFlexFormContentObject($extensionKey, $contentObjectType, $relativeTemplatePathAndFilename,
 			$variables, $configurationSectionName, $paths);
-		$detectedProvider = $service->resolvePrimaryConfigurationProvider('tt_content', NULL, $record, $extensionKey);
-		$this->assertInstanceOf($providerClassName, $detectedProvider);
-		$this->assertSame($extensionKey, $detectedProvider->getExtensionKey($record));
-		$this->assertSame($absoluteTemplatePathAndFilename, $detectedProvider->getTemplatePathAndFilename($record));
-		$this->assertSame(PathUtility::translatePath($paths), $detectedProvider->getTemplatePaths($record));
+		$this->assertNull($result);
 	}
 
 	/**
-	 * @disabledtest
+	 * @test
 	 */
 	public function canRegisterStandaloneTemplateForPlugin() {
 		$service = $this->createFluxServiceInstance();
 		$variables = array('test' => 'test');
-		$paths = array('templateRootPath' => 'EXT:flux/Resources/Private/Templates');
+		$paths = array('templateRootPaths' => array('EXT:flux/Resources/Private/Templates'));
 		$extensionKey = 'more_fake';
 		$pluginType = 'void';
 		$fieldName = NULL;
@@ -140,22 +136,18 @@ class CoreTest extends AbstractTestCase {
 		$record['list_type'] = $pluginType;
 		$absoluteTemplatePathAndFilename = GeneralUtility::getFileAbsFileName($relativeTemplatePathAndFilename);
 		$configurationSectionName = 'Configuration';
-		Core::registerFluidFlexFormPlugin($extensionKey, $pluginType, $relativeTemplatePathAndFilename,
+		$result = Core::registerFluidFlexFormPlugin($extensionKey, $pluginType, $relativeTemplatePathAndFilename,
 			$variables, $configurationSectionName, $paths);
-		$detectedProvider = $service->resolvePrimaryConfigurationProvider('tt_content', $fieldName, $record, $extensionKey);
-		$this->assertInstanceOf($providerClassName, $detectedProvider);
-		$this->assertSame($extensionKey, $detectedProvider->getExtensionKey($record));
-		$this->assertSame($absoluteTemplatePathAndFilename, $detectedProvider->getTemplatePathAndFilename($record));
-		$this->assertSame(PathUtility::translatePath($paths), $detectedProvider->getTemplatePaths($record));
+		$this->assertNull($result);
 	}
 
 	/**
-	 * @disabledtest
+	 * @test
 	 */
 	public function canRegisterStandaloneTemplateForTable() {
 		$service = $this->createFluxServiceInstance();
 		$variables = array('test' => 'test');
-		$paths = array('templateRootPath' => 'EXT:flux/Resources/Private/Templates');
+		$paths = array('templateRootPaths' => array('EXT:flux/Resources/Private/Templates'));
 		$table = 'fake';
 		$fieldName = NULL;
 		$providerClassName = 'FluidTYPO3\Flux\Provider\ProviderInterface';
@@ -163,12 +155,9 @@ class CoreTest extends AbstractTestCase {
 		$record = Records::$contentRecordWithoutParentAndWithoutChildren;
 		$absoluteTemplatePathAndFilename = GeneralUtility::getFileAbsFileName($relativeTemplatePathAndFilename);
 		$configurationSectionName = 'Configuration';
-		Core::registerFluidFlexFormTable($table, $fieldName, $relativeTemplatePathAndFilename,
+		$result = Core::registerFluidFlexFormTable($table, $fieldName, $relativeTemplatePathAndFilename,
 			$variables, $configurationSectionName, $paths);
-		$detectedProvider = $service->resolvePrimaryConfigurationProvider($table, $fieldName, $record);
-		$this->assertInstanceOf($providerClassName, $detectedProvider);
-		$this->assertSame($absoluteTemplatePathAndFilename, $detectedProvider->getTemplatePathAndFilename($record));
-		$this->assertSame(PathUtility::translatePath($paths), $detectedProvider->getTemplatePaths($record));
+		$this->assertNull($result);
 	}
 
 	/**
@@ -255,6 +244,28 @@ class CoreTest extends AbstractTestCase {
 		$this->assertArrayHasKey($fakePackage, Core::getRegisteredPackagesForAutoForms());
 		Core::unregisterFluxDomainFormPackage($fakePackage);
 		$this->assertArrayNotHasKey($fakePackage, Core::getRegisteredPackagesForAutoForms());
+	}
+
+	/**
+	 * @test
+	 */
+	public function registerFormForModelObjectClassNameSetsExtensionNameFromExtensionKeyGlobal() {
+		$GLOBALS['_EXTKEY'] = 'test';
+		$form = $this->getMock('FluidTYPO3\\Flux\\Form', array('setExtensionName'));
+		$form->expects($this->once())->method('setExtensionName')->with('Test');
+		Core::registerFormForModelObjectClassName('FooBar', $form);
+		unset($GLOBALS['_EXTKEY']);
+	}
+
+	/**
+	 * @test
+	 */
+	public function registerFormForTableSetsExtensionNameFromExtensionKeyGlobal() {
+		$GLOBALS['_EXTKEY'] = 'test';
+		$form = $this->getMock('FluidTYPO3\\Flux\\Form', array('setExtensionName'));
+		$form->expects($this->once())->method('setExtensionName')->with('Test');
+		Core::registerFormForTable('foobar', $form);
+		unset($GLOBALS['_EXTKEY']);
 	}
 
 }

--- a/Tests/Unit/Form/Field/AbstractFieldTest.php
+++ b/Tests/Unit/Form/Field/AbstractFieldTest.php
@@ -165,4 +165,14 @@ abstract class AbstractFieldTest extends AbstractFormTest {
 		$this->assertContains('parent.child', $output);
 	}
 
+	/**
+	 * @test
+	 */
+	public function canBuildWithClearableFlag() {
+		$instance = $this->createInstance();
+		$instance->setClearable(TRUE);
+		$result = $this->performTestBuild($instance);
+		$this->assertNotEmpty($result['TCEforms']['config']['wizards']);
+	}
+
 }

--- a/Tests/Unit/Form/Field/ControllerActionsTest.php
+++ b/Tests/Unit/Form/Field/ControllerActionsTest.php
@@ -346,4 +346,19 @@ class ControllerActionsTest extends AbstractFieldTest {
 		$this->assertStringStartsWith('LLL:EXT:flux/Resources/Private/Language/locallang.xlf:flux', $label);
 	}
 
+	/**
+	 * @test
+	 */
+	public function getActionsForExtensionNameAndPluginNameReturnsExpectedArray() {
+		$instance = $this->createInstance();
+		$instance->setControllerExtensionName('Extension');
+		$instance->setPluginName('Plugin');
+		$actions = array('Controller' => array('actions' => array('action1', 'action2')));
+		$expected = array('Controller' => array('action1', 'action2'));
+		$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['extbase']['extensions']['Extension']['plugins']['Plugin']['controllers'] = $actions;
+		$result = $this->callInaccessibleMethod($instance, 'getActionsForExtensionNameAndPluginName');
+		$this->assertEquals($expected, $result);
+		unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['extbase']['extensions']);
+	}
+
 }

--- a/Tests/Unit/Form/Field/TextTest.php
+++ b/Tests/Unit/Form/Field/TextTest.php
@@ -59,11 +59,23 @@ class TextTest extends InputTest {
 	/**
 	 * @test
 	 */
-	public function canBuildConfigurationWithEnableWithTextWithoutDefaultExtras() {
+	public function canBuildConfigurationWithoutDefaultExtrasWithEnableRichText() {
 		/** @var Text $instance */
 		$instance = $this->createInstance();
 		$instance->setDefaultExtras(NULL)->setEnableRichText(TRUE);
-		$this->performTestBuild($instance);
+		$result = $this->performTestBuild($instance);
+		$this->assertArrayHasKey('defaultExtras', $result['TCEforms']['config']);
+	}
+
+	/**
+	 * @test
+	 */
+	public function canBuildConfigurationWithDefaultExtras() {
+		/** @var Text $instance */
+		$instance = $this->createInstance();
+		$instance->setDefaultExtras('richtext[*]');
+		$result = $this->performTestBuild($instance);
+		$this->assertNotEmpty($result['TCEforms']['defaultExtras']);
 	}
 
 }

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -133,6 +133,7 @@ abstract class AbstractProviderTest extends AbstractTestCase {
 	 */
 	public function canGetForm() {
 		$provider = $this->getConfigurationProviderInstance();
+		$provider->setTemplatePathAndFilename($this->getAbsoluteFixtureTemplatePathAndFilename(self::FIXTURE_TEMPLATE_PREVIEW));
 		$record = $this->getBasicRecord();
 		$form = $provider->getForm($record);
 		if ($form) {

--- a/Tests/Unit/Provider/ContentProviderTest.php
+++ b/Tests/Unit/Provider/ContentProviderTest.php
@@ -214,4 +214,30 @@ class ContentProviderTest extends AbstractProviderTest {
 		);
 	}
 
+	/**
+	 * @test
+	 * @dataProvider getMoveDataTestvalues
+	 * @param mixed $postData
+	 * @param string|NULL $expected
+	 */
+	public function getMoveDataReturnsExpectedValues($postData, $expected) {
+		$instance = $this->getMock($this->createInstanceClassName(), array('getRawPostData'));
+		$instance->expects($this->once())->method('getRawPostData')->willReturn($postData);
+		$result = $this->callInaccessibleMethod($instance, 'getMoveData');
+		$this->assertEquals($expected, $result);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getMoveDataTestvalues() {
+		return array(
+			array(NULL, NULL),
+			array('{}', NULL),
+			array('{"method": "test"}', NULL),
+			array('{"method": "test", "data": []}', NULL),
+			array('{"method": "moveContentElement", "data": "test"}', 'test'),
+		);
+	}
+
 }

--- a/Tests/Unit/View/ExposedTemplateViewTest.php
+++ b/Tests/Unit/View/ExposedTemplateViewTest.php
@@ -102,8 +102,9 @@ class ExposedTemplateViewTest extends AbstractTestCase {
 		$templatePathAndFilename = $this->getAbsoluteFixtureTemplatePathAndFilename(self::FIXTURE_TEMPLATE_ABSOLUTELYMINIMAL);
 		$view = $this->getPreparedViewWithTemplateFile($templatePathAndFilename);
 		$view->render();
-		$view->getForm();
-		$view->getForm();
+		$form1 = $view->getForm();
+		$form2 = $view->getForm();
+		$this->assertSame($form1, $form2);
 	}
 
 	/**
@@ -136,7 +137,8 @@ class ExposedTemplateViewTest extends AbstractTestCase {
 	public function canGetStoredVariableWithoutConfigurationSectionName() {
 		$templatePathAndFilename = $this->getAbsoluteFixtureTemplatePathAndFilename(self::FIXTURE_TEMPLATE_ABSOLUTELYMINIMAL);
 		$view = $this->getPreparedViewWithTemplateFile($templatePathAndFilename);
-		$this->callInaccessibleMethod($view, 'getStoredVariable', 'FluidTYPO3\Flux\ViewHelpers\FormViewHelper', 'storage');
+		$result = $this->callInaccessibleMethod($view, 'getStoredVariable', 'FluidTYPO3\Flux\ViewHelpers\FormViewHelper', 'storage');
+		$this->assertEmpty($result);
 	}
 
 	/**
@@ -172,28 +174,15 @@ class ExposedTemplateViewTest extends AbstractTestCase {
 	}
 
 	/**
-	 * @test
-	 */
-	public function canSetAndThenGetTemplateSource() {
-		$service = $this->createFluxServiceInstance();
-		$viewContext = new ViewContext(NULL, 'Flux', 'API');
-		$view = $service->getPreparedExposedTemplateView($viewContext);
-		$view->setTemplateSource('dummy-source');
-		$this->assertEquals('dummy-source', $this->callInaccessibleMethod($view, 'getTemplateSource'));
-	}
-
-	/**
 	 * @param $templatePathAndFilename
 	 * @return ExposedTemplateView
 	 */
 	protected function getPreparedViewWithTemplateFile($templatePathAndFilename) {
 		$templatePaths = $this->getFixtureTemplatePaths();
-		$this->assertFileExists($templatePathAndFilename);
 		$service = $this->createFluxServiceInstance();
-		$viewContext = new ViewContext(NULL, 'Flux', 'API');
+		$viewContext = new ViewContext($templatePathAndFilename, 'Flux', 'API');
 		$viewContext->setTemplatePaths(new TemplatePaths($templatePaths));
 		$view = $service->getPreparedExposedTemplateView($viewContext);
-		$view->setTemplatePathAndFilename($templatePathAndFilename);
 		return $view;
 	}
 

--- a/Tests/Unit/View/PreviewViewTest.php
+++ b/Tests/Unit/View/PreviewViewTest.php
@@ -12,6 +12,7 @@ use FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\Tests\Fixtures\Data\Records;
 use FluidTYPO3\Flux\Tests\Unit\AbstractTestCase;
 use FluidTYPO3\Flux\View\PreviewView;
+use TYPO3\CMS\Backend\View\PageLayoutView;
 
 /**
  * @package Flux
@@ -39,12 +40,26 @@ class PreviewViewTest extends AbstractTestCase {
 				'columns' => array(
 					'CType' => array(
 						'config' => array(
-							'items' => array()
+							'items' => array(
+								'foo'
+							)
 						)
 					)
 				)
 			)
 		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function returnsDefaultsWithoutForm() {
+		$instance = $this->createInstance();
+		$result = $this->callInaccessibleMethod($instance, 'getPreviewOptions');
+		$this->assertEquals(array(
+			PreviewView::OPTION_MODE => PreviewView::MODE_APPEND,
+			PreviewView::OPTION_TOGGLE => TRUE,
+		), $result);
 	}
 
 	/**
@@ -114,6 +129,22 @@ class PreviewViewTest extends AbstractTestCase {
 			array(array(PreviewView::OPTION_MODE => PreviewView::MODE_APPEND, PreviewView::OPTION_TOGGLE => FALSE), 'assertPreviewComesBeforeGrid'),
 			array(array(PreviewView::OPTION_MODE => PreviewView::MODE_PREPEND, PreviewView::OPTION_TOGGLE => TRUE), 'assertPreviewContainsToggle')
 		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function configurePageLayoutViewForLanguageModeSetsSpecialVariablesInLanguageMode() {
+		$languageService = $this->getMock('TYPO3\\CMS\\Lang\\LanguageService', array('getLL'));
+		$languageService->expects($this->once())->method('getLL');
+		$view = $this->getMock('TYPO3\\CMS\\Backend\\View\\PageLayoutView', array('initializeLanguages'));
+		$view->expects($this->once())->method('initializeLanguages');
+		$instance = $this->getMock($this->createInstanceClassName(), array('getPageModuleSettings', 'getLanguageService'));
+		$instance->expects($this->once())->method('getPageModuleSettings')->willReturn(array('function' => 2));
+		$instance->expects($this->once())->method('getLanguageService')->willReturn($languageService);
+		$result = $this->callInaccessibleMethod($instance, 'configurePageLayoutViewForLanguageMode', $view);
+		$this->assertSame($view, $result);
+		$this->assertEquals(1, $result->tt_contentConfig['languageMode']);
 	}
 
 }

--- a/Tests/Unit/ViewHelpers/Form/DataViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Form/DataViewHelperTest.php
@@ -193,9 +193,26 @@ class DataViewHelperTest extends AbstractViewHelperTestCase {
 		$providers = array();
 		$record = array();
 		$field = NULL;
-		ObjectAccess::setProperty($mock, 'configurationService', $configurationService, TRUE);
+		$mock->injectConfigurationService($configurationService);
 		$result = $this->callInaccessibleMethod($mock, 'readDataArrayFromProvidersOrUsingDefaultMethod', $providers, $record, $field);
 		$this->assertNull($result);
+	}
+
+	/**
+	 * @test
+	 */
+	public function readDataArrayFromProvidersOrUsingDefaultMethodUsesProvidersToReadData() {
+		$mock = $this->createInstance();
+		$provider1 = $this->getMock('FluidTYPO3\\Flux\\Provider\\Provider', array('getFlexFormValues'));
+		$provider1->expects($this->once())->method('getFlexFormValues')->willReturn(array('foo' => array('bar' => 'test')));
+		$provider2 = $this->getMock('FluidTYPO3\\Flux\\Provider\\Provider', array('getFlexFormValues'));
+		$provider2->expects($this->once())->method('getFlexFormValues')
+			->willReturn(array('foo' => array('bar' => 'test2', 'baz' => 'test'), 'bar' => 'test'));
+		$providers = array($provider1, $provider2);
+		$record = Records::$contentRecordIsParentAndHasChildren;
+		$field = 'pi_flexform';
+		$result = $this->callInaccessibleMethod($mock, 'readDataArrayFromProvidersOrUsingDefaultMethod', $providers, $record, $field);
+		$this->assertEquals(array('foo' => array('bar' => 'test2', 'baz' => 'test'), 'bar' => 'test'), $result);
 	}
 
 }


### PR DESCRIPTION
This change:

* Refactors Flux's View to use more of the core View's methods, which is now possible due to the recent TemplatePaths addition.
* Refactors Providers to no longer support template sources - only files are supported, which matches the core's View behavior. This prevents unnecessary file loading in cases where templates are already compiled.
* Implements the new TS-fetching wrapper methods on FluxService where applicable.
* Streamlines the use of RenderingContext/ControllerContext when creating Views through FluxService, to match core's behavior.
* Cleans up many classes for transparency and/or legibility, refactors some system operations to methods to allow mocking responses in tests.
* Adjusts CGL - fixes phpdoc inconsistencies, adds a bit of documentation.