### PR TITLE
[BUGFIX] Wrong converted csv item list.

### DIFF
--- a/Classes/Form/Field/Select.php
+++ b/Classes/Form/Field/Select.php
@@ -93,7 +93,9 @@ class Select extends AbstractMultiValueFormField {
 		} elseif (TRUE === is_string($this->items)) {
 			$itemNames = GeneralUtility::trimExplode(',', $this->items);
 			if (!$this->getTranslateCsvItems()) {
-				$items = array_combine($itemNames, $itemNames);
+				foreach ($itemNames as $itemName) {
+					array_push($items, array($itemName, $itemName));
+				}
 			} else {
 				foreach ($itemNames as $itemName) {
 					$resolvedLabel = $this->resolveLocalLanguageValueOfLabel('', $this->name . '.option.' . $itemName);


### PR DESCRIPTION
Since TYPO3 7.5 the items in a item list must be of type array.
Uncaught TYPO3 Exception #1439288036
An item in field settings.header.type of table tt_content is not an array as expected