### PR TITLE
[BUGFIX] Fix getTranslateCsvItems for Select field

### DIFF
--- a/Classes/Form/Field/Select.php
+++ b/Classes/Form/Field/Select.php
@@ -116,10 +116,7 @@ class Select extends AbstractMultiValueFormField {
 				}
 			} else {
 				foreach ($itemNames as $itemName) {
-					$resolvedLabel = $this->resolveLocalLanguageValueOfLabel('', $this->name . '.option.' . $itemName);
-					if (0 === strpos($resolvedLabel, 'LLL:') ) {
-						$resolvedLabel = $itemName;
-					}
+					$resolvedLabel = $this->resolveLocalLanguageValueOfLabel('', $this->getPath() . '.option.' . $itemName);
 					array_push($items, array($resolvedLabel, $itemName));
 				}
 			}

--- a/Tests/Unit/Form/Field/SelectTest.php
+++ b/Tests/Unit/Form/Field/SelectTest.php
@@ -115,4 +115,31 @@ class SelectTest extends AbstractFieldTest {
 		$this->assertEquals($table . 'label', $propertyName);
 	}
 
+
+	/**
+	 * @test
+	 */
+	public function translateCsvItems() {
+		$instance = $this->createInstance();
+		$instance->setExtensionName('flux');
+
+		$form = $this->objectManager->get('FluidTYPO3\Flux\Form');
+		$form->add($instance);
+		$form->setName('parent');
+		$instance->setName('child');
+		$form->add($instance);
+
+		$instance->setItems('foo,bar');
+		$this->assertEquals(array(array('foo', 'foo'), array('bar', 'bar')), $instance->getItems());
+		$instance->setTranslateCsvItems(TRUE);
+
+		$expected = array(
+			array('LLL:EXT:flux/Resources/Private/Language/locallang.xlf:flux.parent.fields.child.option.foo', 'foo'),
+			array('LLL:EXT:flux/Resources/Private/Language/locallang.xlf:flux.parent.fields.child.option.bar', 'bar')
+		);
+
+		$this->assertEquals($expected, $instance->getItems());
+	}
+
+
 }


### PR DESCRIPTION
This broke since the generated language path was no longer correct (`$this->name` vs. `$this->getPath()`), as well as the change in `resolveLocalLanguageValueOfLabel` to no longer actually translate the resolved identifiers. Previously, it was checked whether the `$resolvedLabel` was translated or not, and if not, it fell back to using the `$itemName`. Since `resolveLocalLanguageValueOfLabel` now always returns a string starting w/ `LLL:`, this check has been dropped and the label will be empty if no translation is found.