### PR TITLE
[FEATURE] Package API

### DIFF
--- a/Classes/FluxPackage.php
+++ b/Classes/FluxPackage.php
@@ -1,0 +1,236 @@
+<?php
+namespace FluidTYPO3\Flux;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Flux\Form;
+use FluidTYPO3\Flux\Package\FluxPackageInterface;
+use FluidTYPO3\Flux\Package\PackageNotFoundException;
+use FluidTYPO3\Flux\Utility\CompatibilityRegistry;
+use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
+use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
+use FluidTYPO3\Flux\View\ExposedTemplateView;
+use FluidTYPO3\Flux\View\TemplatePaths;
+use FluidTYPO3\Flux\View\ViewContext;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContext;
+use TYPO3\CMS\Fluid\Core\ViewHelper\TemplateVariableContainer;
+
+/**
+ * Class FluxPackage
+ */
+class FluxPackage implements FluxPackageInterface {
+
+	const IMPLEMENTATION_VIEW = 'view';
+	const IMPLEMENTATION_VIEWCONTEXT = 'viewContext';
+	const IMPLEMENTATION_RENDERINGCONTEXT = 'renderingContext';
+	const IMPLEMENTATION_FORM = 'form';
+	const IMPLEMENTATION_TEMPLATEPATHS = 'templatePaths';
+	const IMPLEMENTATION_TEMPLATEVARIABLEPROVIDER = 'templateVariableProvider';
+	const IMPLEMENTATION_VIEWHELPERRESOLVER = 'viewHelperResolver';
+	const IMPLEMENTATION_VIEWHELPERINVOKER = 'viewHelperInvoker';
+
+	const FEATURE_PREVIEW = 'preview';
+	const FEATURE_TRANSFORMATION = 'transformation';
+	const FEATURE_DATAHANDLING = 'dataHandling';
+
+	/**
+	 * @var array
+	 */
+	protected $manifest = array();
+
+	/**
+	 * @var array
+	 */
+	protected $defaultImplementations = array(
+		self::IMPLEMENTATION_VIEW => ExposedTemplateView::class,
+		self::IMPLEMENTATION_VIEWCONTEXT => ViewContext::class,
+		self::IMPLEMENTATION_RENDERINGCONTEXT => RenderingContext::class,
+		self::IMPLEMENTATION_FORM => Form::class,
+		self::IMPLEMENTATION_TEMPLATEPATHS => TemplatePaths::class,
+		self::IMPLEMENTATION_TEMPLATEVARIABLEPROVIDER => TemplateVariableContainer::class,
+		self::IMPLEMENTATION_VIEWHELPERRESOLVER => NULL, // @TODO: fill when standalone fluid arrives
+		self::IMPLEMENTATION_VIEWHELPERINVOKER => NULL // @TODO: fill when standalone fluid arrives
+	);
+
+	/**
+	 * @param mixed $seedArrayOrExtensionKeyOrManifestPath
+	 * @return FluxPackageInterface
+	 */
+	public static function create($seedArrayOrExtensionKeyOrManifestPath) {
+		return new static($seedArrayOrExtensionKeyOrManifestPath);
+	}
+
+	/**
+	 * Constructor - takes an array of manifest data in the
+	 * same structure as in the manifest JSON file, or an
+	 * extension key in which case the expected manifest
+	 * is resolved using that and naming convention of the
+	 * manifest file. Or takes a full path to the manifest
+	 * file in which case the manifest is read from there.
+	 *
+	 * Note: applies CompatibilityRegistry-resolved versioned
+	 * manifest configuration values immediately.
+	 *
+	 * @param mixed $seedArrayOrExtensionKeyOrManifestPath
+	 */
+	public function __construct($seedArrayOrExtensionKeyOrManifestPath) {
+		if (is_array($seedArrayOrExtensionKeyOrManifestPath)) {
+			$this->manifest = $seedArrayOrExtensionKeyOrManifestPath;
+		} else {
+			$possibleExtensionKey = ExtensionNamingUtility::getExtensionKey($seedArrayOrExtensionKeyOrManifestPath);
+			if (ExtensionManagementUtility::isLoaded($possibleExtensionKey)) {
+				$this->manifest = $this->loadManifestFile(
+					GeneralUtility::getFileAbsFileName(sprintf('EXT:%s/flux.json', $possibleExtensionKey))
+				);
+			} else {
+				$this->manifest = $this->loadManifestFile($seedArrayOrExtensionKeyOrManifestPath);
+			}
+		}
+		if (!empty($this->manifest['compatibility'])) {
+			$scope = $this->manifest['package'] . '/ManifestOverlay';
+			CompatibilityRegistry::register($scope, $this->manifest['compatibility']);
+			RecursiveArrayUtility::mergeRecursiveOverrule($this->manifest, CompatibilityRegistry::get($scope));
+		}
+	}
+
+	/**
+	 * Load flux.json manifest file by path or reference.
+	 *
+	 * @param string $filePathAndFilename
+	 * @return array
+	 */
+	protected function loadManifestFile($filePathAndFilename) {
+		if (strpos($filePathAndFilename, '/') !== 0) {
+			$absoluteManifestPath = GeneralUtility::getFileAbsFileName($filePathAndFilename);
+		} else {
+			$absoluteManifestPath = $filePathAndFilename;
+		}
+		if (!file_exists($absoluteManifestPath)) {
+			throw new PackageNotFoundException(
+				sprintf('Flux manifest file not found! I looked for %s - make sure the manifest exists.', $absoluteManifestPath)
+			);
+		}
+		return json_decode(file_get_contents($absoluteManifestPath), JSON_OBJECT_AS_ARRAY);
+	}
+
+	/**
+	 * Must always return the vendor name (as used in class
+	 * namespaces) corresponding to this package.
+	 *
+	 * @return string
+	 */
+	public function getVendorName() {
+		return ExtensionNamingUtility::getVendorName($this->manifest['package']);
+	}
+
+	/**
+	 * Must always return the ExtensionName format of the
+	 * extension key, excluding the vendor name.
+	 *
+	 * @return string
+	 */
+	public function getExtensionName() {
+		return ExtensionNamingUtility::getExtensionName($this->manifest['package']);
+	}
+
+	/**
+	 * Must always return the $vendor\$extensioName format
+	 * of the vendor and extension name, using values from
+	 * the two preceeding methods.
+	 *
+	 * @return string
+	 */
+	public function getNamespacePrefix() {
+		return $this->getVendorName() . '\\' . $this->getExtensionName() . '\\';
+	}
+
+	/**
+	 * Returns an instance of Flux's TemplatePaths class
+	 * with template paths of this package preloaded.
+	 *
+	 * @return TemplatePaths
+	 */
+	public function getViewPaths() {
+		return new TemplatePaths(!empty($this->manifest['view']) ? $this->manifest['view'] : $this->getExtensionName());
+	}
+
+	/**
+	 * Asserts whether or not this FluxPackage contains an
+	 * integration designed for the controller name, e.g.
+	 * "Content", "Page" etc.
+	 *
+	 * @param string $controllerName
+	 * @return boolean
+	 */
+	public function isProviderFor($controllerName) {
+		return !empty($this->manifest['providers']) && in_array($controllerName, $this->manifest['providers']);
+	}
+
+	/**
+	 * Asserts whether or not the feature is enabled for
+	 * this FluxPackage.
+	 *
+	 * @param string $featureName
+	 * @return boolean
+	 */
+	public function isFeatureEnabled($featureName) {
+		return !empty($this->manifest['features']) && in_array($featureName, $this->manifest['features']);
+	}
+
+	/**
+	 * Get FQN of the class that's designated as an
+	 * implementation, meaning it is replaceable by Flux
+	 * Packages via this method.
+	 *
+	 * @param string $implementationName
+	 * @return string
+	 */
+	public function getImplementation($implementationName) {
+		if (!empty($this->manifest['implementations']) && array_key_exists($implementationName, $this->manifest['implementations'])) {
+			return $this->manifest['implementations'][$implementationName];
+		}
+		return $this->defaultImplementations[$implementationName];
+	}
+
+	/**
+	 * Modify properties of this FluxPackage (in this class
+	 * instance only) by passing an array using the same
+	 * structure as the constructor and as in the manifest.
+	 *
+	 * Is used internally when applying compatibility values:
+	 * the "overlay" type subset of version dependent values
+	 * is detected based on current version and passed to
+	 * this function which then assimilates the values.
+	 *
+	 * @param array $alternativeManifestDeclaration
+	 * @return void
+	 */
+	public function modify(array $alternativeManifestDeclaration) {
+		RecursiveArrayUtility::mergeRecursiveOverrule($this->manifest, $alternativeManifestDeclaration);
+	}
+
+	/**
+	 * Upcasts (promotes) the instance to another class name
+	 * by creating a new instance of the provided class and
+	 * passing $this->manifest as seed. If NULL is passed as
+	 * desired class name the expected final class name is
+	 * determined based on naming convention.
+	 *
+	 * @param string $desiredClassName
+	 * @return FluxPackageInterface
+	 */
+	public function upcast($desiredClassName = NULL) {
+		if (!$desiredClassName) {
+			$desiredClassName = $this->getNamespacePrefix() . 'FluxPackage';
+		}
+		return new $desiredClassName($this->manifest);
+	}
+
+}

