### PR TITLE
[BUGFIX] Fix overriding static w/ non-static

### DIFF
--- a/Classes/ViewHelpers/Field/RadioViewHelper.php
+++ b/Classes/ViewHelpers/Field/RadioViewHelper.php
@@ -21,7 +21,7 @@ class RadioViewHelper extends SelectViewHelper {
 	/**
 	 * @return Checkbox
 	 */
-	public function getComponent() {
+	public static function getComponent() {
 		/** @var Radio $component */
 		$component = $this->getPreparedComponent('Radio');
 		$component->setItems($this->arguments['items']);


### PR DESCRIPTION
`SelectViewHelper`'s getComponent() function is static. This one was not :D