### PR TITLE
[BUGFIX] Data Structure ERROR: No ['ROOT']['el'] element found in ...

### DIFF
--- a/Classes/Backend/DynamicFlexForm.php
+++ b/Classes/Backend/DynamicFlexForm.php
@@ -100,7 +100,7 @@ class DynamicFlexForm {
 				$dataStructure[$index] = $this->patchTceformsWrapper($subStructure, $index);
 			}
 		}
-		if (isset($dataStructure['config']) && $parentIndex !== 'TCEforms') {
+		if (isset($dataStructure['config']['type']) && $parentIndex !== 'TCEforms') {
 			$dataStructure = array('TCEforms' => $dataStructure);
 		}
 		return $dataStructure;


### PR DESCRIPTION
flexform definition.

Only wrapping with 'TCEforms' if inside a 'config' definition exists a 'type' definition.
Prevend wrapping with 'TCEforms' if  'config' is used as fieldname or sheetname.