### PR TITLE
Remove deprecated dependency "cms"

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'category' => 'misc',
 	'shy' => 0,
 	'version' => '7.2.3',
-	'dependencies' => 'cms',
+	'dependencies' => '',
 	'conflicts' => '',
 	'priority' => 'top',
 	'loadOrder' => '',
@@ -34,8 +34,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'CGLcompliance_note' => '',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '6.2.0-7.4.99',
-			'cms' => ''
+			'typo3' => '6.2.0-7.4.99'
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
The TYPO3 CMS sysext `cms` has been deprecated, and as such, extensions which define a dependency on `cms` may cause the dependency notice to be logged in the deprecation log:

> Extension "flux" defines a dependency on ext:cms, which has been removed. Please remove the dependency.

It is not a big deal, but unnecessary.