### PR TITLE
[BUGFIX] Make FAL working inside a section

### DIFF
--- a/Classes/Form/Field/Inline/Fal.php
+++ b/Classes/Form/Field/Inline/Fal.php
@@ -156,6 +156,7 @@ class Fal extends AbstractInlineFormField {
 	 */
 	public function buildConfiguration() {
 		$configuration = $this->prepareConfiguration('inline');
+		unset($configuration['foreign_field']);
 		$configuration['appearance']['createNewRelationLinkTitle'] = $this->getCreateNewRelationLinkTitle();
 		return $configuration;
 	}

--- a/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
+++ b/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
@@ -74,7 +74,8 @@ class FalViewHelper extends AbstractInlineFieldViewHelper {
 		$component = $this->getPreparedComponent('Inline/Fal');
 		if (FALSE === is_array($this->arguments['foreignMatchFields'])) {
 			$component->setForeignMatchFields(array(
-				'fieldname' => $this->arguments['name']
+				// @todo: Retrieve this dynamically
+				'fieldname' => 'pi_flexform'
 			));
 		}
 		$component->setForeignSelectorFieldTcaOverride(array(


### PR DESCRIPTION
Instead of creating a default FAL configuration using "foreign_field"
omit this field. This will result in a comma separated list of
sys_file_reference UIDs being stored in the flexform data field.