### PR TITLE
[TASK] Check invalid characters in names

### DIFF
--- a/Classes/Form/AbstractFormComponent.php
+++ b/Classes/Form/AbstractFormComponent.php
@@ -24,6 +24,7 @@ use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
+
 /**
  * AbstractFormComponent
  */
@@ -165,6 +166,9 @@ abstract class AbstractFormComponent implements FormInterface {
 	 * @return FormInterface
 	 */
 	public function setName($name) {
+        if (TYPO3_MODE === 'FE' && $this->hasIlegalChars($name)) {
+            throw new \Exception('Names must not use \'|\' or \'-\' characters! Given was "' . $name . '".');
+        }
 		$this->name = $name;
 		return $this;
 	}
@@ -503,5 +507,17 @@ abstract class AbstractFormComponent implements FormInterface {
 		}
 		return $structure;
 	}
+    
+    /**
+     * Tests if a given identfier uses illegal characters
+     * 
+     * @param string $str String to check
+     * @return boolean
+     */
+    protected function hasIlegalChars($str)
+    {
+        $pattern = '/[\-\|]+/';
+        return preg_match($pattern, $str);
+    }
 
 }


### PR DESCRIPTION
Please see the attached file. When flux columns contain hyphens or pipes in their name you get problems when moving content elements in the backend. E.g. if you paste an element to "column-2" it gets saved as "column" in the database. The reason is that the parameters for this action are seperated with hyphens and pipes. One possible solution would be to urldecode and encode the parameters. Another would be to give the developer at least a hint, so that he can correct this. I implemented a check for hyphens and pipes in the name and if so an exception will be thrown in frontend.

[ColThree.txt](https://github.com/FluidTYPO3/flux/files/130292/ColThree.txt)

