### PR TITLE
[BUGFIX] workspaces/nested elements - resolved the problem with incorrect pid …

### DIFF
--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -250,6 +250,10 @@ class PreviewView {
 		$content = '';
 		if (TRUE === $grid->hasChildren()) {
 			$workspaceVersionOfRow = $this->workspacesAwareRecordService->getSingle('tt_content', '*', $row['uid']);
+			if ($workspaceVersionOfRow['pid'] == -1 && $workspaceVersionOfRow['t3ver_oid']) {
+				$orgRecord = BackendUtility::getRecord('tt_content', $workspaceVersionOfRow['t3ver_oid'], '*', '', FALSE);
+				$workspaceVersionOfRow['pid'] = $orgRecord['pid'];
+			}
 			$content = $this->drawGrid($workspaceVersionOfRow, $grid, $form);
 
 			$options = $this->getPreviewOptions($form);

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -407,7 +407,7 @@ class PreviewView {
 			'uid_pid' => $after,
 			'colPos' => ContentService::COLPOS_FLUXCONTENT,
 			'sys_language_uid' => $row['sys_language_uid'],
-			'defVals[tt_content][tx_flux_parent]' => $row['uid'],
+			'defVals[tt_content][tx_flux_parent]' => $this->getFluxParentUid($row),
 			'defVals[tt_content][tx_flux_column]' => $columnName,
 			'returnUrl' => $returnUri
 		));
@@ -456,7 +456,7 @@ class PreviewView {
 		// and relies on TYPO3 core query parts for enable-clause-, language- and versioning placeholders. All that needs
 		// to be done after this, is filter the array according to moved/deleted placeholders since TYPO3 will not remove
 		// records based on them having remove placeholders.
-		$condition = "AND tx_flux_parent = '" . $row['uid'] . "' AND tx_flux_column = '" . $area . "' ";
+		$condition = "AND tx_flux_parent = '" . $this->getFluxParentUid($row) . "' AND tx_flux_column = '" . $area . "' ";
 		$condition .= "AND colPos = '" . ContentService::COLPOS_FLUXCONTENT . "' ";
 		$condition .= (1 === $view->tt_contentConfig['showHidden']) ? '' : 'AND hidden = 0 ';
 		$queryParts = $view->makeQueryArray('tt_content', $row['pid'], $condition);
@@ -623,6 +623,14 @@ class PreviewView {
 		$integer = MiscellaneousUtility::generateUniqueIntegerForFluxArea($contentElementUid, $areaName);
 		$_SESSION['target' . $integer] = array($contentElementUid, $areaName);
 		return $integer;
+	}
+
+	/**
+	 * @param array $row
+	 * @return mixed
+	 */
+	protected function getFluxParentUid(array $row) {
+		return $row['t3ver_oid'] ?  $row['t3ver_oid'] : $row['uid'];
 	}
 
 	/**


### PR DESCRIPTION
ENV:
- TYPO3 6.2.17
- FLUX 7.2.3
- FLUIDPAGES 3.3.1
- FLUIDCONTENT 4.3.3


I have the nested structure of elements ![workspaces_nested_el_1](https://cloud.githubusercontent.com/assets/1465174/13008552/3a0bb276-d197-11e5-8cf7-3bf68c28c804.png). When I try add new elements (for ex: text + image) I get blank page ![workspaces_nested_el_2](https://cloud.githubusercontent.com/assets/1465174/13008551/3a0b28b0-d197-11e5-9ebf-5b041b9da41b.png). Both elements were created in workspace, so I have 2 records: ![workspaces_nested_el_3](https://cloud.githubusercontent.com/assets/1465174/13008554/3a0d4708-d197-11e5-8014-4455730a5466.png)

Wrapper: http://pastebin.com/EAN20M3b
Columns: http://pastebin.com/r1UXaS5Z

The problem is with access to page where I want to add new elements. Exactly here typo3/sysext/backend/Classes/Controller/ContentElement/NewContentElementController.php: 140 / 

if ($this->id && $this->access) {
 //...
}

I found that the source my problems could be link to "create new element". Flux generates wrong links: ![workspaces_nested_el_4](https://cloud.githubusercontent.com/assets/1465174/13008553/3a0bd09e-d197-11e5-9235-6e350ab1e11d.png) and TYPO3 can't check correct access to page (in my case with pid = 6).

Links are generated by 2 methods: getNewLink and getNewLinkLegacy: typo3conf/ext/flux/Classes/View/PreviewView.php - executed by renderGrid(..) and next methods. Flux retrieves the correct record but doesn't check it if the record is in workspace. 
I've added additional condition which checks if the record is in workspace mode (if is, returns the base record).

What do you think ? Have anybody had similar problems with workspaces and nested elements ?