### PR TITLE
[BUGFIX] Fix translation Handling

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -302,6 +302,7 @@ class ContentService implements SingletonInterface {
 						// set $translatedParent to the right language ($newLanguageUid):
 						break;
 					}
+					unset($translatedParent);
 				}
 				$sortbyFieldName = TRUE === isset($GLOBALS['TCA']['tt_content']['ctrl']['sortby']) ?
 					$GLOBALS['TCA']['tt_content']['ctrl']['sortby'] : 'sorting';


### PR DESCRIPTION
The ContentService always "fell back" to the default sys_language_uid
content element to fill out the "tx_flux_parent" column, when you
translate a content element. This produces more problems down the line,
etc. This Change fixes that behavior, by unsetting the translatedParent
variable if no matching translatedParent was found.