### PR TITLE
[BUGFIX] Default of '0' must be '0' and not NULL in TYPO3 > 7.5

### DIFF
--- a/Classes/Form/AbstractFormField.php
+++ b/Classes/Form/AbstractFormField.php
@@ -264,12 +264,7 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
 	 * @return mixed
 	 */
 	public function getDefault() {
-		if (FALSE === empty($this->default)) {
-			$defaultValue = $this->default;
-		} else {
-			$defaultValue = NULL;
-		}
-		return $defaultValue;
+		return $this->default;
 	}
 
 	/**


### PR DESCRIPTION
Example with flux form fields:
```html
  <flux:field.select name="type" default="0" items="{0:'Variant A',1:'Variant B',2:'Variant C'}" requestUpdate="1"/>
  <flux:field.input displayCond="FIELD:type:>:0" name="subheadline"/>
```
The field "type" has a default value of "0".
The field "subheadline" has the displayCond="FIELD:type:>:0".
When creating a new element, then the subheadline is shown -> that is wrong.