### PR TITLE
[FEATURE] Missing emptyOption argument for flux:field.select

### DIFF
--- a/Classes/ViewHelpers/Field/SelectViewHelper.php
+++ b/Classes/ViewHelpers/Field/SelectViewHelper.php
@@ -25,6 +25,7 @@ class SelectViewHelper extends AbstractMultiValueFieldViewHelper {
 	public function initializeArguments() {
 		parent::initializeArguments();
 		$this->registerArgument('items', 'mixed', 'Items for the selector; array / CSV / Traversable / Query supported', TRUE);
+		$this->registerArgument('emptyOption', 'mixed', 'If not-FALSE, adds one empty option/value pair to the generated selector box and tries to use this property\'s value (cast to string) as label.', FALSE, FALSE);
 	}
 
 	/**
@@ -34,6 +35,7 @@ class SelectViewHelper extends AbstractMultiValueFieldViewHelper {
 		/** @var Select $component */
 		$component = $this->getPreparedComponent('Select');
 		$component->setItems($this->arguments['items']);
+		$component->setEmptyOption($this->arguments['emptyOption']);
 		return $component;
 	}
 


### PR DESCRIPTION
Allows you to specify an "no value" element. e.g.  'please select...'
Requires the bugfix from pull request #924