### PR TITLE
[BUGFIX] Fix for icons in Preview for 6.2 LTS and master

### DIFF
--- a/Classes/Utility/MiscellaneousUtility.php
+++ b/Classes/Utility/MiscellaneousUtility.php
@@ -11,6 +11,7 @@ namespace FluidTYPO3\Flux\Utility;
 use FluidTYPO3\Flux\Form;
 use TYPO3\CMS\Backend\Utility\IconUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * MiscellaneousUtility Utility
@@ -41,19 +42,19 @@ class MiscellaneousUtility {
 	}
 
 	/**
-	* @param string $icon
-	* @return string
-	*/
+	 * @param string $icon
+	 * @return string
+	 */
 	public static function getIcon($icon) {
 		return IconUtility::getSpriteIcon($icon);
 	}
 
 	/**
-	* @param string $inner
-	* @param string $uri
-	* @param string $title
-	* @return string
-	*/
+	 * @param string $inner
+	 * @param string $uri
+	 * @param string $title
+	 * @return string
+	 */
 	public static function wrapLink($inner, $uri, $title) {
 		return '<a href="#" onclick="window.location.href=\'' . htmlspecialchars($uri) . '\'" title="' . $title . '">' . $inner . '</a>';
 	}
@@ -79,12 +80,12 @@ class MiscellaneousUtility {
 			$controllerName = array_pop($templatePathParts);
 			$allowedExtensions = implode(',', self::$allowedIconTypes);
 			$iconFolder = ExtensionManagementUtility::extPath($extensionKey, 'Resources/Public/Icons/' . $controllerName . '/');
-			$iconRelFolder = ExtensionManagementUtility::extRelPath($extensionKey) . 'Resources/Public/Icons/' . $controllerName . '/';
+			$iconAbsoluteUrl = '/' . str_replace(PATH_site, '', $iconFolder);
 			$iconPathAndName = $iconFolder . $templateName;
 			$iconMatchPattern = $iconPathAndName . '.{' . $allowedExtensions . '}';
 			$filesInFolder = (TRUE === is_dir($iconFolder) ? glob($iconMatchPattern, GLOB_BRACE) : array());
 			$iconFile = (TRUE === is_array($filesInFolder) && 0 < count($filesInFolder) ? reset($filesInFolder) : NULL);
-			$iconRelPathAndFilename = (FALSE === is_null($iconFile)) ? $iconRelFolder . str_replace($iconFolder, '', $iconFile) : NULL;
+			$iconRelPathAndFilename = (FALSE === is_null($iconFile)) ? $iconAbsoluteUrl . str_replace($iconFolder, '', $iconFile) : NULL;
 			return $iconRelPathAndFilename;
 		}
 		return NULL;


### PR DESCRIPTION
Closes: #853

As solution we are returning absolute urls instead of relative paths. I thought about another "if" but it is not possible since the issue only occurs in Preview and not in Edit.