### PR TITLE
[BUGFIX] Fix for not showing hidden content elements in grids anymore

### DIFF
--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -549,6 +549,13 @@ class PreviewView {
 	protected function getInitializedPageLayoutView(array $row) {
 		$pageRecord = $this->workspacesAwareRecordService->getSingle('pages', '*', $row['pid']);
 		$moduleData = $GLOBALS['BE_USER']->getModuleData('web_layout', '');
+
+		// For all elements to be shown in draft workspaces & to also show hidden elements by default if user hasn't disabled the option
+		// analog behavior to the PageLayoutController at the end of menuConfig()
+		if ($this->getBackendUser()->workspace != 0 || FALSE === isset($this->moduleData['tt_content_showHidden']) || $this->moduleData['tt_content_showHidden'] !== '0') {
+			$moduleData['tt_content_showHidden'] = 1;
+		}
+
 		/** @var $dblist PageLayoutView */
 		$dblist = GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager')->get('TYPO3\CMS\Backend\View\PageLayoutView');
 		$dblist->backPath = $GLOBALS['BACK_PATH'];


### PR DESCRIPTION
TYPO3 seems to have changed the storage of "Show hidden content elements" recently, which causes fluidcontent to not get the flag to
show of hide hidden content elements inside grids, etc.
TYPO3 now defaults to showing hidden content elements if the flag is
not set. To adapt to this this commit adds the same behavior to default
to shoing hidden content elements. as soon as you switch the "Show hidden content elements" to off and on again it works, because then the flag
is present in the session.