### PR TITLE
[FEATURE] Add showIconTable option to select component

### DIFF
--- a/Classes/Form/Field/Select.php
+++ b/Classes/Form/Field/Select.php
@@ -59,11 +59,20 @@ class Select extends AbstractMultiValueFormField {
 	protected $renderType = 'selectSingle';
 
 	/**
+	 * Displays option icons as table beneath the select.
+	 *
+	 * @var boolean
+	 * @see https://docs.typo3.org/typo3cms/TCAReference/Reference/Columns/Select/Index.html#showicontable
+	 */
+	protected $showIconTable = FALSE;
+
+	/**
 	 * @return array
 	 */
 	public function buildConfiguration() {
 		$configuration = parent::prepareConfiguration('select');
 		$configuration['items'] = $this->getItems();
+		$configuration['showIconTable'] = $this->getShowIconTable();
 		return $configuration;
 	}
 
@@ -194,6 +203,22 @@ class Select extends AbstractMultiValueFormField {
 		$labelField = $GLOBALS['TCA'][$table]['ctrl']['label'];
 		$propertyName = GeneralUtility::underscoredToLowerCamelCase($labelField);
 		return $propertyName;
+	}
+
+	/**
+	 * @return boolean
+	 */
+	public function getShowIconTable() {
+		return $this->showIconTable;
+	}
+
+	/**
+	 * @param boolean $showIconTable
+	 * @return Select
+	 */
+	public function setShowIconTable($showIconTable) {
+		$this->showIconTable = $showIconTable;
+		return $this;
 	}
 
 }

--- a/Classes/ViewHelpers/Field/SelectViewHelper.php
+++ b/Classes/ViewHelpers/Field/SelectViewHelper.php
@@ -48,6 +48,7 @@ class SelectViewHelper extends AbstractMultiValueFieldViewHelper {
 		$this->registerArgument('emptyOption', 'mixed', 'If not-FALSE, adds one empty option/value pair to the generated selector box and tries to use this property\'s value (cast to string) as label.', FALSE, FALSE);
 		$this->registerArgument('translateCsvItems', 'boolean', 'If TRUE, attempts to resolve a LLL label for each value provided as CSV in "items" attribute using convention for lookup "$field.option.123" if given "123" as CSV item value. Field name is determined by normal Flux field name conventions');
 		$this->registerArgument('renderType', 'string', 'Rendering type as applies in FormEngine/TCA', FALSE, 'selectSingle');
+		$this->registerArgument('showIconTable', 'boolean', 'If TRUE shows the option icons as table beneath the select', FALSE, FALSE);
 	}
 
 	/**
@@ -62,6 +63,7 @@ class SelectViewHelper extends AbstractMultiValueFieldViewHelper {
 		$component->setEmptyOption($arguments['emptyOption']);
 		$component->setTranslateCsvItems((boolean) $arguments['translateCsvItems']);
 		$component->setRenderType($arguments['renderType']);
+		$component->setShowIconTable($arguments['showIconTable']);
 		return $component;
 	}
 


### PR DESCRIPTION
Adds a new argument „showIconTable“ to SelectViewHelper and
corresponding property to FluidTYPO3\Flux\Form\Field\Select to display
a table of option icons beneath the select.

We like to use this to give the user an easy way to select colors from their color scheme.

![bildschirmfoto 2016-04-19 um 13 42 49](https://cloud.githubusercontent.com/assets/1384345/14638089/e1e83992-0635-11e6-985b-97ff111b3da0.png)
