### PR TITLE
Fix extensionName override support

### DIFF
--- a/Classes/Form/AbstractFormComponent.php
+++ b/Classes/Form/AbstractFormComponent.php
@@ -156,6 +156,7 @@ abstract class AbstractFormComponent implements FormInterface {
 		$component->setLabel($label);
 		$component->setLocalLanguageFileRelativePath($this->getLocalLanguageFileRelativePath());
 		$component->setDisableLocalLanguageLabels($this->getDisableLocalLanguageLabels());
+		$component->setExtensionName($this->getExtensionName());
 		return $component;
 	}
 

--- a/Classes/Form/AbstractFormComponent.php
+++ b/Classes/Form/AbstractFormComponent.php
@@ -261,12 +261,11 @@ abstract class AbstractFormComponent implements FormInterface {
 		}
 		$name = $this->getName();
 		$root = $this->getRoot();
+		$extensionName = $this->extensionName;
 		if (FALSE === $root instanceof Form) {
 			$id = 'form';
-			$extensionName = $this->extensionName;
 		} else {
 			$id = $root->getName();
-			$extensionName = $root->getExtensionName();
 		}
 		$extensionKey = ExtensionNamingUtility::getExtensionKey($extensionName);
 		if (FALSE === empty($label)) {

--- a/Classes/ViewHelpers/AbstractFormViewHelper.php
+++ b/Classes/ViewHelpers/AbstractFormViewHelper.php
@@ -35,10 +35,19 @@ abstract class AbstractFormViewHelper extends AbstractViewHelper {
 		$container = $this->getContainer();
 		$container->add($component);
 		// rendering child nodes with Form's last sheet as active container
-		$this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME, $extensionName);
 		$this->setContainer($component);
 		$this->renderChildren();
 		$this->setContainer($container);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function renderChildren() {
+		// Make sure the current extension name always propagates to child nodes
+		$this->viewHelperVariableContainer->addOrUpdate(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME, $this->getExtensionName());
+
+		return parent::renderChildren();
 	}
 
 	/**
@@ -51,7 +60,10 @@ abstract class AbstractFormViewHelper extends AbstractViewHelper {
 		if (TRUE === $this->viewHelperVariableContainer->exists(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME)) {
 			return $this->viewHelperVariableContainer->get(self::SCOPE, self::SCOPE_VARIABLE_EXTENSIONNAME);
 		}
-		return $this->controllerContext->getRequest()->getControllerExtensionName();
+		if (TRUE === isset($this->controllerContext)) {
+			return $this->controllerContext->getRequest()->getControllerExtensionName();
+		}
+		return 'FluidTYPO3.Flux';
 	}
 
 	/**

--- a/Tests/Unit/ViewHelpers/Field/CustomViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Field/CustomViewHelperTest.php
@@ -43,7 +43,8 @@ class CustomViewHelperTest extends AbstractFieldViewHelperTestCase {
 	 */
 	protected function executeViewHelperClosure($templateVariableContainerArguments = array()) {
 		$instance = $this->objectManager->get('FluidTYPO3\Flux\ViewHelpers\Field\CustomViewHelper');
-		$container = $this->objectManager->get('TYPO3\CMS\Fluid\Core\ViewHelper\TemplateVariableContainer');
+		$renderingContext = $this->objectManager->get('TYPO3\CMS\Fluid\Core\Rendering\RenderingContext');
+		$container = $renderingContext->getTemplateVariableContainer();
 		$arguments = array(
 			'name' => 'custom'
 		);
@@ -52,11 +53,8 @@ class CustomViewHelperTest extends AbstractFieldViewHelperTestCase {
 		}
 		$node = new ViewHelperNode($instance, $arguments);
 		$childNode = new TextNode('Hello world!');
-		$renderingContext = $this->getAccessibleMock('TYPO3\CMS\Fluid\Core\Rendering\RenderingContext');
-		ObjectAccess::setProperty($renderingContext, 'templateVariableContainer', $container);
 		$node->addChildNode($childNode);
-		ObjectAccess::setProperty($instance, 'templateVariableContainer', $container, TRUE);
-		ObjectAccess::setProperty($instance, 'renderingContext', $renderingContext, TRUE);
+		$instance->setRenderingContext($renderingContext);
 		$instance->setViewHelperNode($node);
 		/** @var \Closure $closure */
 		$closure = $this->callInaccessibleMethod($instance, 'buildClosure');


### PR DESCRIPTION
Follow-up for #809 

Tests run now, but $root->getExtensionName() is now completely gone. Is this a problem?