### PR TITLE
[BUGFIX] The label names are generated wrong.

### DIFF
--- a/Classes/Form.php
+++ b/Classes/Form.php
@@ -326,7 +326,7 @@ class Form extends Form\AbstractFormContainer implements Form\FieldContainerInte
 			$relativeFilePath = $this->getLocalLanguageFileRelativePath();
 			$relativeFilePath = ltrim($relativeFilePath, '/');
 			$filePrefix = 'LLL:EXT:' . $extensionKey . '/' . $relativeFilePath;
-			$description = $filePrefix . ':' . trim('flux.form.' . $this->id . '.description');
+			$description = $filePrefix . ':' . trim('flux.' . $this->id . '.description');
 		}
 		return $description;
 	}

--- a/Classes/Form/AbstractFormComponent.php
+++ b/Classes/Form/AbstractFormComponent.php
@@ -281,7 +281,7 @@ abstract class AbstractFormComponent implements FormInterface {
 			return $label;
 		}
 		if ($this instanceof Form) {
-			return $filePrefix . ':flux.form.' . $this->getName();
+			return $filePrefix . ':flux.' . $this->getName();
 		}
 		$root = $this->getRoot();
 		$id = $root->getName();

--- a/Tests/Unit/Backend/TableConfigurationPostProcessorTest.php
+++ b/Tests/Unit/Backend/TableConfigurationPostProcessorTest.php
@@ -46,7 +46,7 @@ class TableConfigurationPostProcessorTest extends AbstractTestCase {
 		$this->assertContains($field, $GLOBALS['TCA'][$table]['interface']['showRecordFieldList']);
 		$this->assertContains($field, $GLOBALS['TCA'][$table]['types'][0]['showitem']);
 		$this->assertEquals($GLOBALS['TCA'][$table]['ctrl']['label'], 'title');
-		$this->assertContains('flux.form.this_table_does_not_exist', $GLOBALS['TCA'][$table]['ctrl']['title']);
+		$this->assertContains('flux.this_table_does_not_exist', $GLOBALS['TCA'][$table]['ctrl']['title']);
 	}
 
 	/**


### PR DESCRIPTION
Remove 'form' from the label name, otherwise existing labels are no longer recognized.

see comments in https://github.com/FluidTYPO3/flux/commit/41cb134fe6a2ce2bac05fd04152ab5c392ceaba9