### PR TITLE
Added boolval() to dataType transformation

### DIFF
--- a/Classes/Transformation/FormDataTransformer.php
+++ b/Classes/Transformation/FormDataTransformer.php
@@ -74,6 +74,8 @@ class FormDataTransformer {
 			return floatval($value);
 		} elseif ('array' === $dataType) {
 			return explode(',', $value);
+		} elseif ('bool' === $dataType || 'boolean' === $dataType) {
+			return boolval($value);
 		} else {
 			return $this->getObjectOfType($dataType, $value);
 		}


### PR DESCRIPTION
This is very handy if you like to build up an json configuration object with {v:format.json.encode()}.

Example:
```
<flux:field.checkbox name="slick.autoplay" label="Autoplay" default="0" transform="bool" />
{v:format.json.encode(value:'{settings.slick}')}
```