### PR TITLE
[BUGFIX] Missing 'TCEforms' wrapping on fields in flexform datastructure

### DIFF
--- a/Classes/Form/AbstractFormField.php
+++ b/Classes/Form/AbstractFormField.php
@@ -217,6 +217,9 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
 		if (TRUE === $this->getRequestUpdate()) {
 			$fieldStructureArray['onChange'] = 'reload';
 		}
+		// We need a TCEforms wrap
+		$fieldStructureArray = array('TCEforms' => $fieldStructureArray);
+
 		return $fieldStructureArray;
 	}
 

--- a/Tests/Unit/Form/Field/AbstractFieldTest.php
+++ b/Tests/Unit/Form/Field/AbstractFieldTest.php
@@ -171,7 +171,7 @@ abstract class AbstractFieldTest extends AbstractFormTest {
 		$instance = $this->createInstance();
 		$instance->setClearable(TRUE);
 		$result = $this->performTestBuild($instance);
-		$this->assertNotEmpty($result['config']['wizards']);
+		$this->assertNotEmpty($result['TCEforms']['config']['wizards']);
 	}
 
 	/**

--- a/Tests/Unit/Form/Field/TextTest.php
+++ b/Tests/Unit/Form/Field/TextTest.php
@@ -64,7 +64,7 @@ class TextTest extends InputTest {
 		$instance = $this->createInstance();
 		$instance->setDefaultExtras(NULL)->setEnableRichText(TRUE);
 		$result = $this->performTestBuild($instance);
-		$this->assertArrayHasKey('defaultExtras', $result['config']);
+		$this->assertArrayHasKey('defaultExtras', $result['TCEforms']['config']);
 	}
 
 	/**
@@ -75,7 +75,7 @@ class TextTest extends InputTest {
 		$instance = $this->createInstance();
 		$instance->setDefaultExtras('richtext[*]');
 		$result = $this->performTestBuild($instance);
-		$this->assertNotEmpty($result['defaultExtras']);
+		$this->assertNotEmpty($result['TCEforms']['defaultExtras']);
 	}
 
 }


### PR DESCRIPTION
see also my comment on 0aaa843287c175cf506c7693974a633c2e71bd58

Exception on saving changed data when using a select field with renderType "selectCheckBox". The form data for the select field is an array but must converted to a string.

Without the TCEformsthere there is no conversion and we got an exception.