### PR TITLE
[BUGFIX] Fix wrong plugin type matching

### DIFF
--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -203,7 +203,7 @@ class AbstractProvider implements ProviderInterface {
 		$rowContainsPlugin = (FALSE === empty($row['CType']) && self::CONTENT_OBJECT_TYPE_LIST === $row['CType']);
 		$rowIsEmpty = (0 === count($row));
 		$matchesContentType = ((TRUE === empty($contentObjectType) && TRUE === empty($row['CType'])) || (FALSE === empty($row['CType']) && $row['CType'] === $contentObjectType));
-		$matchesPluginType = ((TRUE === empty($listType) && TRUE === empty($row['list_type'])) || (FALSE === empty($row['list_type']) && $row['list_type'] === $listType));
+		$matchesPluginType = ((FALSE === empty($row['list_type']) && $row['list_type'] === $listType));
 		$matchesTableName = ($providerTableName === $table || NULL === $table);
 		$matchesFieldName = ($providerFieldName === $field || NULL === $field);
 		$matchesExtensionKey = ($providerExtensionKey === $extensionKey || NULL === $extensionKey);


### PR DESCRIPTION
If a user inserts and saves a "General Plugin" as CE without specifying the list_type the
preview in Backend breaks (happens easily with the quick ce button from gridelements).
This is caused by a falsey matching the correct plugin type if it's empty. As the check for
plugin type is only needed if the row actually contains a plugin we can remove the case
of an empty list_type.