### PR TITLE
[TASK] Replace FlashMessage messaging with syslog

### DIFF
--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -451,11 +451,7 @@ class FluxService implements SingletonInterface {
 		$shouldExcludedFriendlySeverities = 2 == $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup']['debugMode'];
 		$isExcludedSeverity = (TRUE === $shouldExcludedFriendlySeverities && TRUE === in_array($severity, self::$friendlySeverities));
 		if (FALSE === $disabledDebugMode && FALSE === $alreadySent && FALSE === $isExcludedSeverity) {
-			$isAjaxCall = (boolean) 0 < GeneralUtility::_GET('ajaxCall');
-			$flashMessage = $this->createFlashMessage($message, $title, $severity);
-			$flashMessage->setStoreInSession($isAjaxCall);
-			$flashMessageQueue = new FlashMessageQueue('flux');
-			$flashMessageQueue->addMessage($flashMessage);
+			$this->logMessage($message, $severity);
 			$this->sentDebugMessages[$hash] = TRUE;
 		}
 	}
@@ -469,12 +465,12 @@ class FluxService implements SingletonInterface {
 
 	/**
 	 * @param string $message
-	 * @param string $title
 	 * @param integer $severity
-	 * @return FlashMessage
+	 * @return void
+	 * @codeCoverageIgnore
 	 */
-	protected function createFlashMessage($message, $title, $severity) {
-		return new FlashMessage($message, $title, $severity);
+	protected function logMessage($message, $severity) {
+		GeneralUtility::sysLog($message, 'flux', $severity);
 	}
 
 }

--- a/Tests/Unit/Service/FluxServiceTest.php
+++ b/Tests/Unit/Service/FluxServiceTest.php
@@ -296,20 +296,9 @@ class FluxServiceTest extends AbstractTestCase {
 	/**
 	 * @test
 	 */
-	public function createFlashMessageCreatesFlashMessage() {
-		$instance = $this->createInstance();
-		$result = $this->callInaccessibleMethod($instance, 'createFlashMessage', 'Message', 'Title', 2);
-		$this->assertAttributeEquals('Message', 'message', $result);
-		$this->assertAttributeEquals('Title', 'title', $result);
-		$this->assertAttributeEquals(2, 'severity', $result);
-	}
-
-	/**
-	 * @test
-	 */
 	public function messageIgnoresRepeatedMessages() {
-		$instance = $this->getMock('FluidTYPO3\\Flux\\Service\\FluxService', array('createFlashMessage'));
-		$instance->expects($this->once())->method('createFlashMessage')->willReturn(new FlashMessage('Test', 'Test', 2));
+		$instance = $this->getMock('FluidTYPO3\\Flux\\Service\\FluxService', array('logMessage'));
+		$instance->expects($this->once())->method('logMessage');
 		$instance->message('Test', 'Test', 2);
 		$instance->message('Test', 'Test', 2);
 	}


### PR DESCRIPTION
The information being sent is not intended for editor consumption anyway - and the FlashMessage implementation is not safe to use in all contexts (requires a backend user initialised). Replacing it with a plain syslog puts the messages in TYPO3's log instead.

Close: https://github.com/FluidTYPO3/fluidcontent/issues/276
Close: https://github.com/FluidTYPO3/fluidcontent/issues/264