### PR TITLE
[BUGFIX] Don't call provider methods for command 'version'.

### DIFF
--- a/Classes/Backend/TceMain.php
+++ b/Classes/Backend/TceMain.php
@@ -97,9 +97,11 @@ class TceMain {
 	 * @return void
 	 */
 	public function processCmdmap_preProcess(&$command, $table, $id, &$relativeTo, &$reference) {
-		$record = array();
-		$arguments = array('command' => $command, 'id' => $id, 'row' => &$record, 'relativeTo' => &$relativeTo);
-		$this->executeConfigurationProviderMethod('preProcessCommand', $table, $id, $record, $arguments, $reference);
+		if ('version' !== $command) {
+			$record = array();
+			$arguments = array('command' => $command, 'id' => $id, 'row' => &$record, 'relativeTo' => &$relativeTo);
+			$this->executeConfigurationProviderMethod('preProcessCommand', $table, $id, $record, $arguments, $reference);
+		}
 	}
 
 	/**
@@ -111,9 +113,11 @@ class TceMain {
 	 * @return void
 	 */
 	public function processCmdmap_postProcess(&$command, $table, $id, &$relativeTo, &$reference) {
-		$record = array();
-		$arguments = array('command' => $command, 'id' => $id, 'row' => &$record, 'relativeTo' => &$relativeTo);
-		$this->executeConfigurationProviderMethod('postProcessCommand', $table, $id, $record, $arguments, $reference);
+		if ('version' !== $command) {
+			$record = array();
+			$arguments = array('command' => $command, 'id' => $id, 'row' => &$record, 'relativeTo' => &$relativeTo);
+			$this->executeConfigurationProviderMethod('postProcessCommand', $table, $id, $record, $arguments, $reference);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This is a partial fix for #961, but it needs improvement before, so don't merge it please.

The problem there is that provider methods are not always executed, because of the caching mechanism that tracks the method calls and limits them to 1 call/request. The problem is that this mechanism only tracks method calls based on these things:

 * method name
 * ID of the modified record
 * Class name of the provider.

But when using workspaces, multiple commands can be issued per request that create the same cache identifier. E.g. in the case described in #961 there are two commands issued:

 * One with `'version'` as command. The provider method of `FluidTYPO3\Flux\Provider\ContentProvider` does nothing for this one, except tracking the method call, in two places: `FluidTYPO3\Flux\Provider\ContentProvider->postProcessCommand`, and also in `FluidTYPO3\Flux\Backend\TceMain->executeConfigurationProviderMethod`.
 * One with `'move'` as command. The provider method should do something on this command, but because the method call has been tracked, nothing happens here.

The pull request prevents tracking of the method call, but this is probably the wrong solution. A proper solution would fix the tracking of method calls.

Any ideas on that? 