### PR TITLE
[BUGFIX] Add section=1 in structure for container

### DIFF
--- a/Classes/Form/Container/Container.php
+++ b/Classes/Form/Container/Container.php
@@ -24,6 +24,7 @@ class Container extends AbstractFormContainer implements ContainerInterface, Fie
 	public function build() {
 		$structureArray = array(
 			'type' => 'array',
+			'section' => '1',
 			'title' => $this->getLabel(),
 			'el' => $this->buildChildren($this->children)
 		);


### PR DESCRIPTION
Related to https://github.com/FluidTYPO3/flux/issues/992
Type array without section creates an Exception

typo3/cms/sysex/backend/Classes/Form/FormDataProvider/TcaFlexProcess.php
```
            foreach ($dataStructureSheetElements as $dataStructureSheetElementName => $dataStructureSheetElementDefinition) {
                if (isset($dataStructureSheetElementDefinition['type']) && $dataStructureSheetElementDefinition['type'] === 'array'
                    && isset($dataStructureSheetElementDefinition['section']) && (string)$dataStructureSheetElementDefinition['section'] === '1'
                ) {
                /* .... */
                } elseif (isset($dataStructureSheetElementDefinition['type']) || isset($dataStructureSheetElementDefinition['section'])) {
                    throw new \UnexpectedValueException(
                        'Broken data structure on field name ' . $fieldName . '. section without type or vice versa is not allowed',
                        1440685208
                    );
```

Solution: Just add 'section' => '1', to the $structureArray