### PR TITLE
[BUGFIX] Always cache TypoScript config in FluxService

### DIFF
--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -353,17 +353,22 @@ class FluxService implements SingletonInterface {
 	 * @return array
 	 */
 	public function getAllTypoScript() {
-		if (!$this->configurationManager instanceof BackendConfigurationManager) {
-			$typoScript = (array) $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
-			$typoScript = GeneralUtility::removeDotsFromTS($typoScript);
-			return $typoScript;
+		$pageId = $this->getCurrentPageId();
+		if (FALSE === isset(self::$typoScript[$pageId])) {
+			self::$typoScript[$pageId] = (array) $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+			self::$typoScript[$pageId] = GeneralUtility::removeDotsFromTS(self::$typoScript[$pageId]);
+		}
+		return (array) self::$typoScript[$pageId];
+	}
+
+	/**
+	 * @return integer
+	 */
+	protected function getCurrentPageId() {
+		if ($this->configurationManager instanceof BackendConfigurationManager) {
+			return (integer) $this->configurationManager->getCurrentPageId();
 		} else {
-			$pageId = $this->configurationManager->getCurrentPageId();
-			if (FALSE === isset(self::$typoScript[$pageId])) {
-				self::$typoScript[$pageId] = (array) $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
-				self::$typoScript[$pageId] = GeneralUtility::removeDotsFromTS(self::$typoScript[$pageId]);
-			}
-			return (array) self::$typoScript[$pageId];
+			return (integer) $GLOBALS['TSFE']->id;
 		}
 	}
 

--- a/Tests/Unit/Service/FluxServiceTest.php
+++ b/Tests/Unit/Service/FluxServiceTest.php
@@ -339,4 +339,18 @@ class FluxServiceTest extends AbstractTestCase {
 		);
 	}
 
+	/**
+	 * @test
+	 */
+	public function testGetAllTypoScriptCache() {
+		$fluxService = $this->createFluxServiceInstance(array('getCurrentPageId'));
+
+		$configurationManager = $this->getMock('FluidTYPO3\Flux\Configuration\ConfigurationManager', array('getConfiguration'));
+		$fluxService->injectConfigurationManager($configurationManager);
+		$configurationManager->expects($this->once())->method('getConfiguration');
+
+		$this->assertNotNull($fluxService->getAllTypoScript());
+		$this->assertNotNull($fluxService->getAllTypoScript());
+	}
+
 }


### PR DESCRIPTION
Previously, #getAllTypoScript did not cache the configuration when
called from the frontend. This resulted in a rather large performance
overhead, since #removeDotsFromTS was called repeatedly. This commit
modifies the behaviour such that the configuration is always cached.

For comparison, here are some performance measurements from one of the projects I'm working on:

#### Before patch

Summary:
  Total:    60.6975 secs
  Slowest:  0.6516 secs
  Fastest:  0.5766 secs
  Average:  0.6070 secs
  Requests/sec: 1.6475

Status code distribution:
  [200] 100 responses

Response time histogram:
  0.577 [1] |∎
  0.584 [3] |∎∎∎∎
  0.592 [11]    |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.599 [17]    |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.607 [17]    |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.614 [26]    |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.622 [11]    |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.629 [7] |∎∎∎∎∎∎∎∎∎∎
  0.637 [3] |∎∎∎∎
  0.644 [3] |∎∎∎∎
  0.652 [1] |∎

Latency distribution:
  10% in 0.5888 secs
  25% in 0.5958 secs
  50% in 0.6070 secs
  75% in 0.6152 secs
  90% in 0.6264 secs
  95% in 0.6349 secs
  99% in 0.6516 secs

---

#### After patch

Summary:
  Total:    36.9266 secs
  Slowest:  0.3906 secs
  Fastest:  0.3468 secs
  Average:  0.3693 secs
  Requests/sec: 2.7081

Status code distribution:
  [200] 100 responses

Response time histogram:
  0.347 [1] |∎∎
  0.351 [3] |∎∎∎∎∎∎
  0.356 [8] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.360 [6] |∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.364 [11]    |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.369 [18]    |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.373 [17]    |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.377 [14]    |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.382 [12]    |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.386 [8] |∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎∎
  0.391 [2] |∎∎∎∎

Latency distribution:
  10% in 0.3546 secs
  25% in 0.3632 secs
  50% in 0.3704 secs
  75% in 0.3766 secs
  90% in 0.3821 secs
  95% in 0.3853 secs
  99% in 0.3906 secs