### PR TITLE
[FEATURE] Allow any Provider to manipulate any TCA detail

### DIFF
--- a/Classes/Backend/FormEngine/ProviderProcessor.php
+++ b/Classes/Backend/FormEngine/ProviderProcessor.php
@@ -1,0 +1,40 @@
+<?php
+namespace FluidTYPO3\Flux\Backend\FormEngine;
+
+use FluidTYPO3\Flux\View\ViewContext;
+use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
+use FluidTYPO3\Flux\Provider\ProviderResolver;
+use FluidTYPO3\Flux\Provider\ProviderInterface;
+use FluidTYPO3\Flux\Service\FluxService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
+
+class ProviderProcessor implements FormDataProviderInterface {
+
+	/**
+	 * @param array $result
+	 * @return void
+	 */
+	public function addData(array $result) {
+		$providers = $this->getProviderResolver()->resolveConfigurationProviders($result['tableName'], NULL, $result['databaseRow']);
+		foreach ($providers as $provider) {
+			$result = $provider->processTableConfiguration($result['databaseRow'], $result);
+		}
+		return $result;
+	}
+
+	/**
+	 * @return ProviderResolver
+	 */
+	protected function getProviderResolver() {
+		return $this->getObjectManager()->get(ProviderResolver::class);
+	}
+
+	/**
+	 * @return ObjectManagerInterface
+	 */
+	protected function getObjectManager() {
+		return GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
+	}
+
+}

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -689,6 +689,20 @@ class AbstractProvider implements ProviderInterface {
 	}
 
 	/**
+	 * Processes the table configuration (TCA) for the table associated
+	 * with this Provider, as determined by the trigger() method. Gets
+	 * passed an instance of the record being edited/created along with
+	 * the current configuration array - and must return a complete copy
+	 * of the configuration array manipulated to the Provider's needs.
+	 *
+	 * @param array $row The record being edited/created
+	 * @return array The large FormEngine configuration array - see FormEngine documentation!
+	 */
+	public function processTableConfiguration(array $row, array $configuration) {
+		return $configuration;
+	}
+
+	/**
 	 * Perform various cleanup operations upon clearing cache
 	 *
 	 * @param array $command

--- a/Classes/Provider/ProviderInterface.php
+++ b/Classes/Provider/ProviderInterface.php
@@ -317,6 +317,18 @@ interface ProviderInterface {
 	public function postProcessCommand($command, $id, array &$row, &$relativeTo, DataHandler $reference);
 
 	/**
+	 * Processes the table configuration (TCA) for the table associated
+	 * with this Provider, as determined by the trigger() method. Gets
+	 * passed an instance of the record being edited/created along with
+	 * the current configuration array - and must return a complete copy
+	 * of the configuration array manipulated to the Provider's needs.
+	 *
+	 * @param array $row The record being edited/created
+	 * @return array The large FormEngine configuration array - see FormEngine documentation!
+	 */
+	public function processTableConfiguration(array $row, array $configuration);
+
+	/**
 	 * Perform operations upon clearing cache(s)
 	 *
 	 * @param array $command

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -72,3 +72,14 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['recStatInfoHooks']['flux'] 
 if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup']['listNestedContent']) && !(boolean) $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup']['listNestedContent']) {
 	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/class.db_list_extra.inc']['getTable']['flux'] = 'FluidTYPO3\Flux\Hooks\RecordListGetTableHookSubscriber';
 }
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][\FluidTYPO3\Flux\Backend\FormEngine\ProviderProcessor::class] = array(
+	'depends' => array(
+		\TYPO3\CMS\Backend\Form\FormDataProvider\PageTsConfig::class,
+		\TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessCommon::class,
+		\TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsProcessShowitem::class
+	),
+	'before' => array(
+		\TYPO3\CMS\Backend\Form\FormDataProvider\TcaColumnsRemoveUnused::class
+	)
+);


### PR DESCRIPTION
No need to use a complicated core API - a single Provider method can now be used to manipulate everything about the TCA related to the table/type that made the provider trigger.