### PR TITLE
[BUGFIX] Range has been inserted for each field in the TCA. 

### DIFF
--- a/Classes/Form/Field/Input.php
+++ b/Classes/Form/Field/Input.php
@@ -54,10 +54,10 @@ class Input extends AbstractFormField implements FieldInterface {
 		$configuration['size'] = $this->getSize();
 		$configuration['max'] = $this->getMaxCharacters();
 		$configuration['eval'] = $validate;
-		if ($minimum >= 0 || $maximum >= 0 && in_array('int', GeneralUtility::trimExplode(',', $validate))) {
+		if (NULL !== $minimum && NULL !== $maximum && in_array('int', GeneralUtility::trimExplode(',', $validate))) {
 			$configuration['range'] = array(
 				'lower' => $minimum,
-				'upper' => $maximum,
+				'upper' => $maximum
 			);
 		}
 		return $configuration;


### PR DESCRIPTION
Whether it was defined or not.

if using <flux:field.input .../> without maximum and minimum, then NULL was used for upper and lower in the range definition.

Since commit https://github.com/TYPO3/TYPO3.CMS/commit/c6d12307dc1de297e373126c181e013216774e6a
this results into an error in the FormEngineValidation.js. NULL is converted to '0'.
A range test of lower 0 to upper 0 will be done and marks the field as not valid if the value is not 0.

There is also a wrong check with the test on $minimum >= 0 or $maximum >= 0. Now it is possible to use negative values for minimum or maximum.