### PR TITLE
[BUGFIX] Change from 10 to 0 for templateRootPaths.0.xxxx

### DIFF
--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -287,9 +287,9 @@ class FluxService implements SingletonInterface {
 	protected function getDefaultViewConfigurationForExtensionKey($extensionKey) {
 		$extensionKey = ExtensionNamingUtility::getExtensionKey($extensionKey);
 		return array(
-			TemplatePaths::CONFIG_TEMPLATEROOTPATHS => array(10 => 'EXT:' . $extensionKey . '/Resources/Private/Templates/'),
-			TemplatePaths::CONFIG_PARTIALROOTPATHS => array(10 => 'EXT:' . $extensionKey . '/Resources/Private/Partials/'),
-			TemplatePaths::CONFIG_LAYOUTROOTPATHS => array(10 => 'EXT:' . $extensionKey . '/Resources/Private/Layouts/'),
+			TemplatePaths::CONFIG_TEMPLATEROOTPATHS => array(0 => 'EXT:' . $extensionKey . '/Resources/Private/Templates/'),
+			TemplatePaths::CONFIG_PARTIALROOTPATHS => array(0 => 'EXT:' . $extensionKey . '/Resources/Private/Partials/'),
+			TemplatePaths::CONFIG_LAYOUTROOTPATHS => array(0 => 'EXT:' . $extensionKey . '/Resources/Private/Layouts/'),
 		);
 	}
 


### PR DESCRIPTION
I recommend changing this to 0 as I noticed others doing with extensions like the news extension. This already cause me a lot of grief because I did not know that 10 was the starting number... see my issue here, https://github.com/FluidTYPO3/flux/issues/831.