### PR TITLE
Fix for editing children elements in workspace

### DIFF
--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -331,6 +331,10 @@ CONTENT;
 		$disableMoveAndNewButtons = FALSE;
 		$langMode = $dblist->tt_contentConfig['languageMode'];
 		$dragDropEnabled = FALSE;
+		
+		// Necessary for edit button in workspace.
+		$dblist->tt_contentData['nextThree'][$row['uid']] = $row['uid'];
+		
 		$rendered = $dblist->tt_content_drawHeader($row, $space, $disableMoveAndNewButtons, $langMode, $dragDropEnabled);
 		$rendered .= '<div class="t3-page-ce-body-inner">' . $dblist->tt_content_drawItem($row) . '</div>';
 		$rendered .= $footerRenderMethod->invokeArgs($dblist, array($row));

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -331,10 +331,10 @@ CONTENT;
 		$disableMoveAndNewButtons = FALSE;
 		$langMode = $dblist->tt_contentConfig['languageMode'];
 		$dragDropEnabled = FALSE;
-		
+
 		// Necessary for edit button in workspace.
 		$dblist->tt_contentData['nextThree'][$row['uid']] = $row['uid'];
-		
+
 		$rendered = $dblist->tt_content_drawHeader($row, $space, $disableMoveAndNewButtons, $langMode, $dragDropEnabled);
 		$rendered .= '<div class="t3-page-ce-body-inner">' . $dblist->tt_content_drawItem($row) . '</div>';
 		$rendered .= $footerRenderMethod->invokeArgs($dblist, array($row));


### PR DESCRIPTION
If you are in workspace, child elements can not be edited by pressing on pencil icon. Permissions error will be thrown, becaus alt_doc.php does not receive id of edit record. This small commit fixes that, but it could propably be done more nicely. 