### PR TITLE
[FEATURE] Conveniently take defaults when new record is created

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -66,5 +66,6 @@ $GLOBALS['TCA']['tt_content']['ctrl']['useColumnsForDefaultValues'] .= ',tx_flux
 );
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_content', ',--div--;LLL:EXT:flux/Resources/Private/Language/locallang.xlf:tt_content.tabs.relation,tx_flux_parent,tx_flux_column,tx_flux_children;LLL:EXT:flux/Resources/Private/Language/locallang.xlf:tt_content.tx_flux_children,,,');
 
+$GLOBALS['TCA']['tt_content']['ctrl']['useColumnsForDefaultValues'] .= ',tx_flux_column,tx_flux_parent';
 
 \FluidTYPO3\Flux\Core::registerConfigurationProvider('FluidTYPO3\Flux\Provider\ContentProvider');


### PR DESCRIPTION
 This patch introduces the `useColumnsForDefaultValues` setting in TCA
 for tt_content and will enable copying of the mentioned columns to newly created
 records.

 The effect should be that the new record will be a sibling in a possible
 parent container.

References #868