--- a/Classes/Form.php
+++ b/Classes/Form.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Flux;
  */
 
 use FluidTYPO3\Flux\Outlet\OutletInterface;
+use FluidTYPO3\Flux\Package\FluxPackageFactory;
 use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
@@ -97,6 +98,24 @@ class Form extends Form\AbstractFormContainer implements Form\FieldContainerInte
 		$defaultSheet->setLabel('LLL:EXT:flux/' . $this->localLanguageFileRelativePath . ':tt_content.tx_flux_options');
 		$this->add($defaultSheet);
 		$this->outlet = $this->getObjectManager()->get('FluidTYPO3\Flux\Outlet\StandardOutlet');
+	}
+
+	/**
+	 * @param array $settings
+	 * @return FormInterface
+	 */
+	public static function create(array $settings = array()) {
+		/** @var ObjectManagerInterface $objectManager */
+		$objectManager = GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager');
+		if (isset($settings['extensionName'])) {
+			$className = FluxPackageFactory::getPackageWithFallback($settings['extensionName'])
+				->getImplementation(FluxPackage::IMPLEMENTATION_FORM);
+		} else {
+			$className = get_called_class();
+		}
+		/** @var FormInterface $object */
+		$object = $objectManager->get($className);
+		return $object->modify($settings);
 	}
 
 	/**

--- a/Classes/Package/FluxPackageFactory.php
+++ b/Classes/Package/FluxPackageFactory.php
@@ -1,0 +1,95 @@
+<?php
+namespace FluidTYPO3\Flux\Package;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+use FluidTYPO3\Flux\FluxPackage;
+use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+
+/**
+ * Class FluxPackageFactory
+ *
+ * Creates instances of FluxPackage based on provided
+ * extension name. Stores created instances in memory.
+ */
+abstract class FluxPackageFactory {
+
+	/**
+	 * @var FluxPackageInterface[]
+	 */
+	protected static $packages = array();
+
+	/**
+	 * @var array|NULL
+	 */
+	protected static $overrides = NULL;
+
+	/**
+	 * Returns the FluxPackage instance associated with
+	 * and possibly existing in $qualifiedExtensionName.
+	 *
+	 * @param string $qualifiedExtensionName
+	 * @return FluxPackageInterface
+	 */
+	public static function getPackage($qualifiedExtensionName) {
+		if (empty($qualifiedExtensionName)) {
+			throw new PackageNotFoundException('Package name cannot be empty');
+		}
+		$extensionKey = ExtensionNamingUtility::getExtensionKey($qualifiedExtensionName);
+		if (!array_key_exists($extensionKey, static::$packages)) {
+			$manifestPath = ExtensionManagementUtility::extPath($extensionKey, 'flux.json');
+			static::$packages[$extensionKey] = FluxPackage::create($manifestPath)->upcast();
+		}
+		return static::$packages[$extensionKey];
+	}
+
+	/**
+	 * Returns the FluxPackage instance associated with
+	 * and possibly existing in $qualifiedExtensionName,
+	 * but falls back to returning the Flux root package
+	 * if the requested package does not exist.
+	 *
+	 * @param string $qualifiedExtensionName
+	 * @return FluxPackageInterface
+	 */
+	public static function getPackageWithFallback($qualifiedExtensionName) {
+		try {
+			return static::getPackage($qualifiedExtensionName);
+		} catch (PackageNotFoundException $error) {
+			return static::getPackage('FluidTYPO3.Flux');
+		}
+	}
+
+	/**
+	 * @param string $qualifiedExtensionName
+	 * @return array
+	 */
+	protected function getTypoScriptOverrides($qualifiedExtensionName) {
+		if (static::$overrides === NULL) {
+			$collected = array();
+			$typoScript = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager')
+				->get('TYPO3\\CMS\\Extbase\\Object\\ObjectManagerInterface')
+				->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+			foreach ((array) ObjectAccess::getPropertyPath($typoScript, 'plugin') as $prefix => $pluginSettings) {
+				if (!empty($pluginSettings['package'])) {
+					$collected[substr($prefix, 3)] = $pluginSettings['package'];
+				}
+			}
+			static::$overrides = $collected;
+		}
+		$packageSignature = ExtensionNamingUtility::getExtensionSignature($qualifiedExtensionName);
+		if (!empty(static::$overrides[$packageSignature])) {
+			return static::$overrides[$packageSignature];
+		}
+		return array();
+	}
+
+}

