### PR TITLE
[BUGFIX] Separating templates on two PID-Rootlines

### DIFF
--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -19,6 +19,7 @@ use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
 use FluidTYPO3\Flux\View\ExposedTemplateView;
 use FluidTYPO3\Flux\View\TemplatePaths;
 use FluidTYPO3\Flux\View\ViewContext;
+use FluidTYPO3\Flux\Configuration\ConfigurationManager;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -339,11 +340,15 @@ class FluxService implements SingletonInterface {
 	 * @return array
 	 */
 	public function getAllTypoScript() {
-		if (0 === count(self::$typoScript)) {
-			self::$typoScript = (array) $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
-			self::$typoScript = GeneralUtility::removeDotsFromTS(self::$typoScript);
+		if (!$this->configurationManager instanceof ConfigurationManager) {
+			debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 		}
-		return self::$typoScript;
+		$pageId = $this->configurationManager->getCurrentPageId();
+		if (FALSE === isset(self::$typoScript[$pageId])) {
+			self::$typoScript[$pageId] = (array) $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+			self::$typoScript[$pageId] = GeneralUtility::removeDotsFromTS(self::$typoScript);
+		}
+		return (array) self::$typoScript[$pageId];
 	}
 
 	/**

--- a/Tests/Unit/AbstractTestCase.php
+++ b/Tests/Unit/AbstractTestCase.php
@@ -178,7 +178,7 @@ abstract class AbstractTestCase extends BaseTestCase {
 		/** @var FluxService $fluxService */
 		$fluxService = $this->getMock('FluidTYPO3\\Flux\\Service\\FluxService', $methods, array(), '', FALSE);
 		$fluxService->injectObjectManager($this->objectManager);
-		$configurationManager = $this->objectManager->get('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManagerInterface');
+		$configurationManager = $this->getMock('FluidTYPO3\Flux\Configuration\ConfigurationManager');
 		$fluxService->injectConfigurationManager($configurationManager);
 		return $fluxService;
 	}

--- a/Tests/Unit/Backend/PreviewTest.php
+++ b/Tests/Unit/Backend/PreviewTest.php
@@ -24,6 +24,9 @@ class PreviewTest extends AbstractTestCase {
 	 * Setup
 	 */
 	public function setUp() {
+		$configurationManager = $this->getMock('FluidTYPO3\Flux\Configuration\ConfigurationManager');
+		$fluxService = $this->objectManager->get('FluidTYPO3\Flux\Service\FluxService');
+		$fluxService->injectConfigurationManager($configurationManager);
 		$GLOBALS['TYPO3_DB'] = $this->getMock('TYPO3\\CMS\\Core\\Database\\DatabaseConnection', array('exec_SELECTgetRows'), array(), '', FALSE);
 		$GLOBALS['TYPO3_DB']->expects($this->any())->method('exec_SELECTgetRows')->willReturn(array());
 		$tempFiles = (array) glob(GeneralUtility::getFileAbsFileName('typo3temp/flux-preview-*.tmp'));

--- a/Tests/Unit/Backend/TceMainTest.php
+++ b/Tests/Unit/Backend/TceMainTest.php
@@ -25,6 +25,9 @@ class TceMainTest extends AbstractTestCase {
 	 * @return void
 	 */
 	public function setUp() {
+		$configurationManager = $this->getMock('FluidTYPO3\Flux\Configuration\ConfigurationManager');
+		$fluxService = $this->objectManager->get('FluidTYPO3\Flux\Service\FluxService');
+		$fluxService->injectConfigurationManager($configurationManager);
 		$GLOBALS['TYPO3_DB'] = $this->getMock('TYPO3\\CMS\\Core\\Database\\DatabaseConnection', array('exec_SELECTgetSingleRow'), array(), '', FALSE);
 		$GLOBALS['TYPO3_DB']->expects($this->any())->method('exec_SELECTgetRows')->willReturn(FALSE);
 		$GLOBALS['TCA'] = array(


### PR DESCRIPTION
This commit fixes a bug in the FluxService which caused problems with different typoscript on seperate pages in the backend. This happened, because the FluxService didn't take the pageId into account for caching the internal typoscript it uses.

fixes #978