### PR TITLE
[BUGFIX] Since TYPO3 CMS 6.2 the 'script' configuration is deprecated,  ...

### DIFF
--- a/Classes/Form/AbstractFormComponent.php
+++ b/Classes/Form/AbstractFormComponent.php
@@ -150,7 +150,9 @@ abstract class AbstractFormComponent implements FormInterface {
 		/** @var FormInterface $component */
 		$className = $this->createComponentClassName($type, $namespace);
 		$component = $this->getObjectManager()->get($className);
-		$component->setName($name);
+		if (NULL === $component->getName()) {
+			$component->setName($name);
+		}
 		$component->setLabel($label);
 		$component->setLocalLanguageFileRelativePath($this->getLocalLanguageFileRelativePath());
 		$component->setDisableLocalLanguageLabels($this->getDisableLocalLanguageLabels());

--- a/Classes/Form/AbstractWizard.php
+++ b/Classes/Form/AbstractWizard.php
@@ -37,9 +37,9 @@ abstract class AbstractWizard extends AbstractFormComponent implements WizardInt
 	protected $icon;
 
 	/**
-	 * @var string
+	 * @var array
 	 */
-	protected $script;
+	protected $module;
 
 	/**
 	 * @return array
@@ -49,8 +49,8 @@ abstract class AbstractWizard extends AbstractFormComponent implements WizardInt
 			'type' => $this->type,
 			'title' => $this->getLabel(),
 			'icon' => $this->icon,
-			'script' => $this->script,
 			'hideParent' => intval($this->getHideParent()),
+			'module' => $this->module
 		);
 		$configuration = $this->buildConfiguration();
 		$structure = array_merge($structure, $configuration);

--- a/Classes/Form/Wizard/Add.php
+++ b/Classes/Form/Wizard/Add.php
@@ -32,9 +32,11 @@ class Add extends AbstractWizard {
 	protected $icon = 'add.gif';
 
 	/**
-	 * @var string
+	 * @var array
 	 */
-	protected $script = 'wizard_add.php';
+	protected $module = array(
+		'name' => 'wizard_add'
+	);
 
 	/**
 	 * @var string
@@ -56,9 +58,11 @@ class Add extends AbstractWizard {
 	 */
 	public function buildConfiguration() {
 		$configuration = array(
-			'table' => $this->getTable(),
-			'pid' => $this->getStoragePageUid(),
-			'setValue' => intval($this->getSetValue())
+			'params' => array(
+				'table'=> $this->getTable(),
+				'pid' => $this->getStoragePageUid(),
+				'setValue' => intval($this->getSetValue())
+			)
 		);
 		return $configuration;
 	}

--- a/Classes/Form/Wizard/ColorPicker.php
+++ b/Classes/Form/Wizard/ColorPicker.php
@@ -32,9 +32,11 @@ class ColorPicker extends AbstractWizard {
 	protected $icon = 'EXT:flux/Resources/Public/Icons/ColorWheel.png';
 
 	/**
-	 * @var string
+	 * @var array
 	 */
-	protected $script = 'wizard_colorpicker.php';
+	protected $module = array(
+		'name' => 'wizard_colorpicker',
+	);
 
 	/**
 	 * @var string
@@ -58,7 +60,6 @@ class ColorPicker extends AbstractWizard {
 		$configuration = array(
 			'type' => 'colorbox',
 			'title' => $this->getLabel(),
-			'script' => $this->script,
 			'hideParent' => intval($this->getHideParent()),
 			'dim' => $this->getDimensions(),
 			'exampleImg' => $this->getIcon(),

--- a/Classes/Form/Wizard/Edit.php
+++ b/Classes/Form/Wizard/Edit.php
@@ -32,9 +32,11 @@ class Edit extends AbstractWizard {
 	protected $icon = 'edit2.gif';
 
 	/**
-	 * @var string
+	 * @var array
 	 */
-	protected $script = 'wizard_edit.php';
+	protected $module = array(
+		'name' => 'wizard_edit'
+	);
 
 	/**
 	 * @var boolean
@@ -59,7 +61,6 @@ class Edit extends AbstractWizard {
 			'type' => 'popup',
 			'title' => $this->getLabel(),
 			'icon' => $this->icon,
-			'script' => $this->script,
 			'popup_onlyOpenIfSelected' => intval($this->getOpenOnlyIfSelected()),
 			'JSopenParams' => 'height=' . $this->getHeight() . ',width=' . $this->getWidth() . ',status=0,menubar=0,scrollbars=1'
 		);

--- a/Classes/Form/Wizard/Link.php
+++ b/Classes/Form/Wizard/Link.php
@@ -35,11 +35,6 @@ class Link extends AbstractWizard {
 	/**
 	 * @var string
 	 */
-	protected $script = 'wizard_add.php';
-
-	/**
-	 * @var string
-	 */
 	protected $activeTab = 'file';
 
 	/**
@@ -72,14 +67,21 @@ class Link extends AbstractWizard {
 	 */
 	public function buildConfiguration() {
 		$structure = array(
-			'script' => 'browse_links.php?mode=wizard&act=' . $this->getActiveTab(),
 			'JSopenParams' => 'height=' . $this->getHeight() . ',width=' . $this->getWidth() . ',status=0,menubar=0,scrollbars=1',
 			'params' => array(
 				'blindLinkOptions' => implode(',', $this->getBlindLinkOptions()),
 				'blindLinkFields' => implode(',', $this->getBlindLinkFields()),
-				'allowedExtensions' => implode(',', $this->getAllowedExtensions()),
+				'allowedExtensions' => implode(',', $this->getAllowedExtensions())
+			),
+			'module' => array(
+				'name' => 'wizard_element_browser',
+				'urlParameters' => array(
+					'mode' => 'wizard',
+					'act' => $this->getActiveTab()
+				)
 			)
 		);
+
 		return $structure;
 	}
 

--- a/Classes/Form/Wizard/ListWizard.php
+++ b/Classes/Form/Wizard/ListWizard.php
@@ -32,9 +32,11 @@ class ListWizard extends AbstractWizard {
 	protected $icon = 'list.gif';
 
 	/**
-	 * @var string
+	 * @var array
 	 */
-	protected $script = 'wizard_list.php';
+	protected $module = array(
+		'name' => 'wizard_list'
+	);
 
 	/**
 	 * @var string

--- a/Classes/Form/Wizard/Select.php
+++ b/Classes/Form/Wizard/Select.php
@@ -34,11 +34,6 @@ class Select extends AbstractWizard {
 	/**
 	 * @var string
 	 */
-	protected $script = 'wizard_list.php';
-
-	/**
-	 * @var string
-	 */
 	protected $mode = 'substitution';
 
 	/**

--- a/Classes/Form/Wizard/Slider.php
+++ b/Classes/Form/Wizard/Slider.php
@@ -32,9 +32,9 @@ class Slider extends AbstractWizard {
 	protected $icon = NULL;
 
 	/**
-	 * @var string
+	 * @var array
 	 */
-	protected $script = NULL;
+	protected $module = NULL;
 
 	/**
 	 * @var integer

--- a/Classes/Form/Wizard/Suggest.php
+++ b/Classes/Form/Wizard/Suggest.php
@@ -33,9 +33,9 @@ class Suggest extends AbstractWizard {
 	protected $icon = NULL;
 
 	/**
-	 * @var string
+	 * @var array
 	 */
-	protected $script = NULL;
+	protected $module = NULL;
 
 	/**
 	 * @var string

--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -353,7 +353,7 @@ class FluxService implements SingletonInterface {
 	 */
 	public function getAllTypoScript() {
 		if (0 === count(self::$typoScript)) {
-			self::$typoScript = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+			self::$typoScript = (array) $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
 			self::$typoScript = GeneralUtility::removeDotsFromTS(self::$typoScript);
 		}
 		return self::$typoScript;

--- a/Classes/Service/WorkspacesAwareRecordService.php
+++ b/Classes/Service/WorkspacesAwareRecordService.php
@@ -88,8 +88,11 @@ class WorkspacesAwareRecordService extends RecordService implements SingletonInt
 	 * @return array|boolean
 	 */
 	protected function getWorkspaceVersionOfRecordOrRecordItself($table, $record) {
-		$copy = $record;
-		BackendUtility::workspaceOL($table, $copy);
+		$copy = FALSE;
+		if (NULL !== $GLOBALS['BE_USER']) {
+			$copy = $record;
+			BackendUtility::workspaceOL($table, $copy);
+		}
 		return $copy === FALSE ? $record : $copy;
 	}
 
@@ -98,7 +101,7 @@ class WorkspacesAwareRecordService extends RecordService implements SingletonInt
 	 * @return boolean
 	 */
 	protected function hasWorkspacesSupport($table) {
-		return BackendUtility::isTableWorkspaceEnabled($table);
+		return (NULL !== $GLOBALS['BE_USER'] && BackendUtility::isTableWorkspaceEnabled($table));
 	}
 
 }

--- a/Tests/Unit/Form/Field/AbstractFieldTest.php
+++ b/Tests/Unit/Form/Field/AbstractFieldTest.php
@@ -181,9 +181,9 @@ abstract class AbstractFieldTest extends AbstractFormTest {
 	public function modifyCreatesWizards() {
 		$form = Form::create();
 		$field = $form->createField('Input', 'testfield');
-		$this->assertFalse($field->has('test'));
-		$field->modify(array('wizards' => array('test' => array('type' => 'Add', 'name' => 'test', 'label' => 'Test'))));
-		$this->assertTrue($field->has('test'));
+		$this->assertFalse($field->has('add'));
+		$field->modify(array('wizards' => array('test' => array('type' => 'Add', 'name' => 'add', 'label' => 'Test'))));
+		$this->assertTrue($field->has('add'));
 	}
 
 	/**
@@ -192,8 +192,8 @@ abstract class AbstractFieldTest extends AbstractFormTest {
 	public function modifyModifiesWizards() {
 		$form = Form::create();
 		$field = $form->createField('Input', 'testfield');
-		$wizard = $field->createWizard('Add', 'test', 'Original label');
-		$field->modify(array('wizards' => array('test' => array('type' => 'Add', 'name' => 'test', 'label' => 'Test'))));
+		$wizard = $field->createWizard('Add', 'add', 'Original label');
+		$field->modify(array('wizards' => array('test' => array('type' => 'Add', 'name' => 'add', 'label' => 'Test'))));
 		$this->assertEquals('Test', $wizard->getLabel());
 	}
 

--- a/Tests/Unit/Service/WorkspacesAwareRecordServiceTest.php
+++ b/Tests/Unit/Service/WorkspacesAwareRecordServiceTest.php
@@ -32,9 +32,11 @@ class WorkspacesAwareRecordServiceTest extends RecordServiceTest {
 	 * @test
 	 */
 	public function getWorkspaceVersionOfRecordOrRecordItselfReturnsSelf() {
+		$GLOBALS['BE_USER'] = new \stdClass();
 		$instance = new WorkspacesAwareRecordService();
 		$result = $this->callInaccessibleMethod($instance, 'getWorkspaceVersionOfRecordOrRecordItself', 'void', array('uid' => 1));
 		$this->assertEquals(array('uid' => 1), $result);
+		unset($GLOBALS['BE_USER']);
 	}
 
 }


### PR DESCRIPTION
...use 'module' instead.

**Update: removed TYPO3_version check, its obsolete.**
**Sorry - Now also Updated ColorPicker, Select, Slider and Suggest, this was missing in the last pull request**
```createComponent``` in ```AbstractFormComponent``` overrides the defined name in the wizard classes to 'wizard', so only one wizard was displayed.
In the add wizard the 'params' definition was missing.
See also http://docs.typo3.org/typo3cms/TCAReference/6.2/AdditionalFeatures/WizardsConfiguration/