### PR TITLE
[TASK] Add option to set internalType on File

### DIFF
--- a/Classes/Form/Field/File.php
+++ b/Classes/Form/Field/File.php
@@ -42,6 +42,11 @@ class File extends AbstractMultiValueFormField {
 	protected $showThumbnails = FALSE;
 
 	/**
+	 * @var string
+	 */
+	protected $internalType = 'file';
+
+	/**
 	 * @return array
 	 */
 	public function buildConfiguration() {
@@ -49,7 +54,7 @@ class File extends AbstractMultiValueFormField {
 		$configuration['disallowed'] = $this->getDisallowed();
 		$configuration['allowed'] = $this->getAllowed();
 		$configuration['max_size'] = $this->getMaxSize();
-		$configuration['internal_type'] = 'file';
+		$configuration['internal_type'] = $this->getInternalType();
 		$configuration['uploadfolder'] = $this->getUploadFolder();
 		$configuration['show_thumbs'] = $this->getShowThumbnails();
 		return $configuration;
@@ -157,6 +162,22 @@ class File extends AbstractMultiValueFormField {
 	 */
 	public function getShowThumbnails() {
 		return (boolean) $this->showThumbnails;
+	}
+
+	/**
+	 * @param string $internalType
+	 * @return File
+	 */
+	public function setInternalType($internalType) {
+		$this->internalType = $internalType;
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getInternalType() {
+		return $this->internalType;
 	}
 
 }

--- a/Classes/ViewHelpers/Field/FileViewHelper.php
+++ b/Classes/ViewHelpers/Field/FileViewHelper.php
@@ -38,6 +38,7 @@ class FileViewHelper extends AbstractMultiValueFieldViewHelper {
 		$this->registerArgument('disallowed', 'string', 'Defines a list of file types NOT allowed in this field');
 		$this->registerArgument('uploadFolder', 'string', 'Upload folder. DEPRECATED, will be moved to the File field ViewHelper');
 		$this->registerArgument('showThumbnails', 'boolean', 'If TRUE, displays thumbnails for selected values', FALSE, FALSE);
+		$this->registerArgument('internalType', 'string', 'sets the internal type of this field', FALSE, 'file');
 	}
 
 	/**
@@ -53,6 +54,7 @@ class FileViewHelper extends AbstractMultiValueFieldViewHelper {
 		$component->setAllowed($arguments['allowed']);
 		$component->setUploadFolder($arguments['uploadFolder']);
 		$component->setShowThumbnails($arguments['showThumbnails']);
+		$component->setInternalType($arguments['internalType']);
 		return $component;
 	}
 


### PR DESCRIPTION
This option enables to set the internalType on the file field in order to change the "storage" of the
field to fal id instead of a path by setting it to "db". By default it's set to "file", which is the same as it
has been so far.