### PR TITLE
[TASK] Drop custom paste icons

### DIFF
--- a/Classes/View/LegacyPreviewView.php
+++ b/Classes/View/LegacyPreviewView.php
@@ -77,7 +77,7 @@ class LegacyPreviewView extends PreviewView {
 			$column->getLabel(),
 			$target,
 			$id,
-            $this->drawNewIcon($row, $column) . $this->drawPasteIcon($row, $column) . $this->drawPasteIcon($row, $column, TRUE),
+            $this->drawNewIcon($row, $column),
 			$content
 		);
     }

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -339,9 +339,7 @@ class PreviewView {
 
 		return sprintf($this->templates['record'], $disabledClass, $record['_CSSCLASS'], $record['uid'], $record['uid'],
 			$element, $colPosFluxContent, $parentRow['pid'], $parentRow['uid'], $record['uid'],
-			$this->drawNewIcon($parentRow, $column, $record['uid']) .
-			$this->drawPasteIcon($parentRow, $column, FALSE, $record) .
-			$this->drawPasteIcon($parentRow, $column, TRUE, $record));
+			$this->drawNewIcon($parentRow, $column, $record['uid']));
 	}
 
 	/**
@@ -433,22 +431,6 @@ class PreviewView {
 			'&defVals[tt_content][tx_flux_column]=' . $columnName .
 			'&returnUrl=' . $returnUri;
 		return $uri;
-	}
-
-	/**
-	 * @param array $row
-	 * @param Column $column
-	 * @param boolean $reference
-	 * @param array $relativeTo
-	 * @return string
-	 */
-	protected function drawPasteIcon(array $row, Column $column, $reference = FALSE, array $relativeTo = array()) {
-		$command = TRUE === $reference ? 'reference' : 'paste';
-		$relativeUid = TRUE === isset($relativeTo['uid']) ? $relativeTo['uid'] : 0;
-		$columnName = $column->getName();
-		$relativeTo = $row['pid'] . '-' . $command . '-' . $relativeUid . '-' .
-			$row['uid'] . (FALSE === empty($columnName) ? '-' . $columnName : '') . '-' . ContentService::COLPOS_FLUXCONTENT;
-		return ClipBoardUtility::createIconWithUrl($relativeTo, $reference);
 	}
 
 	/**
@@ -681,7 +663,7 @@ class PreviewView {
 			$column->getLabel(),
 			$target,
 			$id,
-			$this->drawNewIcon($row, $column) . $this->drawPasteIcon($row, $column) . $this->drawPasteIcon($row, $column, TRUE),
+			$this->drawNewIcon($row, $column),
 			$content
 		);
 	}

--- a/Tests/Unit/View/LegacyPreviewViewTest.php
+++ b/Tests/Unit/View/LegacyPreviewViewTest.php
@@ -27,7 +27,6 @@ class LegacyPreviewViewTest extends AbstractTestCase {
 		$column->expects($this->once())->method('getLabel')->willReturn('foobar-label');
 		$subject = $this->getMock('FluidTYPO3\\Flux\\View\\LegacyPreviewView', array('drawNewIcon', 'drawPasteIcon'));
 		$subject->expects($this->once())->method('drawNewIcon');
-		$subject->expects($this->exactly(2))->method('drawPasteIcon');
 		$this->callInaccessibleMethod($subject, 'parseGridColumnTemplate', array(), $column, 1, NULL, 'f-target', 2, 'f-content');
 	}
 

--- a/Tests/Unit/View/PreviewViewTest.php
+++ b/Tests/Unit/View/PreviewViewTest.php
@@ -77,7 +77,6 @@ class PreviewViewTest extends AbstractTestCase {
 				'drawRecord',
 				'registerTargetContentAreaInSession',
 				'drawNewIcon',
-				'drawPasteIcon',
 				'getInitializedPageLayoutView'
 			)
 		);
@@ -85,7 +84,6 @@ class PreviewViewTest extends AbstractTestCase {
 		$instance->expects($this->exactly(2))->method('drawRecord');
 		$instance->expects($this->once())->method('getInitializedPageLayoutView')->willReturn(new PageLayoutView());
 		$instance->expects($this->once())->method('drawNewIcon');
-		$instance->expects($this->exactly(2))->method('drawPasteIcon');
 		$instance->expects($this->once())->method('registerTargetContentAreaInSession');
 		$result = $this->callInaccessibleMethod($instance, 'drawGridColumn', $record, $column);
 		$this->assertNotEmpty($result);
@@ -314,7 +312,6 @@ class PreviewViewTest extends AbstractTestCase {
 		$column->expects($this->once())->method('getLabel')->willReturn('foobar-label');
 		$subject = $this->getMock('FluidTYPO3\\Flux\\View\\PreviewView', array('drawNewIcon', 'drawPasteIcon'));
 		$subject->expects($this->once())->method('drawNewIcon');
-		$subject->expects($this->exactly(2))->method('drawPasteIcon');
 		$this->callInaccessibleMethod($subject, 'parseGridColumnTemplate', array(), $column, 1, NULL, 'f-target', 2, 'f-content');
 	}
 


### PR DESCRIPTION
Reasons are as follows:

* Paste icons require yet another custom format on the two supported versions.
* Paste icons currently broken on both versions.
* Paste icons require custom styling on each version.
* Paste icons have no style equivalent on 7.x
* 7.x in general has no paste icons (uses clickmenu)
* Expecting core solution (possibly not until core's container content feature is done).

Suggest dropping those icons now, as part of Flux 7.3 release.