--- a/Classes/Package/FluxPackageInterface.php
+++ b/Classes/Package/FluxPackageInterface.php
@@ -1,0 +1,123 @@
+<?php
+namespace FluidTYPO3\Flux\Package;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Flux\View\TemplatePaths;
+
+/**
+ * Interface FluxPackageInterface
+ *
+ * Implemented by FluxPackage instances - describes required
+ * methods for a package class (manifest API) that's unique
+ * per extension.
+ */
+interface FluxPackageInterface {
+
+	/**
+	 * Constructor - takes an array of manifest data in the
+	 * same structure as in the manifest JSON file, or an
+	 * extension key in which case the expected manifest
+	 * is resolved using that and naming convention of the
+	 * manifest file. Or takes a full path to the manifest
+	 * file in which case the manifest is read from there.
+	 *
+	 * @param mixed $seedArrayOrExtensionKeyOrManifestPath
+	 */
+	public function __construct($seedArrayOrExtensionKeyOrManifestPath);
+
+	/**
+	 * Must always return the vendor name (as used in class
+	 * namespaces) corresponding to this package.
+	 *
+	 * @return string
+	 */
+	public function getVendorName();
+
+	/**
+	 * Must always return the ExtensionName format of the
+	 * extension key, excluding the vendor name.
+	 *
+	 * @return string
+	 */
+	public function getExtensionName();
+
+	/**
+	 * Must always return the $vendor\$extensioName format
+	 * of the vendor and extension name, using values from
+	 * the two preceeding methods.
+	 *
+	 * @return string
+	 */
+	public function getNamespacePrefix();
+
+	/**
+	 * Returns an instance of Flux's TemplatePaths class
+	 * with template paths of this package preloaded.
+	 *
+	 * @return TemplatePaths
+	 */
+	public function getViewPaths();
+
+	/**
+	 * Asserts whether or not this FluxPackage contains an
+	 * integration designed for the controller name, e.g.
+	 * "Content", "Page" etc.
+	 *
+	 * @param string $controllerName
+	 * @return boolean
+	 */
+	public function isProviderFor($controllerName);
+
+	/**
+	 * Asserts whether or not the feature is enabled for
+	 * this FluxPackage.
+	 *
+	 * @param string $featureName
+	 * @return boolean
+	 */
+	public function isFeatureEnabled($featureName);
+
+	/**
+	 * Get FQN of the class that's designated as an
+	 * implementation, meaning it is replaceable by Flux
+	 * Packages via this method.
+	 *
+	 * @param string $implementationName
+	 * @return string
+	 */
+	public function getImplementation($implementationName);
+
+	/**
+	 * Modify properties of this FluxPackage (in this class
+	 * instance only) by passing an array using the same
+	 * structure as the constructor and as in the manifest.
+	 *
+	 * Is used internally when applying compatibility values:
+	 * the "overlay" type subset of version dependent values
+	 * is detected based on current version and passed to
+	 * this function which then assimilates the values.
+	 *
+	 * @param array $alternativeManifestDeclaration
+	 * @return void
+	 */
+	public function modify(array $alternativeManifestDeclaration);
+
+	/**
+	 * Upcasts (promotes) the instance to another class name
+	 * by creating a new instance of the provided class and
+	 * passing $this->manifest as seed. If NULL is passed as
+	 * desired class name the expected final class name is
+	 * determined based on naming convention.
+	 *
+	 * @param string|NULL $desiredClassName
+	 * @return FluxPackageInterface
+	 */
+	public function upcast($desiredClassName = NULL);
+
+}

