### PR TITLE
[BUGFIX] Remove empty data node from flexform XML

### DIFF
--- a/Classes/Utility/MiscellaneousUtility.php
+++ b/Classes/Utility/MiscellaneousUtility.php
@@ -146,6 +146,11 @@ class MiscellaneousUtility {
 				$sheetNode->parentNode->removeChild($sheetNode);
 			}
 		}
+		// Remove eventually empty data node
+		$dataNode = $dom->getElementsByTagName('data')->item(0);
+		if (0 === $dataNode->getElementsByTagName('sheet')->length) {
+			$dataNode->parentNode->removeChild($dataNode);
+		}
 		$xml = $dom->saveXML();
 		// hack-like pruning of empty-named node inserted when removing objects from a previously populated Section
 		$xml = str_replace('<field index=""></field>', '', $xml);


### PR DESCRIPTION
This patch fixes an error when saving an empty flexform as described in fluidcontent#256.