### PR TITLE
[TASK] Remove duplicate code

### DIFF
--- a/Classes/Form/AbstractFormComponent.php
+++ b/Classes/Form/AbstractFormComponent.php
@@ -117,14 +117,7 @@ abstract class AbstractFormComponent implements FormInterface {
 	 * @return FieldInterface
 	 */
 	public function createField($type, $name, $label = NULL) {
-		/** @var FieldInterface $component */
-		$className = $this->createComponentClassName($type, 'FluidTYPO3\Flux\Form\Field');
-		$component = $this->getObjectManager()->get($className);
-		$component->setName($name);
-		$component->setLabel($label);
-		$component->setLocalLanguageFileRelativePath($this->getLocalLanguageFileRelativePath());
-		$component->setDisableLocalLanguageLabels($this->getDisableLocalLanguageLabels());
-		return $component;
+		return $this->createComponent('FluidTYPO3\Flux\Form\Field', $type, $name, $label);
 	}
 
 	/**
@@ -134,14 +127,7 @@ abstract class AbstractFormComponent implements FormInterface {
 	 * @return ContainerInterface
 	 */
 	public function createContainer($type, $name, $label = NULL) {
-		/** @var ContainerInterface $component */
-		$className = $this->createComponentClassName($type, 'FluidTYPO3\Flux\Form\Container');
-		$component = $this->getObjectManager()->get($className);
-		$component->setName($name);
-		$component->setLabel($label);
-		$component->setLocalLanguageFileRelativePath($this->getLocalLanguageFileRelativePath());
-		$component->setDisableLocalLanguageLabels($this->getDisableLocalLanguageLabels());
-		return $component;
+		return $this->createComponent('FluidTYPO3\Flux\Form\Container', $type, $name, $label);
 	}
 
 	/**
@@ -151,8 +137,19 @@ abstract class AbstractFormComponent implements FormInterface {
 	 * @return WizardInterface
 	 */
 	public function createWizard($type, $name, $label = NULL) {
-		/** @var WizardInterface $component */
-		$className = $this->createComponentClassName($type, 'FluidTYPO3\Flux\Form\Wizard');
+		return $this->createComponent('FluidTYPO3\Flux\Form\Wizard', $type, $name, $label);
+	}
+
+	/**
+	 * @param string $namespace
+	 * @param string $type
+	 * @param string $name
+	 * @param string|NULL $label
+	 * @return FormInterface
+	 */
+	public function createComponent($namespace, $type, $name, $label = NULL) {
+		/** @var FormInterface $component */
+		$className = $this->createComponentClassName($type, $namespace);
 		$component = $this->getObjectManager()->get($className);
 		$component->setName($name);
 		$component->setLabel($label);


### PR DESCRIPTION
`createField`, `createContainer` and `createWizard` use nearly the same code.
```php
  $className = $this->createComponentClassName($type, 'FluidTYPO3\Flux\Form\XXX');
  $component = $this->getObjectManager()->get($className);
  $component->setName($name);
  $component->setLabel($label);
  $component->setLocalLanguageFileRelativePath($this->getLocalLanguageFileRelativePath());
  $component->setDisableLocalLanguageLabels($this->getDisableLocalLanguageLabels());
  return $component;
```
The code has been moved to the new method `createComponent`