--- a/Classes/Package/PackageNotFoundException.php
+++ b/Classes/Package/PackageNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+namespace FluidTYPO3\Flux\Package;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+/**
+ * Class PackageNotFoundException
+ */
+class PackageNotFoundException extends \RuntimeException {
+
+}

--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -8,9 +8,11 @@ namespace FluidTYPO3\Flux\Service;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Flux\FluxPackage;
 use FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\Form\Container\Grid;
 use FluidTYPO3\Flux\Helper\Resolver;
+use FluidTYPO3\Flux\Package\FluxPackageFactory;
 use FluidTYPO3\Flux\Provider\ProviderInterface;
 use FluidTYPO3\Flux\Provider\ProviderResolver;
 use FluidTYPO3\Flux\Transformation\FormDataTransformer;
@@ -187,10 +189,16 @@ class FluxService implements SingletonInterface {
 		$context->setRequest($request);
 		$context->setResponse($response);
 		/** @var $renderingContext RenderingContext */
-		$renderingContext = $this->objectManager->get('TYPO3\\CMS\\Fluid\\Core\\Rendering\\RenderingContext');
+		$renderingContext = $this->objectManager->get(
+			FluxPackageFactory::getPackageWithFallback($qualifiedExtensionName)
+				->getImplementation(FluxPackage::IMPLEMENTATION_RENDERINGCONTEXT)
+		);
 		$renderingContext->setControllerContext($context);
 		/** @var $exposedView ExposedTemplateView */
-		$exposedView = $this->objectManager->get('FluidTYPO3\Flux\View\ExposedTemplateView');
+		$exposedView = $this->objectManager->get(
+			FluxPackageFactory::getPackageWithFallback($qualifiedExtensionName)
+				->getImplementation(FluxPackage::IMPLEMENTATION_VIEW)
+		);
 		$exposedView->setRenderingContext($renderingContext);
 		$exposedView->setControllerContext($context);
 		$exposedView->assignMultiple($variables);
@@ -221,7 +229,10 @@ class FluxService implements SingletonInterface {
 			} catch (\RuntimeException $error) {
 				$this->debug($error);
 				/** @var Form $form */
-				self::$cache[$cacheKey] = $this->objectManager->get('FluidTYPO3\Flux\Form');
+				self::$cache[$cacheKey] = $this->objectManager->get(
+					FluxPackageFactory::getPackageWithFallback($extensionName)
+						->getImplementation(FluxPackage::IMPLEMENTATION_FORM)
+				);
 				self::$cache[$cacheKey]->createField('UserFunction', 'error')
 					->setFunction('FluidTYPO3\Flux\UserFunction\ErrorReporter->renderField')
 					->setArguments(array($error)

--- a/Classes/ViewHelpers/AbstractFormViewHelper.php
+++ b/Classes/ViewHelpers/AbstractFormViewHelper.php
@@ -126,7 +126,9 @@ abstract class AbstractFormViewHelper extends AbstractViewHelper implements Comp
 		} elseif (TRUE === $templateVariableContainer->exists(static::SCOPE_VARIABLE_FORM)) {
 			$form = $templateVariableContainer->get(static::SCOPE_VARIABLE_FORM);
 		} else {
-			$form = Form::create();
+			$form = Form::create(array(
+				'extensionName' => $renderingContext->getControllerContext()->getRequest()->getControllerExtensionName()
+			));
 			$viewHelperVariableContainer->add(static::SCOPE, static::SCOPE_VARIABLE_FORM, $form);
 		}
 		return $form;

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -8,7 +8,9 @@ namespace FluidTYPO3\Flux\ViewHelpers;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Flux\FluxPackage;
 use FluidTYPO3\Flux\Form;
+use FluidTYPO3\Flux\Package\FluxPackageFactory;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
@@ -50,7 +52,8 @@ class FormViewHelper extends AbstractFormViewHelper {
 		$viewHelperVariableContainer = $renderingContext->getViewHelperVariableContainer();
 		$templateVariableContainer = $renderingContext->getTemplateVariableContainer();
 		$extensionName = static::getExtensionNameFromRenderingContextOrArguments($renderingContext, $arguments);
-		$form = Form::create();
+		$formClassName = FluxPackageFactory::getPackageWithFallback($extensionName)->getImplementation(FluxPackage::IMPLEMENTATION_FORM);
+		$form = call_user_func_array(array($formClassName, 'create'), array());
 		$container = $form->last();
 		// configure Form instance
 		$form->setId($arguments['id']);

--- a/Tests/Unit/Helper/ResolveUtilityTest.php
+++ b/Tests/Unit/Helper/ResolveUtilityTest.php
@@ -39,7 +39,7 @@ class ResolveUtilityTest extends AbstractTestCase {
 	public function resolvesClassNamesInSubNamespaceOfPackage() {
 		$resolver = new Resolver();
 		$result = $resolver->resolveClassNamesInPackageSubNamespace('FluidTYPO3.Flux', '');
-		$this->assertEquals(array('FluidTYPO3\\Flux\\Core', 'FluidTYPO3\\Flux\\Form'), $result);
+		$this->assertEquals(array('FluidTYPO3\\Flux\\Core', 'FluidTYPO3\\Flux\\FluxPackage', 'FluidTYPO3\\Flux\\Form'), $result);
 	}
 
 	/**

--- a/Tests/Unit/ViewHelpers/AbstractFormViewHelperTestCase.php
+++ b/Tests/Unit/ViewHelpers/AbstractFormViewHelperTestCase.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Flux\Tests\Unit\ViewHelpers;
 
 use FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\ViewHelpers\AbstractFormViewHelper;
+use TYPO3\CMS\Extbase\Mvc\Web\Request;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 
 /**
@@ -33,12 +34,23 @@ abstract class AbstractFormViewHelperTestCase extends AbstractViewHelperTestCase
 			'TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface',
 			array('getTemplateVariableContainer', 'getViewHelperVariableContainer', 'getControllerContext')
 		);
+		$this->controllerContext = $this->getMock(
+			'TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext',
+			array('getRequest')
+		);
+		$this->controllerContext->expects($this->any())
+			->method('getRequest')
+			->willReturn(new Request());
+
 		$this->renderingContext->expects($this->any())
 			->method('getTemplateVariableContainer')
 			->willReturn($this->templateVariableContainer);
 		$this->renderingContext->expects($this->any())
 			->method('getViewHelperVariableContainer')
 			->willReturn($this->viewHelperVariableContainer);
+		$this->renderingContext->expects($this->any())
+			->method('getControllerContext')
+			->willReturn($this->controllerContext);
 	}
 
 	/**

--- a/Tests/Unit/ViewHelpers/Form/ContentViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Form/ContentViewHelperTest.php
@@ -54,6 +54,7 @@ class ContentViewHelperTest extends AbstractViewHelperTestCase {
 		$renderingcontext->expects($this->atLeastOnce())->method('getTemplateVariableContainer')->willReturn(
 			$this->getMock('TYPO3\CMS\Fluid\Core\ViewHelper\TemplateVariableContainer')
 		);
+		$renderingcontext->expects($this->any())->method('getControllerContext')->willReturn($controllerContext);
 		$mock->setRenderingContext($renderingcontext);
 		$mock->setArguments(array());
 		$mock::getComponent($renderingcontext, array());

--- a/flux.json
+++ b/flux.json
@@ -1,0 +1,4 @@
+{
+  "package": "FluidTYPO3.Flux",
+  "providers": ["Content"]
+}


### PR DESCRIPTION
Flux Manifest and Package Concept
=================================

### Intention:

To define a JSON-based manifest for Flux, enabling packages (later including non-extensions) to gain control over which features the package provides and how it provides them. And to define an API, PHP-based, that allows the package a dynamic way to affect the features. The manifest and packages being closely linked - the manifest being used to “seed” the Package instance.

### Purpose:

The following are the main purposes for using the package/manifest feature:

* To enable configuration-free integration with Flux features based on class name convention lookup (which can be overridden).
* Provide common API on a per-package basis: allowing packages to do things like deliver custom class names Flux will use as substitutes for Flux's inner, semi-public API).
* To allow modifying parameters stored in the manifest by using TypoScript (with the traditional use cases: manipulating third-party exts, multisite usage, etc).

### Precautions:

Some features of Flux may need to be fitted with an Interface (e.g. the ViewContext, TemplatePaths, ExposedTemplateView etc. classes. To be discussed in team which ones, if any.

### Files and classes involved:

Packages can, in addition to current methods of registering provisioning, also provide:

a manifest named flux.json which resides in the package’s root directory (alongside composer.json etc.)
A single class named $vendor\$extensionName\FluxPackage which returns manifest configuration values for your package.

The FluxPackage instance can be seeded with properties of the manifest; a common FluxPackage implementation is seeded with those properties for those packages that do not provide their own FluxPackage class[1]. No other files or classes are required in order to utilise the package/manifest feature - but additional classes can be delivered via the FluxPackage instance or defined in the manifest.

### Sample manifest file including all properties currently imagined by this author:

	{
	  “package”: “MyVendorName.MyExtension”,
	  “providers”: [“Content”, “Page”],
	  “view”: {
	    “templateRootPaths”: [“path/one/“, “path/two/“],
	    “partialRootPaths”: [“path/one”],
	    "namespaces": {
	      // namespaces made available in all templates automatically, but only inside this extension
	      "myext": "MyVendor\\MyExtension\\ViewHelpers",
	      "flux": "FluidTYPO3\\Flux\\ViewHelpers"
	    }
	  },
	  “features”: {
	    “transformation”: false, // circumvent all form data transforms inside this extension
	    “preview”: false, // render no previews at all from within this extension
	    “dataHandling”: false // circumvent record processing by Providers in this extension
	  },
	  “implementations”: {
	    “view”: “MyVendorName\\MyExtension\\View\\MySpecialExposedView”, // custom implementation of ExposedTemplateView (Flux-only pattern)
	    “viewContext”: “MyVendorName\\MyExtension\\View\\MyCustomViewContext”, // allows replacing the special ViewContext (Flux-only pattern)
	    "renderingContext": "MyVendor\\MyExtension\\Rendering\\RenderingContext", // allows replacing the rendering context with a custom version
	    “form”: “MyVendor\\MyExtension\\Form\\MySpecialStandardForm”, // default class of Form instances, will be used when ViewHelpers or TypoScript create forms for the extension
	    “templatePaths”: “MyVendor\\MyExtension\\View\\TemplatePaths”, // note: corresponding TemplatePaths pattern implemented in standalone fluid; Flux’s version will subclass it in future
	    “templateVariableProvider”: “MyVendor\\MyExtension\\View\\MyCustomVariableProvider”, // note: this is in preparation for standalone fluid as dependency, will not work on 7.6
	    “viewHelperResolver”: “MyVendor\\MyExtension\\View\\MySpecialViewHelperResolver”, // in preparation for standalone fluid
	    “viewHelperInvoker”: “MyVendor\\MyExtension\\View\\MySpecialViewHelperInvoker”, // in preparation for standalone fluid
	  },
	  “compatibility”: {
	    “7.6”: {features: {transformation: false}}, // complete copy of entire manifest possible. This case: disables “transformation” feature on TYPO3 7.6 and above..
	    “8.0”: {providers: [“Content”]} // overrule available providers on TYPO3 version 8.0 and above.
	  }
	}

With the absolute minimal version being:

	{
	  “package”: “MyVendorName.MyExtension”
	}

Simply put, this flux.json becomes a manifest much like the one used by Composer but dealing specifically with Flux (and Fluid features that we can manipulate via FluxPackages once standalone Fluid arrives with the improved PHP API and open ability to replace implementations). And like Composer the manifest has a “Package” class associated with it - but again, allowing Flux- and TYPO3-specific operation. FluxPackage instances then become the public-to-internal bridge for many Flux features that currently require significant skill to utilise.

Another purpose is to allow toggling OFF individual features - in the future we might change these default states when we deprecate features; which would in effect allow some extensions to continue subscribing to deprecated features while others do not. It can also be seen as a way to optimise performance by skipping that are fairly costly steps, e.g. data transformation (which runs on every value, tries to find a corresponding Form component for it, reads transformation instruction and finally does the transform, all in a loop. Short circuiting such logic when it is determined not to be required, but being able to toggle it on later, would be ideal. These “feature flags” (a simplification bordering on misuse) can be further described as constants within Flux - giving an additional layer of warning against deprecation as well as a fast way to search for places where FluidTYPO3 uses the feature flag.

Most of the implementation-controlling attributes can be automatically detected by class name conventions as well (which is why the keys in the “implementation” object are not FQNs, rather identifiers!), for example allowing Flux to resolve an expected Form class name based on the $vendor that’s specified in this manifest.

By making the vendor name the only absolutely required setting we guarantee that class name convention based lookups can function without the additional configuration defining the expected class name. Only when the class names differ from convention, or when extension A wishes to use a certain implementation provided by extension B, for example a custom Form class name, is the additional configuration of implementations required.

Although one might argue that overriding default values of ViewHelper arguments might first of all not make a lot of sense to define in a manifest like this, second of all should be natively supported by the core… with that considered, it makes a lot of sense to integrate this in a “Package” style concept - and since there is no such concept in the core (yet) we may as well provide it in Flux. The overrides defined here are every bit as possible using “just” PHP (for example via a controller that manipulates the view’s ViewHelperResolver) but are allowed here because controllers in Flux are optional. Our ViewHelperResolver implementation then takes care of modifying these directly via ArgumentDefinitions.

And lastly: by incorporating the CompatibilityRegistry in the seeding of FluxPackages we can allow seeding with different values according to minimum TYPO3 version - without ever touching PHP. and having every root variable right in the same file as your version based overrides.

Applesauce!

### Suggested FluxPackage interface:

	interface FluxPackageInterface {
	  public function __construct($seedArrayOrExtensionKeyOrManifestPath) : void;
	  public function getVendorName() : string;
	  public function getExtensionName() : string;
	  public function getViewPaths() : TemplatePaths;
	  public function isProviderFor($controllerName) : boolean;
	  public function isFeatureEnabled($featureName) : boolean;
	  public function getImplementation($implementationName) : object;
	  public function modify(array $alternativeManifestDeclaration) : FluxPackageInterface;
	}

There’s not a whole lot to explain here, but what should be explained is:

* getViewPaths() will return an instance of TemplatePaths; this is for ease of use (such as chaining calls to read partial paths or resolve a specific template file via FluxPackage).
* Default implementations of isProviderFor() and isFeatureEnabled() will check in the arrays defined in the manifest, if not defined, then attempt to resolve a general yes/no verdict.
* getImplementation() always returns a viable instance of the correct type; or fails hard with an exception about the nature of the problem (desired class missing/unloadable, not of the correct type, etc.)
* modify() returns self simply to allow easy chaining - the original instance is also modified.

Together these functions provide a reliable API for the features that consume Provider Extensions.

### Page context awareness

Since TYPO3 uses the page context to allow TypoScript, pageTSconfig etc. to be changed per page, Flux will do the same and allow the attributes of a given FluxPackage to be manipulated directly via TypoScript and fetching via ConfigurationManager. Any request that then has a page UID as context will then automatically use the TS which applies - and to handle this, a method similar to the modify() method on Form components: accepting an array of input (structured identically to the JSON manifest) which then merges with any already loaded attribute values, overriding ones that were previously set.

This particular feature is likely to be infrequently used but, I expect, should become quite popular with multisite setups (in which each branch could customise how each Provider Extension works under that branch). It also is one more way for Flux to erase the boundaries between PHP, TS, Fluid and a handful of TYPO3 core APIs.

### Footnotes

[1] By wrapping all current ways Flux ingests these manifest properties in a common class which delivers default implementations for all features depending on detected classes/files, we can completely replace all current usages with this FluxPackage concept from day one. We would merely need to have this default FluxPackage to seed itself with Provider controller names etc. that were registered via FluidTYPO3\Flux\Core - which we can then deprecate, or keep as wrapper API for an indefinite time.