### PR TITLE
[TASK] Clean db field in case flexform is all empty

### DIFF
--- a/Classes/Utility/MiscellaneousUtility.php
+++ b/Classes/Utility/MiscellaneousUtility.php
@@ -96,7 +96,7 @@ class MiscellaneousUtility {
 	 *
 	 * @param string $xml
 	 * @param array $removals
-	 * @return string
+	 * @return NULL|string
 	 */
 	public static function cleanFlexFormXml($xml, array $removals = array()) {
 		$dom = new \DOMDocument();
@@ -149,10 +149,10 @@ class MiscellaneousUtility {
 				$sheetNode->parentNode->removeChild($sheetNode);
 			}
 		}
-		// Remove eventually empty data node
+		// Return NULL value in case remaining flexform XML is all empty
 		$dataNode = $dom->getElementsByTagName('data')->item(0);
 		if (0 === $dataNode->getElementsByTagName('sheet')->length) {
-			$dataNode->parentNode->removeChild($dataNode);
+			return NULL;
 		}
 		$xml = $dom->saveXML();
 		// hack-like pruning of empty-named node inserted when removing objects from a previously populated Section


### PR DESCRIPTION
This patch makes ``MiscellaneousUtility::cleanFlexFormXml()`` return ``NULL`` in case the resulting XML is all empty thus resetting the according db field to a clean state.