### PR TITLE
[TASK] Get rid of deprecation log in TYPO3 7.1

### DIFF
--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -141,7 +141,7 @@ class GetViewHelper extends AbstractViewHelper {
 				'source' => $row['uid'],
 				'dontCheckPid' => 1
 			);
-			array_push($elements, $this->configurationManager->getContentObject()->RECORDS($conf));
+			array_push($elements, $this->configurationManager->getContentObject()->cObjGetSingle('RECORDS', $conf));
 		}
 		return $elements;
 	}


### PR DESCRIPTION
using of `cObjGetSingle('RECORDS', $conf)` instead of `RECORDS($conf)` which is deprecated in TYPO3 8.0.