### PR TITLE
TASK] Change expected exception message from NULL to empty string

### DIFF
--- a/Tests/Unit/Form/Field/AbstractFieldTest.php
+++ b/Tests/Unit/Form/Field/AbstractFieldTest.php
@@ -123,7 +123,7 @@ abstract class AbstractFieldTest extends AbstractFormTest {
 	public function throwsExceptionOnInvalidFieldTypeWhenCreatingFromDefinition() {
 		$properties = $this->chainProperties;
 		$properties['type'] = 'InvalidType';
-		$this->setExpectedException('RuntimeException', NULL, 1375373527);
+		$this->setExpectedException('RuntimeException', '', 1375373527);
 		call_user_func_array(array($this->getObjectClassName(), 'create'), array($properties));
 	}
 

--- a/Tests/Unit/Helper/ResolveUtilityTest.php
+++ b/Tests/Unit/Helper/ResolveUtilityTest.php
@@ -75,7 +75,7 @@ class ResolveUtilityTest extends AbstractTestCase {
 	 */
 	public function throwsExceptionForClassIfSetToHardFail() {
 		$resolver = new Resolver();
-		$this->setExpectedException('RuntimeException', NULL, 1364498093);
+		$this->setExpectedException('RuntimeException', '', 1364498093);
 		$resolver->resolveFluxControllerClassNameByExtensionKeyAndAction('FluidTYPO3.Flux', 'render', 'Void', TRUE);
 	}
 
@@ -84,7 +84,7 @@ class ResolveUtilityTest extends AbstractTestCase {
 	 */
 	public function throwsExceptionForActionIfSetToHardFail() {
 		$resolver = new Resolver();
-		$this->setExpectedException('RuntimeException', NULL, 1364498223);
+		$this->setExpectedException('RuntimeException', '', 1364498223);
 		$resolver->resolveFluxControllerClassNameByExtensionKeyAndAction('FluidTYPO3.Flux', 'void', 'Content', FALSE, TRUE);
 	}
 

--- a/Tests/Unit/Outlet/Pipe/TypeConverterPipeTest.php
+++ b/Tests/Unit/Outlet/Pipe/TypeConverterPipeTest.php
@@ -44,7 +44,7 @@ class TypeConverterPipeTest extends AbstractPipeTestCase {
 		$converter = $this->objectManager->get($converterClass);
 		$instance->setTypeConverter($converter);
 		$instance->setTargetType('TYPO3\CMS\Domain\Model\FrontendUser');
-		$this->setExpectedException('FluidTYPO3\Flux\Outlet\Pipe\Exception', NULL, 1386292424);
+		$this->setExpectedException('FluidTYPO3\Flux\Outlet\Pipe\Exception', '', 1386292424);
 		$instance->conduct($this->defaultData);
 	}
 
@@ -72,7 +72,7 @@ class TypeConverterPipeTest extends AbstractPipeTestCase {
 		$converter = $this->objectManager->get($converterClass);
 		$instance->setTypeConverter($converter);
 		$instance->setTargetType('DateTime');
-		$this->setExpectedException('TYPO3\CMS\Extbase\Property\Exception\TypeConverterException', NULL, 1308003914);
+		$this->setExpectedException('TYPO3\CMS\Extbase\Property\Exception\TypeConverterException', '', 1308003914);
 		$instance->conduct(array());
 	}
 

--- a/Tests/Unit/View/ExposedTemplateViewTest.php
+++ b/Tests/Unit/View/ExposedTemplateViewTest.php
@@ -126,7 +126,7 @@ class ExposedTemplateViewTest extends AbstractTestCase {
 	 */
 	public function throwsRuntimeExceptionIfImproperlyInitialized() {
 		$view = $this->objectManager->get('FluidTYPO3\Flux\View\ExposedTemplateView');
-		$this->setExpectedException('RuntimeException', NULL, 1343521593);
+		$this->setExpectedException('RuntimeException', '', 1343521593);
 		$this->callInaccessibleMethod($view, 'getStoredVariable', 'FluidTYPO3\Flux\ViewHelpers\FormViewHelper', 'storage');
 	}
 

--- a/Tests/Unit/ViewHelpers/Field/ControllerActionsViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Field/ControllerActionsViewHelperTest.php
@@ -76,7 +76,7 @@ class ControllerActionsViewHelperTest extends AbstractFieldViewHelperTestCase {
 			'subActions' => array()
 		);
 		$instance = $this->buildViewHelperInstance($arguments, array(), NULL, $arguments['extensionName'], $arguments['pluginName']);;
-		$this->setExpectedException('RuntimeException', NULL, 1346514748);
+		$this->setExpectedException('RuntimeException', '', 1346514748);
 		$instance->initializeArgumentsAndRender();
 	}
 	/**


### PR DESCRIPTION
ENV:
- PHPUnit 5.2.5
- PHP 5.6.11

I have 23 errors when run phpunit on clean repo: "FAILURES!
Tests: 1702, Assertions: 3653, Errors: 23." All errors refers to incorrect expected value.