### PR TITLE
[BUGFIX] Do not group by uid

### DIFF
--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -101,7 +101,7 @@ class GetViewHelper extends AbstractViewHelper {
 		// Depending on the TYPO3 setting config.sys_language_overlay, the $record could be either one of the localized version or default version.
 		$conditions = "(tx_flux_parent = '" . $id . "' AND tx_flux_column = '" . $area . "' AND pid = '" . $record['pid'] . "')" .
 			$GLOBALS['TSFE']->cObj->enableFields('tt_content');
-		$rows = $this->recordService->get('tt_content', '*', $conditions, 'uid', $order, $offset . ',' . $limit);
+		$rows = $this->recordService->get('tt_content', '*', $conditions, '', $order, $offset . ',' . $limit);
 
 		$elements = FALSE === (boolean) $this->arguments['render'] ? $rows : $this->getRenderedRecords($rows);
 		if (TRUE === empty($this->arguments['as'])) {


### PR DESCRIPTION
Since uid is a unique field, it's not required to group by it.
The query fails on other DBMS as MySQL due to the grouping.