### PR TITLE
[BUGFIX] Adapt to unannounced API change in TYPO3

### DIFF
--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -137,7 +137,9 @@ class ContentProvider extends AbstractProvider implements ProviderInterface {
 					$this->contentService->pasteAfter($command, $row, $parameters, $reference);
 				} else {
 					$moveData = $this->getMoveData();
-					$this->contentService->moveRecord($row, $relativeTo, $moveData, $reference);
+					if (NULL !== $moveData) {
+						$this->contentService->moveRecord($row, $relativeTo, $moveData, $reference);
+					}
 				}
 			}
 			self::trackMethodCallWithClassName(__CLASS__, __FUNCTION__, $id);

--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -86,9 +86,11 @@ class ContentService implements SingletonInterface {
 		$parentUid = NULL;
 		$relativeRecord = NULL;
 		$possibleColPos = NULL;
-		if (1 < substr_count($parameters[1], '-')) {
+		$nestedArguments = explode('-', $parameters[1]);
+		$numberOfNestedArguments = count($nestedArguments);
+		if (5 < $numberOfNestedArguments) {
 			// Parameters were passed in a hyphen-glued string, created by Flux and passed into command.
-			list ($pid, $subCommand, $relativeUid, $parentUid, $possibleArea, $possibleColPos) = explode('-', $parameters[1]);
+			list ($pid, $subCommand, $relativeUid, $parentUid, $possibleArea, $possibleColPos) = $nestedArguments;
 			$parentUid = (integer) $parentUid;
 			// Parent into same grid results in endless loop
 			if ('move' === $command && (integer) $id === $parentUid && (integer) $pid === (integer) $row['pid']) {
@@ -101,12 +103,16 @@ class ContentService implements SingletonInterface {
 				// overridden regardless.
 				$possibleColPos = self::COLPOS_FLUXCONTENT;
 			}
-		} else {
+		} elseif (5 === $numberOfNestedArguments) {
 			// Parameters are directly from TYPO3 and it almost certainly is a paste to page column.
-			list ($tablename, $pid, $relativeUid) = $parameters;
-			// Third parameter is not passed by every context. If not set and $pid is negative,
+			list (, $possibleColPos, , $relativeUid) = $nestedArguments;
+			// $relativeUid parameter is not passed by every context. If not set and $pid is negative,
 			// we must assume that the positive value of $pid is our relative target UID.
 			$relativeUid = (integer) (0 >= (integer) $pid) ? $pid : $relativeUid;
+		} elseif (2 === count($parameters) && is_numeric($parameters[1])) {
+			// The most basic form of pasting: using the clickmenu to "paste after" sends only
+			// two parameters and the second parameter is always numeric-only.
+			list ($tablename, $relativeUid) = $parameters;
 		}
 
 		// Creating the copy mapping array. Initial processing of all records being pasted,
@@ -209,10 +215,8 @@ class ContentService implements SingletonInterface {
 				$relativeUid = (integer) $relativeUid;
 				if ('colpos' === $prefix && 'page' === $prefix2) {
 					$row['colPos'] = $column;
-					if ('top' === $relativePosition && 0 < $relativeUid) {
-						$row['tx_flux_parent'] = $relativeUid;
-						$row['tx_flux_column'] = $area;
-					}
+					$row['tx_flux_parent'] = $relativeUid;
+					$row['tx_flux_column'] = $area;
 				}
 			} elseif (0 > (integer) $relativeTo) {
 				// inserting a new element after another element. Check column position of that element.

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -434,7 +434,7 @@ class PreviewView {
 		$relativeUid = TRUE === isset($relativeTo['uid']) ? $relativeTo['uid'] : 0;
 		$columnName = $column->getName();
 		$relativeTo = $row['pid'] . '-' . $command . '-' . $relativeUid . '-' .
-			$row['uid'] . (FALSE === empty($columnName) ? '-' . $columnName : '');
+			$row['uid'] . (FALSE === empty($columnName) ? '-' . $columnName : '') . '-' . ContentService::COLPOS_FLUXCONTENT;
 		return ClipBoardUtility::createIconWithUrl($relativeTo, $reference);
 	}
 

--- a/Tests/Unit/Provider/ContentProviderTest.php
+++ b/Tests/Unit/Provider/ContentProviderTest.php
@@ -101,8 +101,12 @@ class ContentProviderTest extends AbstractProviderTest {
 	 * @test
 	 */
 	public function postProcessCommandCallsExpectedMethodToMoveRecord() {
-		$mock = $this->getMock(str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4)), array('getCallbackCommand'));
+		$mock = $this->getMock(
+			str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4)),
+			array('getCallbackCommand', 'getMoveData')
+		);
 		$mock->expects($this->once())->method('getCallbackCommand')->will($this->returnValue(array('move' => 1)));
+		$mock->expects($this->once())->method('getMoveData')->willReturn(array());
 		$mockContentService = $this->getMock('FluidTYPO3\Flux\Service\ContentService', array('pasteAfter', 'moveRecord'));
 		$mockContentService->expects($this->once())->method('moveRecord');
 		ObjectAccess::setProperty($mock, 'contentService', $mockContentService, TRUE);


### PR DESCRIPTION
This change adapts our paste handling method to understand the changed format coming from TYPO3 since a 6.2.x change.

* Parameters dispatched by drag and drop are no longer predictable the same way
* Vital indicators in parameters are now gone ('top' position no longer sent)
* Parameter count is changed

Our code is now adapted to the new situation in 6.2.14, but the patch very likely breaks any earlier versions.

Close: #905
Close: https://github.com/FluidTYPO3/fluidcontent/issues/270