### PR TITLE
Fix extensionName override support

### DIFF
--- a/Classes/Form/AbstractFormComponent.php
+++ b/Classes/Form/AbstractFormComponent.php
@@ -63,7 +63,7 @@ abstract class AbstractFormComponent implements FormInterface {
 	/**
 	 * @var string
 	 */
-	protected $extensionName = 'FluidTYPO3.Flux';
+	protected $extensionName = '';
 
 	/**
 	 * @var ContainerInterface
@@ -261,12 +261,17 @@ abstract class AbstractFormComponent implements FormInterface {
 		}
 		$name = $this->getName();
 		$root = $this->getRoot();
+		$extensionName = $this->extensionName;
 		if (FALSE === $root instanceof Form) {
 			$id = 'form';
-			$extensionName = $this->extensionName;
 		} else {
 			$id = $root->getName();
-			$extensionName = $root->getExtensionName();
+			if (TRUE === empty($extensionName)) {
+				$extensionName = $root->getExtensionName();
+			}
+		}
+		if (TRUE === empty($extensionName)) {
+			return $name;
 		}
 		$extensionKey = ExtensionNamingUtility::getExtensionKey($extensionName);
 		if (FALSE === empty($label)) {

--- a/Classes/ViewHelpers/AbstractFormViewHelper.php
+++ b/Classes/ViewHelpers/AbstractFormViewHelper.php
@@ -35,10 +35,19 @@ abstract class AbstractFormViewHelper extends AbstractViewHelper {
 		$container = $this->getContainer();
 		$container->add($component);
 		// rendering child nodes with Form's last sheet as active container
-		$this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME, $extensionName);
 		$this->setContainer($component);
 		$this->renderChildren();
 		$this->setContainer($container);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function renderChildren() {
+		// Make sure the current extension name always propagates to child nodes
+		$this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME, $this->getExtensionName());
+
+		return parent::renderChildren();
 	}
 
 	/**


### PR DESCRIPTION
I'm a bit unsure about the AbstractFormComponent changes and their implications. I've removed the default extensionName setting as as far I could see it will get explictly set anyway and it simplifies the logic in resolveLocalLangValueOfLabel, but that assumption might be wrong.