### PR TITLE
[BUGFIX] Update ListViewHelper.php

### DIFF
--- a/Classes/ViewHelpers/Wizard/ListViewHelper.php
+++ b/Classes/ViewHelpers/Wizard/ListViewHelper.php
@@ -33,7 +33,7 @@ class ListViewHelper extends AbstractWizardViewHelper {
 	 * @param array $arguments
 	 * @return ListWizard
 	 */
-	public function getComponent(RenderingContextInterface $renderingContext, array $arguments) {
+	public static function getComponent(RenderingContextInterface $renderingContext, array $arguments) {
 		/** @var ListWizard $component */
 		$component = static::getPreparedComponent('ListWizard', $renderingContext, $arguments);
 		$component->setTable($arguments['table']);


### PR DESCRIPTION
Hi,

I get the following error after I try to open the Page Configuration:

``` PHP Runtime Deprecation Notice: Non-static method FluidTYPO3\Flux\ViewHelpers\Wizard\ListViewHelper::getComponent() should not be called statically in /var/www/webroot/typo3conf/ext/flux/Classes/ViewHelpers/AbstractFormViewHelper.php line 46```

I don't know if this is the correct fix, but every other viewhelper ```getComponent``` is static too