### PR TITLE
[BUGFIX] Make PathUtility work as expected with arrays

### DIFF
--- a/Classes/Utility/PathUtility.php
+++ b/Classes/Utility/PathUtility.php
@@ -38,19 +38,33 @@ class PathUtility {
 	 * @return mixed
 	 */
 	public static function translatePath($path) {
-		if (is_array($path) == FALSE) {
-			$path = (0 === strpos($path, '/') ? $path : GeneralUtility::getFileAbsFileName($path));
+		if (is_string($path)) {
+			$path = GeneralUtility::isAbsPath($path) ? $path : GeneralUtility::getFileAbsFileName($path);
 			if (is_dir($path)) {
 				$path = realpath($path) . '/';
 			}
 			$path = GeneralUtility::fixWindowsFilePath($path);
-		} else {
-			foreach ($path as $key => $subPath) {
-				if (TRUE === in_array($key, self::$knownPathNames)) {
-					$path[$key] = self::translatePath($subPath);
+		} elseif (is_array($path)) {
+			$templatePaths = self::getTemplatePathFields($path);
+			foreach ($templatePaths as $field => $subpath) {
+				if (is_array($subpath)) {
+					$path[$field] = array_map(array(__CLASS__, __METHOD__), $subpath);
+				} else {
+					$path[$field] = self::translatePath($subpath);
 				}
 			}
 		}
 		return $path;
+	}
+
+	/**
+	 * Get fields from view configuration that are template paths
+	 *
+	 * @param array $viewConfiguration
+	 * @return array
+	 */
+	public static function getTemplatePathFields(array $viewConfiguration) {
+		$knownPathKeys = array_fill_keys(self::$knownPathNames, NULL);
+		return array_intersect_key($viewConfiguration, $knownPathKeys);
 	}
 }

--- a/Tests/Unit/Utility/PathUtilityTest.php
+++ b/Tests/Unit/Utility/PathUtilityTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace FluidTYPO3\Flux\Tests\Unit\Utility;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Flux\Tests\Unit\AbstractTestCase;
+use FluidTYPO3\Flux\Utility\PathUtility;
+
+/**
+ * @package Flux
+ */
+class PathUtilityTest extends AbstractTestCase {
+
+	/**
+	 * @test
+	 */
+	public function testGetTemplatePathFields() {
+		$viewConfiguration = array(
+			'templateRootPath' => 'EXT:foo/Resources/Private/Templates/',
+			'templateRootPaths' => array(
+				0 => 'EXT:foo/Resources/Private/Templates/'
+			),
+			'partialRootPaths' => array(
+				0 => 'EXT:foo/Resources/Private/Partials/'
+			),
+			'layoutRootPaths' => array(
+				0 => 'EXT:foo/Resources/Private/Layouts/'
+			)
+		);
+		$mixedViewConfiguration = $viewConfiguration + array('enabled' => TRUE);
+		$this->assertEquals($viewConfiguration, PathUtility::getTemplatePathFields($mixedViewConfiguration));
+	}
+
+}


### PR DESCRIPTION
- Drop unnecessary array key check
- Check for types explicitly
- Use GeneralUtility for checking absolute paths