### PR TITLE
[BUGFIX] Wrong sort order of  all RootPaths

### DIFF
--- a/Classes/View/TemplatePaths.php
+++ b/Classes/View/TemplatePaths.php
@@ -255,9 +255,6 @@ class TemplatePaths {
 		// sort and unique, ensuring that the keys used in TypoScript become
 		// the dictated order of paths. The lower the number, the lower the
 		// path's priority is.
-		krsort($templateRootPaths, SORT_NUMERIC);
-		krsort($layoutRootPaths, SORT_NUMERIC);
-		krsort($partialRootPaths, SORT_NUMERIC);
 		$templateRootPaths = array_values(array_unique($templateRootPaths));
 		$partialRootPaths = array_values(array_unique($partialRootPaths));
 		$layoutRootPaths = array_values(array_unique($layoutRootPaths));
@@ -353,12 +350,15 @@ class TemplatePaths {
 		}
 		// second recorded: the modern plural paths configurations
 		if (TRUE === isset($paths[self::CONFIG_TEMPLATEROOTPATHS])) {
+			ksort($paths[self::CONFIG_TEMPLATEROOTPATHS],SORT_NUMERIC);
 			$templateRootPaths = array_merge($templateRootPaths, array_values((array) $paths[self::CONFIG_TEMPLATEROOTPATHS]));
 		}
 		if (TRUE === isset($paths[self::CONFIG_LAYOUTROOTPATHS])) {
+			ksort($paths[self::CONFIG_LAYOUTROOTPATHS],SORT_NUMERIC);
 			$layoutRootPaths = array_merge($layoutRootPaths, array_values((array) $paths[self::CONFIG_LAYOUTROOTPATHS]));
 		}
 		if (TRUE === isset($paths[self::CONFIG_PARTIALROOTPATHS])) {
+			ksort($paths[self::CONFIG_PARTIALROOTPATHS],SORT_NUMERIC);
 			$partialRootPaths = array_merge($partialRootPaths, array_values((array) $paths[self::CONFIG_PARTIALROOTPATHS]));
 		}
 		$templateRootPaths = array_map(array($this, 'ensureSuffixedPath'), $templateRootPaths);


### PR DESCRIPTION
Here is the Problem
Wrong sort order when using more then one RootPath.

### Example
```typoscript
view {
  templateRootPaths {
    10 = EXT:a/Resources/Private/Templates/
    20 = EXT:b/Resources/Private/Templates/
  }
 ...
}
```

In the method `fillFromTypoScriptArray` 

Array templateRootPaths before krsort 
0 = EXT:a/Resources/Private/Templates/
1 = EXT:b/Resources/Private/Templates/

Array templateRootPaths after krsort 
1 = EXT:b/Resources/Private/Templates/
0 = EXT:a/Resources/Private/Templates/

Array templateRootPaths after `array_values(array_unique( ...))` 
0 = EXT:b/Resources/Private/Templates/
1 = EXT:a/Resources/Private/Templates/

Later in the method `resolveTemplateFileForControllerAndActionAndFormat` 
```php
foreach (array_reverse($this->templateRootPaths) as $templateRootPath) { ...}
````
with array_revers now the first used Path is
1 = EXT:a/Resources/Private/Templates/ 
Thats wrong!

In this pull request krsort is removed and a ksort is inserted in the method `extractPathArrays`
now the rootPath with the higher numeric key is used.

