### PR TITLE
[FEATURE] Bring back the paste and reference buttons.

### DIFF
--- a/Classes/Utility/MiscellaneousUtility.php
+++ b/Classes/Utility/MiscellaneousUtility.php
@@ -11,6 +11,8 @@ namespace FluidTYPO3\Flux\Utility;
 use FluidTYPO3\Flux\Form;
 use TYPO3\CMS\Backend\Utility\IconUtility;
 use TYPO3\CMS\Core\Imaging\GraphicalFunctions;
+use TYPO3\CMS\Core\Imaging\Icon;
+use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -26,6 +28,11 @@ class MiscellaneousUtility {
 	 * @var array
 	 */
 	private static $allowedIconTypes = array('svg', 'png', 'gif');
+
+	/**
+	 * @var IconFactory
+	 */
+	private static $iconFactory;
 
 	/**
 	 * @param integer $contentElementUid
@@ -44,7 +51,11 @@ class MiscellaneousUtility {
 	 * @return string
 	 */
 	public static function getIcon($icon) {
-		return IconUtility::getSpriteIcon($icon);
+		if (NULL === static::$iconFactory) {
+			static::$iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+		}
+
+		return static::$iconFactory->getIcon($icon, Icon::SIZE_SMALL);
 	}
 
 	/**
@@ -54,7 +65,7 @@ class MiscellaneousUtility {
 	 * @return string
 	 */
 	public static function wrapLink($inner, $uri, $title) {
-		return '<a href="#" onclick="window.location.href=\'' . htmlspecialchars($uri) . '\'" title="' . $title . '">' . $inner . '</a>';
+		return '<a href="#" class="btn btn-default btn-sm" onclick="window.location.href=\'' . htmlspecialchars($uri) . '\'" title="' . $title . '">' . $inner . '</a>';
 	}
 
 	/**

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -342,7 +342,10 @@ class PreviewView {
 
 		return sprintf($this->templates['record'], $disabledClass, $record['_CSSCLASS'], $record['uid'], $record['uid'],
 			$element, $colPosFluxContent, $parentRow['pid'], $parentRow['uid'], $record['uid'],
-			$this->drawNewIcon($parentRow, $column, $record['uid']));
+			$this->drawNewIcon($parentRow, $column, $record['uid']).
+			$this->drawPasteIcon($parentRow, $column, FALSE, $record).
+			$this->drawPasteIcon($parentRow, $column, TRUE, $record));
+
 	}
 
 	/**
@@ -619,6 +622,22 @@ class PreviewView {
 	/**
 	 * @param array $row
 	 * @param Column $column
+	 * @param boolean $reference
+	 * @param array $relativeTo
+	 * @return string
+	 */
+	protected function drawPasteIcon(array $row, Column $column, $reference = FALSE, array $relativeTo = array()) {
+		$command = TRUE === $reference ? 'reference' : 'paste';
+		$relativeUid = TRUE === isset($relativeTo['uid']) ? $relativeTo['uid'] : 0;
+		$columnName = $column->getName();
+		$relativeTo = $row['pid'] . '-' . $command . '-' . $relativeUid . '-' .
+				$row['uid'] . (FALSE === empty($columnName) ? '-' . $columnName : '') . '-' . ContentService::COLPOS_FLUXCONTENT;
+		return ClipBoardUtility::createIconWithUrl($relativeTo, $reference);
+	}
+
+	/**
+	 * @param array $row
+	 * @param Column $column
 	 * @param integer $colPosFluxContent
 	 * @param PageLayoutView $dblist
 	 * @param integer $target
@@ -637,7 +656,7 @@ class PreviewView {
 			$column->getLabel(),
 			$target,
 			$id,
-			$this->drawNewIcon($row, $column),
+			$this->drawNewIcon($row, $column). $this->drawPasteIcon($row, $column) . $this->drawPasteIcon($row, $column, TRUE),
 			$content
 		);
 	}


### PR DESCRIPTION
* Works in TYPO3 7.6.
* Now in the TYPO3 7 design.

![image](https://cloud.githubusercontent.com/assets/1583746/11135222/733974d4-89a3-11e5-8aa6-dc59ecad0611.png)
