### PR TITLE
Wrong order of parameters in compile function

### DIFF
--- a/Classes/ViewHelpers/VariableViewHelper.php
+++ b/Classes/ViewHelpers/VariableViewHelper.php
@@ -57,7 +57,7 @@ class VariableViewHelper extends AbstractViewHelper implements CompilableInterfa
 			TemplateCompiler $templateCompiler) {
 		return sprintf(
 			'\\TYPO3\\CMS\\Extbase\\Reflection\\ObjectAccess::getPropertyPath(' .
-			'%s[\'name\'], $renderingContext->getTemplateVariableContainer()->getAll())',
+			'$renderingContext->getTemplateVariableContainer()->getAll(), %s[\'name\'])',
 			$argumentsVariableName
 		);
 	}


### PR DESCRIPTION
The code returned from the compile function had a wrong order of parameters.