### PR TITLE
[BUGFIX] Fixed incorrect cleaning of FlexForm XML

### DIFF
--- a/Classes/Utility/MiscellaneousUtility.php
+++ b/Classes/Utility/MiscellaneousUtility.php
@@ -130,12 +130,19 @@ class MiscellaneousUtility {
 		$dom->loadXML($xml);
 		$dom->preserveWhiteSpace = FALSE;
 		$dom->formatOutput = TRUE;
+		$fieldNodesToRemove = array();
 		foreach ($dom->getElementsByTagName('field') as $fieldNode) {
 			/** @var \DOMElement $fieldNode */
 			if (TRUE === in_array($fieldNode->getAttribute('index'), $removals)) {
-				$fieldNode->parentNode->removeChild($fieldNode);
+				$fieldNodesToRemove[] = $fieldNode;
 			}
 		}
+
+		foreach ($fieldNodesToRemove as $fieldNodeToRemove) {
+			/** @var \DOMElement $fieldNodeToRemove */
+			$fieldNodeToRemove->parentNode->removeChild($fieldNodeToRemove);
+		}
+
 		// Assign a hidden ID to all container-type nodes, making the value available in templates etc.
 		foreach ($dom->getElementsByTagName('el') as $containerNode) {
 			/** @var \DOMElement $containerNode */


### PR DESCRIPTION
During FlexForm cleaning, field nodes are iterated over and specially
flagged fields are removed. This removal happens during iteration and
the change in the array causes the next element to be skipped.

This bug is visible within EXT:fluidpages when saving a page with
no configuration changes. Values that were not specifically set on the
configuration form are saved in the FlexForm XML.

The solution is to gather fieldNodes to be removed, but remove them in a
separate loop.