### PR TITLE
[TASK] Translate select options

### DIFF
--- a/Classes/Form/Field/Select.php
+++ b/Classes/Form/Field/Select.php
@@ -67,7 +67,11 @@ class Select extends AbstractMultiValueFormField {
 		} elseif (TRUE === is_string($this->items)) {
 			$itemNames = GeneralUtility::trimExplode(',', $this->items);
 			foreach ($itemNames as $itemName) {
-				array_push($items, array($itemName, $itemName));
+				$resolvedLabel = $this->resolveLocalLanguageValueOfLabel('', $this->name . '.option.' . $itemName);
+				if (0 === strpos($resolvedLabel, 'LLL:') ) {
+					$resolvedLabel = $itemName;
+				}
+				array_push($items, array($resolvedLabel, $itemName));
 			}
 		} elseif (TRUE === is_array($this->items) || TRUE === $this->items instanceof \Traversable) {
 			foreach ($this->items as $itemIndex => $itemValue) {


### PR DESCRIPTION
Finally resolve select options.
Example:
```html
<flux:field.select name="test" items="1,2,3,4" />
```

```xml
			<trans-unit id="flux.example.test.option.1" xml:space="preserve">
				<source>Option</source>
			</trans-unit>
			<trans-unit id="flux.example.test.option.2" xml:space="preserve">
				<source>Option 2</source>
			</trans-unit>
			<trans-unit id="flux.example.test.option.3" xml:space="preserve">
				<source>Option 3</source>
			</trans-unit>
```
Result
![builder8](https://cloud.githubusercontent.com/assets/1295633/9213520/bdbddcba-4093-11e5-838a-5cbbca4257a1.png)


This also allows to translate headlines in fluidcontent_core
Headline XY....
Normal Headline