### PR TITLE
[BUGFIX] Call provider methods for different commands.

### DIFF
--- a/Classes/Backend/TceMain.php
+++ b/Classes/Backend/TceMain.php
@@ -99,7 +99,7 @@ class TceMain {
 	public function processCmdmap_preProcess(&$command, $table, $id, &$relativeTo, &$reference) {
 		$record = array();
 		$arguments = array('command' => $command, 'id' => $id, 'row' => &$record, 'relativeTo' => &$relativeTo);
-		$this->executeConfigurationProviderMethod('preProcessCommand', $table, $id, $record, $arguments, $reference);
+		$this->executeConfigurationProviderMethod('preProcessCommand', $table, $id, $command, $record, $arguments, $reference);
 	}
 
 	/**
@@ -113,7 +113,7 @@ class TceMain {
 	public function processCmdmap_postProcess(&$command, $table, $id, &$relativeTo, &$reference) {
 		$record = array();
 		$arguments = array('command' => $command, 'id' => $id, 'row' => &$record, 'relativeTo' => &$relativeTo);
-		$this->executeConfigurationProviderMethod('postProcessCommand', $table, $id, $record, $arguments, $reference);
+		$this->executeConfigurationProviderMethod('postProcessCommand', $table, $id, $command, $record, $arguments, $reference);
 	}
 
 	/**
@@ -126,7 +126,7 @@ class TceMain {
 	public function processDatamap_preProcessFieldArray(array &$incomingFieldArray, $table, $id, &$reference) {
 		$arguments = array('row' => &$incomingFieldArray, 'id' => $id);
 		$incomingFieldArray = $this->executeConfigurationProviderMethod(
-			'preProcessRecord', $table, $id, $incomingFieldArray, $arguments, $reference);
+			'preProcessRecord', $table, $id, '', $incomingFieldArray, $arguments, $reference);
 	}
 
 	/**
@@ -140,7 +140,7 @@ class TceMain {
 	public function processDatamap_postProcessFieldArray($status, $table, $id, &$fieldArray, &$reference) {
 		$arguments = array('status' => $status, 'id' => $id, 'row' => &$fieldArray);
 		$fieldArray = $this->executeConfigurationProviderMethod(
-			'postProcessRecord', $table, $id, $fieldArray, $arguments, $reference);
+			'postProcessRecord', $table, $id, '', $fieldArray, $arguments, $reference);
 	}
 
 	/**
@@ -157,7 +157,7 @@ class TceMain {
 		}
 		$arguments = array('status' => $status, 'id' => $id, 'row' => &$fieldArray);
 		$fieldArray = $this->executeConfigurationProviderMethod('postProcessDatabaseOperation',
-			$table, $id, $fieldArray, $arguments, $reference);
+			$table, $id, '', $fieldArray, $arguments, $reference);
 	}
 
 	/**
@@ -166,12 +166,13 @@ class TceMain {
 	 * @param string $methodName
 	 * @param string $table
 	 * @param mixed $id
+	 * @param string $command
 	 * @param array $record
 	 * @param array $arguments
 	 * @param DataHandler $reference
 	 * @return array
 	 */
-	protected function executeConfigurationProviderMethod($methodName, $table, $id, array $record, array $arguments, DataHandler $reference) {
+	protected function executeConfigurationProviderMethod($methodName, $table, $id, $command, array $record, array $arguments, DataHandler $reference) {
 		try {
 			$id = $this->resolveRecordUid($id, $reference);
 			$record = $this->ensureRecordDataIsLoaded($table, $id, $record);
@@ -179,9 +180,9 @@ class TceMain {
 			$arguments[] = &$reference;
 			$detectedProviders = $this->configurationService->resolveConfigurationProviders($table, NULL, $record);
 			foreach ($detectedProviders as $provider) {
-				if (TRUE === $provider->shouldCall($methodName, $id)) {
+				if (TRUE === $provider->shouldCall($methodName, $id, $command)) {
 					call_user_func_array(array($provider, $methodName), array_values($arguments));
-					$provider->trackMethodCall($methodName, $id);
+					$provider->trackMethodCall($methodName, $id, $command);
 				}
 			}
 		} catch (\RuntimeException $error) {

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -886,15 +886,16 @@ class AbstractProvider implements ProviderInterface {
 
 	/**
 	 * Use by TceMain to track method calls to providers for a certain $id.
-	 * Every provider should only be called once per method / $id.
+	 * Every provider should only be called once per method / $id / command.
 	 * When TceMain has called the provider it will call this method afterwards.
 	 *
 	 * @param string $methodName
 	 * @param mixed $id
+	 * @param string command
 	 * @return void
 	 */
-	public function trackMethodCall($methodName, $id) {
-		self::trackMethodCallWithClassName(get_called_class(), $methodName, $id);
+	public function trackMethodCall($methodName, $id, $command = '') {
+		self::trackMethodCallWithClassName(get_called_class(), $methodName, $id, $command);
 	}
 
 	/**
@@ -906,10 +907,11 @@ class AbstractProvider implements ProviderInterface {
 	 *
 	 * @param string $methodName
 	 * @param mixed $id
+	 * @param string $command
 	 * @return boolean
 	 */
-	public function shouldCall($methodName, $id) {
-		return self::shouldCallWithClassName(get_class($this), $methodName, $id);
+	public function shouldCall($methodName, $id, $command = '') {
+		return self::shouldCallWithClassName(get_class($this), $methodName, $id, $command);
 	}
 
 	/**
@@ -919,10 +921,11 @@ class AbstractProvider implements ProviderInterface {
 	 * @param string $className
 	 * @param string $methodName
 	 * @param mixed $id
+	 * @param string $command
 	 * @return void
 	 */
-	protected function trackMethodCallWithClassName($className, $methodName, $id) {
-		$cacheKey = $className . $methodName . $id;
+	protected function trackMethodCallWithClassName($className, $methodName, $id, $command = '') {
+		$cacheKey = $className . $methodName . $id . $command;
 		self::$trackedMethodCalls[$cacheKey] = TRUE;
 	}
 
@@ -933,10 +936,11 @@ class AbstractProvider implements ProviderInterface {
 	 * @param string $className
 	 * @param string $methodName
 	 * @param mixed $id
+	 * @param string $command
 	 * @return boolean
 	 */
-	protected function shouldCallWithClassName($className, $methodName, $id) {
-		$cacheKey = $className . $methodName . $id;
+	protected function shouldCallWithClassName($className, $methodName, $id, $command = '') {
+		$cacheKey = $className . $methodName . $id . $command;
 		return empty(self::$trackedMethodCalls[$cacheKey]);
 	}
 

--- a/Classes/Provider/ContentProvider.php
+++ b/Classes/Provider/ContentProvider.php
@@ -103,11 +103,11 @@ class ContentProvider extends AbstractProvider implements ProviderInterface {
 	 * @return void
 	 */
 	public function postProcessRecord($operation, $id, array &$row, DataHandler $reference, array $removals = array()) {
-		if (TRUE === self::shouldCallWithClassName(__CLASS__, __FUNCTION__, $id)) {
+		if (TRUE === self::shouldCallWithClassName(__CLASS__, __FUNCTION__, $id, $operation)) {
 			parent::postProcessRecord($operation, $id, $row, $reference, $removals);
 			$parameters = GeneralUtility::_GET();
 			$this->contentService->affectRecordByRequestParameters($id, $row, $parameters, $reference);
-			self::trackMethodCallWithClassName(__CLASS__, __FUNCTION__, $id);
+			self::trackMethodCallWithClassName(__CLASS__, __FUNCTION__, $id, $operation);
 		}
 	}
 
@@ -123,7 +123,7 @@ class ContentProvider extends AbstractProvider implements ProviderInterface {
 	 * @return void
 	 */
 	public function postProcessCommand($command, $id, array &$row, &$relativeTo, DataHandler $reference) {
-		if (TRUE === self::shouldCallWithClassName(__CLASS__, __FUNCTION__, $id)) {
+		if (TRUE === self::shouldCallWithClassName(__CLASS__, __FUNCTION__, $id, $command)) {
 			parent::postProcessCommand($command, $id, $row, $relativeTo, $reference);
 			$pasteCommands = array('copy', 'move');
 			if (TRUE === in_array($command, $pasteCommands)) {
@@ -140,7 +140,7 @@ class ContentProvider extends AbstractProvider implements ProviderInterface {
 			if ('localize' === $command) {
 				$this->contentService->fixPositionInLocalization($id, $relativeTo, $row, $reference);
 			}
-			self::trackMethodCallWithClassName(__CLASS__, __FUNCTION__, $id);
+			self::trackMethodCallWithClassName(__CLASS__, __FUNCTION__, $id, $command);
 		}
 	}
 

--- a/Classes/Provider/ProviderInterface.php
+++ b/Classes/Provider/ProviderInterface.php
@@ -21,16 +21,18 @@ interface ProviderInterface {
 
 	/**
 	 * Use by TceMain to track method calls to providers for a certain $id.
-	 * Every provider should only be called once per method / $id.
+	 * Every provider should only be called once per method / $id / command.
 	 * Before calling a provider, TceMain will call this method.
-	 * If the provider hasn't been called for that method / $id before, it is.
+	 * If the provider hasn't been called for that method / $id / command
+	 * before, it is.
 	 *
 	 *
 	 * @param string $methodName
 	 * @param mixed $id
+	 * @param string $command
 	 * @return boolean
 	 */
-	public function shouldCall($methodName, $id);
+	public function shouldCall($methodName, $id, $command = '');
 
 	/**
 	 * Use by TceMain to track method calls to providers for a certain $id.

--- a/Tests/Unit/Backend/TceMainTest.php
+++ b/Tests/Unit/Backend/TceMainTest.php
@@ -215,7 +215,7 @@ class TceMainTest extends AbstractTestCase {
 		$handler->substNEWwithIDs['NEW123'] = 123;
 		$mock->injectConfigurationService($configurationService);
 		$result = $this->callInaccessibleMethod($mock, 'executeConfigurationProviderMethod',
-			'method', 'tt_content', 'NEW123', $record, $parameters, $handler);
+			'method', 'tt_content', 'command', 'NEW123', $record, $parameters, $handler);
 		$this->assertEmpty($result);
 	}
 
@@ -236,7 +236,7 @@ class TceMainTest extends AbstractTestCase {
 		$configurationService = $this->getMock('FluidTYPO3\\Flux\\Service\\FluxService', array('resolveConfigurationProviders'));
 		$configurationService->expects($this->once())->method('resolveConfigurationProviders')->willReturn($providers);
 		$mock->injectConfigurationService($configurationService);
-		$result = $this->callInaccessibleMethod($mock, 'executeConfigurationProviderMethod', $command, 'void', 1, $row, $arguments, $caller);
+		$result = $this->callInaccessibleMethod($mock, 'executeConfigurationProviderMethod', $command, 'void', 1, 'command', $row, $arguments, $caller);
 		$this->assertEquals($row, $result);
 	}
 


### PR DESCRIPTION
Not only once for each method/id combination.

Partly resolves #961. Moving the first content element into a newly created container works now, but moving elements after this first element does still not work.