### PR TITLE
[BUGFIX] Only show flux preview in page modul if CType of content ele…

### DIFF
--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -129,6 +129,9 @@ class PreviewView {
 	 * @return string
 	 */
 	public function getPreview(ProviderInterface $provider, array $row) {
+		if ($row['CType']!=='fluidcontent_content') {
+			return '';
+		}
 		$form = $provider->getForm($row);
 		$options = $this->getPreviewOptions($form);
 		$mode = $this->getOptionMode($options);

--- a/Tests/Fixtures/Data/Records.php
+++ b/Tests/Fixtures/Data/Records.php
@@ -21,6 +21,7 @@ class Records {
 	const UID_CONTENT_PARENT = 90000003;
 	const UID_CONTENT_CHILD = 90000004;
 	const UID_CONTENT_PARENTANDCHILDREN = 90000005;
+	const UID_CONTENT_TEXTELEMENT = 90000006;
 
 	const UID_TEMPLATE_ROOT = 91000001;
 
@@ -38,6 +39,7 @@ class Records {
 	 */
 	public static $contentRecordWithoutParentAndWithoutChildren = array(
 		'uid' => self::UID_CONTENT_NOPARENTNOCHILDREN,
+		'CType' => 'fluidcontent_content',
 		'header' => 'Has no parent',
 		'colPos' => 0,
 		'tx_flux_parent' => 0,
@@ -62,6 +64,7 @@ class Records {
 	 */
 	public static $contentRecordIsParentAndHasChildren = array(
 		'uid' => self::UID_CONTENT_PARENT,
+		'CType' => 'fluidcontent_content',
 		'header' => 'Is itself parent, has no parent',
 		'colPos' => 0,
 		'tx_flux_parent' => 0,
@@ -90,6 +93,20 @@ class Records {
 		'tx_flux_parent' => 0,
 		'tx_flux_column' => '',
 		'tx_flux_children' => 1
+	);
+
+	/**
+	 * @var array
+	 */
+	public static $contentRecordWithTextElement = array(
+		'uid' => self::UID_CONTENT_TEXTELEMENT,
+		'CType' => 'text',
+		'header' => 'Default text element but with tx_fed_fcefile set',
+		'colPos' => ContentService::COLPOS_FLUXCONTENT,
+		'tx_flux_parent' => 0,
+		'tx_flux_column' => '',
+		'tx_flux_children' => 0,
+		'tx_fed_fce_file' => 'dummy-not-empty'
 	);
 
 }

--- a/Tests/Unit/View/PreviewViewTest.php
+++ b/Tests/Unit/View/PreviewViewTest.php
@@ -318,4 +318,28 @@ class PreviewViewTest extends AbstractTestCase {
 		$this->callInaccessibleMethod($subject, 'parseGridColumnTemplate', array(), $column, 1, NULL, 'f-target', 2, 'f-content');
 	}
 
+	/**
+	 * @test
+	 */
+	public function testGetPreviewForNonFluxElements() {
+		$provider = $this->objectManager->get('FluidTYPO3\\Flux\\Provider\\Provider');
+		$form = Form::create(array('name' => 'test', 'options' => array('preview' => $options)));
+		$grid = Form\Container\Grid::create(array());
+		$grid->createContainer('Row', 'row')->createContainer('Column', 'column');
+		$provider->setGrid($grid);
+		$provider->setForm($form);
+		$provider->setTemplatePaths(array());
+		$provider->setTemplatePathAndFilename($this->getAbsoluteFixtureTemplatePathAndFilename(self::FIXTURE_TEMPLATE_PREVIEW));
+		$previewView = $this->getMock($this->createInstanceClassName(), array('registerTargetContentAreaInSession'));
+		$previewView->expects($this->any())->method('registerTargetContentAreaInSession');
+		$previewView->injectConfigurationService($this->objectManager->get('FluidTYPO3\\Flux\\Service\\FluxService'));
+		$previewView->injectConfigurationManager(
+			$this->objectManager->get('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager')
+		);
+		$previewView->injectWorkspacesAwareRecordService(
+			$this->objectManager->get('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService')
+		);
+		$result = $previewView->getPreview($provider, Records::$contentRecordWithTextElement);
+		$this->assertEmpty($result);
+	}
 }


### PR DESCRIPTION
…ment is fluidcontent_content

Avoids trouble with elements that have been flux elements and have been changed from editors to f.e. shortcuts. These shortcuts have been displayed with the flux grid before this bugfix