### PR TITLE
Further restrict available content elements by list_type

### DIFF
--- a/Classes/Hooks/WizardItemsHookSubscriber.php
+++ b/Classes/Hooks/WizardItemsHookSubscriber.php
@@ -274,7 +274,8 @@ class WizardItemsHookSubscriber implements NewContentElementWizardHookInterface 
 		$whitelist = array_unique($whitelist);
 		if (0 < count($whitelist)) {
 			foreach ($items as $name => $item) {
-				if (FALSE !== strpos($name, '_') && FALSE === in_array($item['tt_content_defValues']['CType'], $whitelist)) {
+				if (FALSE !== strpos($name, '_') && FALSE === in_array($item['tt_content_defValues']['CType'], $whitelist) && FALSE 
+=== in_array($name, $whitelist)) {
 					unset($items[$name]);
 				}
 			}


### PR DESCRIPTION
I really suck at PHP so I most certainly won't understand why this is a bad idea, but I had to modify the WizardItemsHook slightly.

I really just copied the idea from here: https://github.com/FluidTYPO3/flux/issues/491

In this issue the idea was to further restrict available content elements in the wizard for fluidcontent-elements. This issue was closed because there is now official support for this feature in fluidcontent. However, it is still not possible to further restrict the available plugins by list_type. To do that I had to re-implent the code from https://github.com/FluidTYPO3/flux/issues/491 on line 277.

    if (FALSE !== strpos($name, '_') && FALSE === in_array($item['tt_content_defValues']['CType'], $whitelist) && FALSE === in_array($name, $whitelist)) {

I would be not the least bit surpirsed if there's a better way to this, however, I realy need this feature. I'd be glad to use the official feature upon release instead of my little hack.