### PR TITLE
[BUGFIX] Show only the preview if CType is equal to 'fluidcontent_con…

### DIFF
--- a/Classes/Backend/Preview.php
+++ b/Classes/Backend/Preview.php
@@ -86,23 +86,25 @@ class Preview implements PageLayoutViewDrawItemHookInterface {
 		} else {
 			$itemContent = '<a name="c' . $row['uid'] . '"></a>' . $itemContent;
 		}
-		$providers = $this->configurationService->resolveConfigurationProviders('tt_content', $fieldName, $row);
-		foreach ($providers as $provider) {
-			/** @var ProviderInterface $provider */
-			list ($previewHeader, $previewContent, $continueDrawing) = $provider->getPreview($row);
-			if (FALSE === empty($previewHeader)) {
-				$headerContent = $previewHeader . (FALSE === empty($headerContent) ? ': ' . $headerContent : '');
-				$drawItem = FALSE;
+		if ('fluidcontent_content' === $row['CType'] ) {
+			$providers = $this->configurationService->resolveConfigurationProviders('tt_content', $fieldName, $row);
+			foreach ($providers as $provider) {
+				/** @var ProviderInterface $provider */
+				list ($previewHeader, $previewContent, $continueDrawing) = $provider->getPreview($row);
+				if (FALSE === empty($previewHeader)) {
+					$headerContent = $previewHeader . (FALSE === empty($headerContent) ? ': ' . $headerContent : '');
+					$drawItem      = FALSE;
+				}
+				if (FALSE === empty($previewContent)) {
+					$itemContent .= $previewContent;
+					$drawItem = FALSE;
+				}
+				if (FALSE === $continueDrawing) {
+					break;
+				}
 			}
-			if (FALSE === empty($previewContent)) {
-				$itemContent .= $previewContent;
-				$drawItem = FALSE;
-			}
-			if (FALSE === $continueDrawing) {
-				break;
-			}
+			$this->attachAssets();
 		}
-		$this->attachAssets();
 		return NULL;
 	}
 

--- a/Tests/Unit/Backend/PreviewTest.php
+++ b/Tests/Unit/Backend/PreviewTest.php
@@ -87,6 +87,7 @@ class PreviewTest extends AbstractTestCase {
 		$header = 'test';
 		$item = 'test';
 		$record = Records::$contentRecordIsParentAndHasChildren;
+		$record['CType'] = 'fluidcontent_content';
 		$draw = TRUE;
 		$this->setup();
 		$instance->renderPreview($header, $item, $record, $draw);


### PR DESCRIPTION
…tent'

 Avoid rendering of the preview if the field 'tx_fed_fcefile' isn't empty, and also CType isn't equal to 'fluidcontent_content'.
 This happens, if you change the CType of an 'fluidcontent_content' element.