### PR TITLE
Fix select field rendering in 7.6

### DIFF
--- a/Classes/Form/AbstractMultiValueFormField.php
+++ b/Classes/Form/AbstractMultiValueFormField.php
@@ -46,7 +46,7 @@ abstract class AbstractMultiValueFormField extends AbstractFormField implements 
 	/**
 	 * @var string
 	 */
-	protected $renderMode = NULL;
+	protected $renderMode = 'default';
 
 	/**
 	 * @param string $type


### PR DESCRIPTION
Inspired by this request https://github.com/FluidTYPO3/flux/commit/43912a3eeb3119bd1387266887b7bc998727a086
I changed the $renderMode back to 'default'. So rendering of the select field works again in 7.6.