### PR TITLE
[BUGFIX] Initialize full $row in FlexForm hook

### DIFF
--- a/Classes/Backend/DynamicFlexForm.php
+++ b/Classes/Backend/DynamicFlexForm.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Flux\Backend;
  */
 
 use FluidTYPO3\Flux\Service\FluxService;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
@@ -62,6 +63,8 @@ class DynamicFlexForm {
 	 * @return void
 	 */
 	public function getFlexFormDS_postProcessDS(&$dataStructArray, $conf, &$row, $table, $fieldName) {
+		// $row doesn't neccessarily contain all fields that we need
+		$fullrow = BackendUtility::getRecord($table, $row['uid']);
 		if (empty($fieldName) === TRUE) {
 			// Cast NULL if an empty but not-NULL field name was passed. This has significance to the Flux internals in
 			// respect to which ConfigurationProvider(s) are returned.
@@ -70,9 +73,9 @@ class DynamicFlexForm {
 		if (FALSE === is_array($dataStructArray)) {
 			$dataStructArray = array();
 		}
-		$providers = $this->configurationService->resolveConfigurationProviders($table, $fieldName, $row);
+		$providers = $this->configurationService->resolveConfigurationProviders($table, $fieldName, $fullrow);
 		foreach ($providers as $provider) {
-			$provider->postProcessDataStructure($row, $dataStructArray, $conf);
+			$provider->postProcessDataStructure($fullrow, $dataStructArray, $conf);
 		}
 		if (empty($dataStructArray)) {
 			$dataStructArray = array('ROOT' => array('el' => array()));

--- a/Classes/Backend/DynamicFlexForm.php
+++ b/Classes/Backend/DynamicFlexForm.php
@@ -11,6 +11,7 @@ namespace FluidTYPO3\Flux\Backend;
 use FluidTYPO3\Flux\Service\FluxService;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 /**
@@ -64,7 +65,11 @@ class DynamicFlexForm {
 	 */
 	public function getFlexFormDS_postProcessDS(&$dataStructArray, $conf, &$row, $table, $fieldName) {
 		// $row doesn't neccessarily contain all fields that we need
-		$fullrow = BackendUtility::getRecord($table, $row['uid']);
+		if (MathUtility::canBeInterpretedAsInteger($row['uid'])) {
+			$fullrow = BackendUtility::getRecord($table, $row['uid']);
+		} else {
+			$fullrow = $row;
+		}
 		if (empty($fieldName) === TRUE) {
 			// Cast NULL if an empty but not-NULL field name was passed. This has significance to the Flux internals in
 			// respect to which ConfigurationProvider(s) are returned.


### PR DESCRIPTION
$row which is passed to our FlexForm hook by TYPO3 only contains the
record uid in TYPO3 master, so we have to assure to get the whole record
in order to build the proper DS