### PR TITLE
Update TemplatePaths.php

### DIFF
--- a/Classes/View/TemplatePaths.php
+++ b/Classes/View/TemplatePaths.php
@@ -344,14 +344,14 @@ class TemplatePaths {
 			}
 		}
 		// last appended if set: the legacy singular paths configuration
-		if (TRUE === isset($paths[self::CONFIG_TEMPLATEROOTPATH])) {
-			$templateRootPaths[] = $paths[self::CONFIG_TEMPLATEROOTPATH];
+		if (TRUE === isset($paths[self::CONFIG_TEMPLATEROOTPATH])) {			
+			$templateRootPaths = array_merge($templateRootPaths,$paths[self::CONFIG_TEMPLATEROOTPATH]);
 		}
-		if (TRUE === isset($paths[self::CONFIG_LAYOUTROOTPATH])) {
-			$layoutRootPaths[] = $paths[self::CONFIG_LAYOUTROOTPATH];
+		if (TRUE === isset($paths[self::CONFIG_LAYOUTROOTPATH])) {			
+			$layoutRootPaths = array_merge($layoutRootPaths,$paths[self::CONFIG_LAYOUTROOTPATH]);			
 		}
-		if (TRUE === isset($paths[self::CONFIG_PARTIALROOTPATH])) {
-			$partialRootPaths[] = $paths[self::CONFIG_PARTIALROOTPATH];
+		if (TRUE === isset($paths[self::CONFIG_PARTIALROOTPATH])) {			
+			$partialRootPaths = array_merge($partialRootPaths,$paths[self::CONFIG_PARTIALROOTPATH]);
 		}
 		// translate all paths to absolute paths
 		$templateRootPaths = array_map(array($this, 'ensureAbsolutePath'), $templateRootPaths);


### PR DESCRIPTION
Core: Error handler (FE): PHP Warning: rtrim() expects parameter 1 to be string, array given in /home/www/doc/9007/*/typo3conf/ext/flux/Classes/View/TemplatePaths.php line 308

$paths[self::CONFIG_LAYOUTROOTPATH] is an array and not correct pushed on $layoutRootPaths.