### PR TITLE
[BUGFIX] Disable up and down buttons in in Web->Page

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -207,6 +207,7 @@ class ContentService implements SingletonInterface {
 				list ($parent, $column) = $this->getTargetAreaStoredInSession($relativeTo);
 				$row['tx_flux_parent'] = $parent;
 				$row['tx_flux_column'] = $column;
+				$row['sorting'] = $tceMain->getSortNumber('tt_content', 0, $row['pid']);
 			} elseif (0 <= (integer) $relativeTo && FALSE === empty($parameters[1])) {
 				list($prefix, $column, $prefix2, , , $relativePosition, $relativeUid, $area) = GeneralUtility::trimExplode('-', $parameters[1]);
 				$relativeUid = (integer) $relativeUid;

--- a/Classes/View/PageLayoutView.php
+++ b/Classes/View/PageLayoutView.php
@@ -1,0 +1,26 @@
+<?php
+namespace FluidTYPO3\Flux\View;
+
+	/*
+	 * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+	 *
+	 * For the full copyright and license information, please read the
+	 * LICENSE.md file that was distributed with this source code.
+	 */
+
+class PageLayoutView extends \TYPO3\CMS\Backend\View\PageLayoutView
+{
+	/**
+	 * @param $pageinfo
+	 */
+	public function setPageinfo( $pageinfo ) {
+		$this->pageinfo = $pageinfo;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getPageinfo() {
+		return $this->pageinfo;
+	}
+}

--- a/Tests/Unit/View/PreviewViewTest.php
+++ b/Tests/Unit/View/PreviewViewTest.php
@@ -13,7 +13,7 @@ use FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\Tests\Fixtures\Data\Records;
 use FluidTYPO3\Flux\Tests\Unit\AbstractTestCase;
 use FluidTYPO3\Flux\View\PreviewView;
-use TYPO3\CMS\Backend\View\PageLayoutView;
+use FluidTYPO3\Flux\View\PageLayoutView;
 use TYPO3\CMS\Core\Versioning\VersionState;
 
 /**
@@ -119,7 +119,7 @@ class PreviewViewTest extends AbstractTestCase {
 		$parentRow = array('bar' => 'foo');
 		$record = array('foo' => 'bar');
 		$column = new Form\Container\Column();
-		$view = $this->getMock('TYPO3\\CMS\\Backend\\View\\PageLayoutView', array('tt_content_drawHeader'));
+		$view = $this->getMock('FluidTYPO3\\Flux\\View\\PageLayoutView', array('tt_content_drawHeader'));
 		$view->expects($this->any())->method('tt_content_drawHeader')
 			->with($record, $this->anything(), $this->anything(), $this->anything());
 		$instance = $this->createInstance();
@@ -281,7 +281,7 @@ class PreviewViewTest extends AbstractTestCase {
 	public function configurePageLayoutViewForLanguageModeSetsSpecialVariablesInLanguageMode() {
 		$languageService = $this->getMock('TYPO3\\CMS\\Lang\\LanguageService', array('getLL'));
 		$languageService->expects($this->once())->method('getLL');
-		$view = $this->getMock('TYPO3\\CMS\\Backend\\View\\PageLayoutView', array('initializeLanguages'));
+		$view = $this->getMock('FluidTYPO3\\Flux\\View\\PageLayoutView', array('initializeLanguages'));
 		$view->expects($this->once())->method('initializeLanguages');
 		$instance = $this->getMock($this->createInstanceClassName(), array('getPageModuleSettings', 'getLanguageService'));
 		$instance->expects($this->once())->method('getPageModuleSettings')->willReturn(array('function' => 2));


### PR DESCRIPTION
and respect edit content permissions.

Since TYPO3 7.6 the up and down buttons are hidden.

This commit also includes the correct sorting value geneartion when an element was moved to first position in a grid column.

This pull request replaces #1014