### PR TITLE
[BUGFIX] Move element to first position in grid column

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -207,6 +207,7 @@ class ContentService implements SingletonInterface {
 				list ($parent, $column) = $this->getTargetAreaStoredInSession($relativeTo);
 				$row['tx_flux_parent'] = $parent;
 				$row['tx_flux_column'] = $column;
+				$row['sorting'] = $tceMain->getSortNumber('tt_content', 0, $row['pid']);
 			} elseif (0 <= (integer) $relativeTo && FALSE === empty($parameters[1])) {
 				list($prefix, $column, $prefix2, , , $relativePosition, $relativeUid, $area) = GeneralUtility::trimExplode('-', $parameters[1]);
 				$relativeUid = (integer) $relativeUid;

--- a/Resources/Public/js/DragDrop.js
+++ b/Resources/Public/js/DragDrop.js
@@ -154,6 +154,23 @@ define(['jquery', 'jquery-ui/sortable'], function ($) {
      */
     return function() {
         DragDrop.initialize();
+        // Workaround move with the element with the up button to the first position in grid column
+        // The 'href' of the up button href becomes the 'href' of the down button of the first element
+        $('[data-colpos="18181"]').each(
+            function(i){
+                var gridColumn = $(this);
+                var pageId = parseInt(gridColumn.find(' > [data-page]').data('page'));
+                if (pageId<0) {
+                    var downArrow = gridColumn.find('> .t3js-page-ce-sortable span.icon-actions-move-down').first().closest('a');
+                    var upArrow = gridColumn.find('> .t3js-page-ce-sortable span.icon-actions-move-up').first().closest('a');
+                    // Check if up and down arrow exists
+                    if (upArrow.length && downArrow.length) {
+                        // Set 'href' of the up button to the 'href' of the down button of the first element in the grid column
+                        upArrow.attr('href', downArrow.attr('href'));
+                    }
+                }
+            });
+
         return DragDrop;
     }();
 });


### PR DESCRIPTION
This bugfix resolves the following problems:
1. drag and drop to the first position = the element was not moved.
2. moving the element with the arrow buttons to the first position = the element was disappeared from the page