### PR TITLE
Fixing & handling issues caused by wrong handling of tx_flux_parent when creating translations

### DIFF
--- a/Classes/Hooks/WizardItemsHookSubscriber.php
+++ b/Classes/Hooks/WizardItemsHookSubscriber.php
@@ -239,7 +239,6 @@ class WizardItemsHookSubscriber implements NewContentElementWizardHookInterface
                 }
             }
         }
-
     }
 
     /**

--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -64,7 +64,7 @@ class ContentService implements SingletonInterface
         unset($id, $tceMain);
         if (false === empty($parameters['overrideVals']['tt_content']['tx_flux_parent'])) {
             $row['tx_flux_parent'] = (integer) $parameters['overrideVals']['tt_content']['tx_flux_parent'];
-            if (0 < $row['tx_flux_parent']) {
+            if (0 < $row['tx_flux_parent'] && false === empty($row['tx_flux_column'])) {
                 $row['colPos'] = self::COLPOS_FLUXCONTENT;
             }
         }
@@ -269,7 +269,7 @@ class ContentService implements SingletonInterface
             $row['tx_flux_parent'] = null;
             $row['tx_flux_column'] = null;
         }
-        if (0 < $row['tx_flux_parent']) {
+        if (0 < $row['tx_flux_parent'] && false === empty($row['tx_flux_column'])) {
             $row['colPos'] = self::COLPOS_FLUXCONTENT;
         }
         $this->updateRecordInDatabase($row);

--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -358,7 +358,7 @@ class ContentService implements SingletonInterface
                     $copiedParents = (array) $this->workspacesAwareRecordService->get(
                         'tt_content',
                         'uid,sys_language_uid',
-                        "t3_origuid = '" . (integer) $oldRecord['tx_flux_parent'] . "' AND sys_language_uid = '" . (integer) $newLanguageUid . "' " . BackendUtility::deleteClause('tt_content')
+                        "t3_origuid = '" . (integer) $oldRecord['tx_flux_parent'] . "' AND pid = '" . (integer) $row['pid'] . "' AND CType = 'fluidcontent_content' AND sys_language_uid = '" . (integer) $newLanguageUid . "' " . BackendUtility::deleteClause('tt_content')
                     );
 
                     if (count($copiedParents) > 0) {

--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -358,7 +358,11 @@ class ContentService implements SingletonInterface
                     $copiedParents = (array) $this->workspacesAwareRecordService->get(
                         'tt_content',
                         'uid,sys_language_uid',
-                        "t3_origuid = '" . (integer) $oldRecord['tx_flux_parent'] . "' AND pid = '" . (integer) $row['pid'] . "' AND CType = 'fluidcontent_content' AND sys_language_uid = '" . (integer) $newLanguageUid . "' " . BackendUtility::deleteClause('tt_content')
+                        "t3_origuid = '" . (integer) $oldRecord['tx_flux_parent'] . "' AND " .
+                            "pid = '" . (integer) $row['pid'] . "' AND " .
+                            "CType = 'fluidcontent_content' AND " .
+                            "sys_language_uid = '" . (integer) $newLanguageUid . "' " .
+                            BackendUtility::deleteClause('tt_content')
                     );
 
                     if (count($copiedParents) > 0) {

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -384,7 +384,6 @@ class PreviewView
             $this->drawPasteIcon($parentRow, $column, false, $record).
             $this->drawPasteIcon($parentRow, $column, true, $record)
         );
-
     }
 
     /**

--- a/Classes/ViewHelpers/Field/TextViewHelper.php
+++ b/Classes/ViewHelpers/Field/TextViewHelper.php
@@ -65,7 +65,6 @@ class TextViewHelper extends AbstractFieldViewHelper
             false,
             ''
         );
-
     }
 
     /**

--- a/Tests/Unit/Service/ContentServiceTest.php
+++ b/Tests/Unit/Service/ContentServiceTest.php
@@ -41,11 +41,41 @@ class ContentServiceTest extends AbstractTestCase
         $parameters['overrideVals']['tt_content']['tx_flux_parent'] = 999999;
         $record = Records::$contentRecordIsParentAndHasChildren;
         $this->assertSame(0, $record['tx_flux_parent']);
+        $tceMain = GeneralUtility::makeInstance('TYPO3\CMS\Core\DataHandling\DataHandler');
+        $this->createInstance()->affectRecordByRequestParameters('NEW12345', $record, $parameters, $tceMain);
+        $this->assertSame(999999, $record['tx_flux_parent']);
+    }
+
+    /**
+     * @test
+     */
+    public function affectByRequestParametersSetsColPosIfColumnSpecified()
+    {
+        $parameters['overrideVals']['tt_content']['tx_flux_parent'] = 999999;
+        $record = Records::$contentRecordIsParentAndHasChildren;
+        $record['tx_flux_column'] = 'someColumn';
+        $this->assertSame(0, $record['tx_flux_parent']);
         $this->assertSame(0, $record['colPos']);
         $tceMain = GeneralUtility::makeInstance('TYPO3\CMS\Core\DataHandling\DataHandler');
         $this->createInstance()->affectRecordByRequestParameters('NEW12345', $record, $parameters, $tceMain);
         $this->assertSame(999999, $record['tx_flux_parent']);
         $this->assertSame(ContentService::COLPOS_FLUXCONTENT, $record['colPos']);
+    }
+
+    /**
+     * @test
+     */
+    public function affectByRequestParametersDoesNotSetColPosIfColumnMissing()
+    {
+        $parameters['overrideVals']['tt_content']['tx_flux_parent'] = 999999;
+        $record = Records::$contentRecordIsParentAndHasChildren;
+        $record['tx_flux_column'] = '';
+        $this->assertSame(0, $record['tx_flux_parent']);
+        $this->assertSame(0, $record['colPos']);
+        $tceMain = GeneralUtility::makeInstance('TYPO3\CMS\Core\DataHandling\DataHandler');
+        $this->createInstance()->affectRecordByRequestParameters('NEW12345', $record, $parameters, $tceMain);
+        $this->assertSame(999999, $record['tx_flux_parent']);
+        $this->assertSame(0, $record['colPos']);
     }
 
     /**
@@ -447,5 +477,93 @@ class ContentServiceTest extends AbstractTestCase
         $this->assertEquals($newColPos, $row['colPos']);
         // pid will be changed from TYPO3 Core
         $this->assertEquals(1, $row['pid']);
+    }
+
+    /**
+     * @test
+     * @dataProvider getmoveRecordChangesColPosTestValues
+     * @param array $rowBefore (partial) record before changes have been applied
+     * @param int $relativeTo value for relativeTo (multiple interpretations by moveRecord, see ContentService)
+     * @param array $relativeToRecord (partial) record to be returned if queried for absolute $relativeTo value as content uid (return value for ContentService::loadRecordFromDatabase mock)
+     * @param array $targetAreaStoredInSession return value for ContentService::getTargetAreaStoredInSession mock
+     * @param array $parameters parameters as given to moveRecord
+     * @param int $expectedColPos the expected colPos after moveRecord has been called
+     */
+    public function moveRecordChangesColPos($rowBefore, $relativeTo, $relativeToRecord, $targetAreaStoredInSession, $parameters, $expectedColPos)
+    {
+        $mock = $this->getMock(
+            $this->createInstanceClassName(),
+            array('loadRecordFromDatabase', 'updateRecordInDatabase', 'updateMovePlaceholder', 'getTargetAreaStoredInSession')
+        );
+        $mock->expects($this->any())->method('loadRecordFromDatabase')->with(abs($relativeTo))->will($this->returnValue($relativeToRecord));
+        $mock->expects($this->any())->method('getTargetAreaStoredInSession')->with($relativeTo)->will($this->returnValue($targetAreaStoredInSession));
+        $mock->expects($this->any())->method('updateRecordInDatabase');
+        $mock->expects($this->any())->method('updateMovePlaceholder');
+        $dataHandler = $this->getMock('TYPO3\\CMS\\Core\\DataHandling\\DataHandler', array('resorting'));
+        $dataHandler->expects($this->any())->method('resorting');
+
+        $row = $rowBefore; // row will be modified by reference
+        $mock->moveRecord($row, $relativeTo, $parameters, $dataHandler);
+
+        $this->assertEquals($expectedColPos, $row['colPos']);
+    }
+
+    /**
+     * @return array
+     */
+    public function getmoveRecordChangesColPosTestValues()
+    {
+        $colPosFluxContent = 18181;
+
+        return [
+            // cases where colPos may change due to relative record using different colPos (starting with colPos 2, colPos 1 on relative record, neither flux parent or column name is set)
+            [['colPos' => 2], 0 - MiscellaneousUtility::UNIQUE_INTEGER_OVERHEAD - 1, [], [0, ''], ['', ''], 2], // using session
+            [['colPos' => 2], 123, ['tx_flux_column' => '', 'tx_flux_parent' => 0, 'colPos' => 1], [], ['', 'colpos-1-page-unused-unused-top-0-'], 1], // using parameters
+            [['colPos' => 2], -23, ['tx_flux_column' => '', 'tx_flux_parent' => 0, 'colPos' => 1], [], ['', ''], 1], // "inserting new element after"
+            [['colPos' => 2], 123, ['tx_flux_column' => '', 'tx_flux_parent' => 0, 'colPos' => 1], [], ['', ''], 2], // "first position in colPos"
+            [['colPos' => 2], 0, ['tx_flux_column' => '', 'tx_flux_parent' => 0, 'colPos' => 1], [0, ''], ['', ''], 2], // unmatched inner cases
+            [['colPos' => 2], 'x123', ['tx_flux_column' => '', 'tx_flux_parent' => 0, 'colPos' => 1], [], ['', ''], 2], // not changing for gridelements
+
+            // cases where colPos should remain unchanged (testing with colPos 0, same colPos for relative record, flux parent is set but no column name)
+            [['colPos' => 0], 0 - MiscellaneousUtility::UNIQUE_INTEGER_OVERHEAD - 1, [], [2, ''], ['', ''], 0], // using session 
+            [['colPos' => 0], 123, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 0], [], ['', 'colpos-0-page-unused-unused-top-1-'], 0], // using parameters
+            [['colPos' => 0], -23, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 0], [], ['', ''], 0], // "inserting new element after"
+            [['colPos' => 0], 123, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 0], [], ['', ''], 0], // "first position in colPos"
+            [['colPos' => 0], 0, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 0], [2, ''], ['', ''], 0], // unmatched inner cases
+            [['colPos' => 0], 'x123', ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 0], [], ['', ''], 0], // gridelements
+
+            // cases where colPos may change due to relative record using different colPos (starting with colPos 2, colPos 1 on relative record, flux parent is set but no column name)
+            [['colPos' => 2], 0 - MiscellaneousUtility::UNIQUE_INTEGER_OVERHEAD - 1, [], [2, ''], ['', ''], 2], // using session
+            [['colPos' => 2], 123, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 1], [], ['', 'colpos-1-page-unused-unused-top-1-'], 1], // using parameters
+            [['colPos' => 2], -23, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 1], [], ['', ''], 1], // "inserting new element after"
+            [['colPos' => 2], 123, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 1], [], ['', ''], 2], // "first position in colPos"
+            [['colPos' => 2], 0, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 1], [2, ''], ['', ''], 2], // unmatched inner cases
+            [['colPos' => 2], 'x123', ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 1], [], ['', ''], 2], // not changing for gridelements
+
+            // cases where colPos may change due to relative record using different colPos (starting with colPos 0, colPos 2 on relative record, flux parent is set but no column name)
+            // (just testing for another starting colPos, otherwise same as before)
+            [['colPos' => 0], 0 - MiscellaneousUtility::UNIQUE_INTEGER_OVERHEAD - 1, [], [2, ''], ['', ''], 0], // using session 
+            [['colPos' => 0], 123, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 2], [], ['', 'colpos-2-page-unused-unused-top-1-'], 2], // using parameters
+            [['colPos' => 0], -23, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 2], [], ['', ''], 2], // "inserting new element after"
+            [['colPos' => 0], 123, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 2], [], ['', ''], 0], // "first position in colPos"
+            [['colPos' => 0], 0, ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 2], [2, ''], ['', ''], 0], // unmatched inner cases
+            [['colPos' => 0], 'x123', ['tx_flux_column' => '', 'tx_flux_parent' => 2, 'colPos' => 2], [], ['', ''], 0], // not changing for gridelements
+
+            // cases where colPos may change due to relative record using different colPos (testing with colPos 0, colPos 1 for relative record, flux column name is set without flux parent ID)
+            [['colPos' => 0], 0 - MiscellaneousUtility::UNIQUE_INTEGER_OVERHEAD - 1, [], [0, 'column'], ['', ''], 0], // using session 
+            [['colPos' => 0], 123, ['tx_flux_column' => 'column', 'tx_flux_parent' => 0, 'colPos' => 1], [], ['', 'colpos-1-page-unused-unused-top-0-column'], 1], // using parameters
+            [['colPos' => 0], -23, ['tx_flux_column' => 'column', 'tx_flux_parent' => 0, 'colPos' => 1], [], ['', ''], 1], // "inserting new element after"
+            [['colPos' => 0], 123, ['tx_flux_column' => 'column', 'tx_flux_parent' => 0, 'colPos' => 1], [], ['', ''], 0], // "first position in colPos"
+            [['colPos' => 0], 0, ['tx_flux_column' => 'column', 'tx_flux_parent' => 0, 'colPos' => 1], [0, 'column'], ['', ''], 0], // unmatched inner cases
+            [['colPos' => 0], 'x123', ['tx_flux_column' => 'column', 'tx_flux_parent' => 0, 'colPos' => 1], [], ['', ''], 0], // gridelements
+
+            // cases where colPos may change due to relative record specifying a flux column (starting with colPos 0)
+            [['colPos' => 0], 0 - MiscellaneousUtility::UNIQUE_INTEGER_OVERHEAD - 1, [], [2, 'column'], ['', ''], $colPosFluxContent], // using session 
+            [['colPos' => 0], 123, ['tx_flux_column' => 'column', 'tx_flux_parent' => 2, 'colPos' => 1], [], ['', 'colpos-1-page-unused-unused-top-1-column'], $colPosFluxContent], // using parameters
+            [['colPos' => 0], -23, ['tx_flux_column' => 'column', 'tx_flux_parent' => 2, 'colPos' => 1], [], ['', ''], $colPosFluxContent], // "inserting new element after"
+            [['colPos' => 0], 123, ['tx_flux_column' => 'column', 'tx_flux_parent' => 2, 'colPos' => 1], [], ['', ''], 0], // "first position in colPos"
+            [['colPos' => 0], 0, ['tx_flux_column' => 'column', 'tx_flux_parent' => 2, 'colPos' => 1], [2, ''], ['', ''], 0], // unmatched inner cases
+            [['colPos' => 0], 'x123', ['tx_flux_column' => 'column', 'tx_flux_parent' => 2, 'colPos' => 1], [], ['', ''], 0], // not changing for gridelements
+        ];
     }
 }

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -19,11 +19,20 @@ class ext_update {
 	 * @return string
 	 */
 	public function main() {
+		$numAffected = 0;
+
 		$GLOBALS['TYPO3_DB']->exec_UPDATEquery('tt_content', 'colPos = -42', array('colPos' => 18181));
+		$numAffected += $GLOBALS['TYPO3_DB']->sql_affected_rows();
+
+		// clean up any inconsistencies from issue #1125
+		$GLOBALS['TYPO3_DB']->exec_UPDATEquery('tt_content', 'tx_flux_parent != 0 and ((tx_flux_column is null) or (tx_flux_column = \'\'))', array('tx_flux_parent' => 0));
+		$numAffected += $GLOBALS['TYPO3_DB']->sql_affected_rows();
+
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_reflection');
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_reflection_tags');
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_object');
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_object_tags');
-		return $GLOBALS['TYPO3_DB']->sql_affected_rows() . ' rows have been updated. System object caches cleared.';
+
+		return $numAffected . ' rows have been updated. System object caches cleared.';
 	}
 }

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -1,4 +1,7 @@
 <?php
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Backend\Utility\IconUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 /**
  * Class ext_update
@@ -33,6 +36,70 @@ class ext_update {
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_object');
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_object_tags');
 
-		return $numAffected . ' rows have been updated. System object caches cleared.';
+		$msg = '<p>' . $numAffected . ' rows have been updated. System object caches cleared.</p>';
+
+		// search for any disappeared content due to issue #1125
+		$inaccessibleRecords = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
+			'uid, pid, CType, header',
+			'tt_content',
+			'colPos = 18181 AND ((tx_flux_parent IS NULL) OR (tx_flux_parent = 0) OR (tx_flux_column IS NULL) OR (tx_flux_column = \'\')) ' . BackendUtility::deleteClause('tt_content'),
+			'',
+			'pid ASC, uid ASC'
+		);
+
+		if (count($inaccessibleRecords) > 0) {
+			$msg .= '<div class="panel panel-warning">';
+
+			$msg .= '<div class="panel-heading">';
+			$msg .= 'Inaccessible Content';
+			$msg .= '</div class="panel-heading">';
+
+			$msg .= '<div class="panel-body">';
+			$msg .= '<p>Some content elements were found to have become inaccessible from backend and most-likely also from frontend. These issues need to be investigated individually and cannot be fixed automatically.</p>';
+			$msg .= '<p>To fix these issues, follow the links below to edit the records.</p>';
+			$msg .= '<ul>';
+			$msg .= '<li>If the content element is still relevant (despite having been inaccessible previously), you can restore it by selecting a column other than "Fluid Content Area" and then saving these changes. Please check its position and appearance immediately afterwards (you may want to hide it before saving).</li>';
+			$msg .= '<li>If you are sure you could delete the content (which may not have been updated since it disappeared from backend). Please note that the content may only be a translation of another record. You may choose to delete the record via the edit link.</li>';
+			$msg .= '<li>You can re-run the update script for flux at any time to see this information again. It will not show once there are no more affected, not deleted content elements.</li>';
+			if (ExtensionManagementUtility::isLoaded('workspaces')) {
+				$msg .= '<li>Note that the effect on workspaces has not been tested, be cautious if you are actively relying on that feature.</li>';
+			}
+			$msg .= '</ul>';
+			$msg .= '<p>Affected records:</p>';
+
+			$msg .= '<table class="table table-striped table-hover">';
+			$msg .= '<thead>';
+			$msg .= '<tr>';
+			$msg .= '<th>Content ID</th>';
+			$msg .= '<th>Page ID</th>';
+			$msg .= '<th>CType</th>';
+			$msg .= '<th>Header (if set)</th>';
+			$msg .= '<th>Actions</th>';
+			$msg .= '</tr>';
+			$msg .= '</thead>';
+			$msg .= '<tbody>';
+
+			foreach ($inaccessibleRecords as $inaccessibleRecord) {
+				$msg .= '<tr>';
+				$msg .= '<td>' . htmlspecialchars($inaccessibleRecord['uid']) . '</td>';
+				$msg .= '<td>' . htmlspecialchars($inaccessibleRecord['pid']) . '</td>';
+				$msg .= '<td>' . htmlspecialchars($inaccessibleRecord['CType']) . '</td>';
+				$msg .= '<td>' . htmlspecialchars($inaccessibleRecord['header']) . '</td>';
+				$msg .= '<td><div class="btn-group">';
+				$iconEditContent = IconUtility::getSpriteIcon('actions-document-open');
+				$jsEditContent = BackendUtility::editOnClick('&edit[tt_content][' . (integer) $inaccessibleRecord['uid'] . ']=edit');
+				$msg .= '<a class="btn btn-default" href="#" onclick="javascript:' . htmlspecialchars($jsEditContent) . '">' . $iconEditContent . '</a>';
+				$msg .= '</div></td>';
+				$msg .= '</tr>';
+			}
+
+			$msg .= '</tbody>';
+			$msg .= '</table>';
+			$msg .= '</div>';
+
+			$msg .= '</div>';
+		}
+
+		return $msg;
 	}
 }


### PR DESCRIPTION
The issue with content disappearing due to being assigned `colPos=18181` by error (#1125) was a subsequent fault caused by assigning a random `tx_flux_parent` reference when creating translations for elements not being assigned to a column of a container FCE.

This pull request contains a number of changes adressing the root cause and (hopefully all) effects:
- `ContentService::initializeRecordByNewAndOldAndLanguageUids` now checks for `tx_flux_parent` being 0 before using it as `t3_origuid` (which resulted in random IDs being used)
  - We added a few conditions to the query (`CType`, `pid`, `sys_language_uid`) for better result sanity and to remove the unnecessary foreach-loop (why loop if we are querying the database anyway).
  - `$translatedParents` has been renamed to `$copiedParents`, see below
- When moving or otherwise editing content elements `tx_flux_column` is now mandatory as well as `tx_flux_parent` (`ContentService::moveRecord` and `ContentService::affectRecordByRequestParameters`). This prevents records having been translated prior to the above fix to be moved to `colPos=18181` when there is no container column to show them in (just what was described in #1125).
- The update script now removes all `tx_flux_parent` where `tx_flux_column` has not been set, thus removing the erroneous parent reference caused by the translation bug.
- As content may already have disappeared from backend (and frontend!) the update script now checks for any (non-deleted) records which are assigned to `colPos=18181` without `tx_flux_column` (the translation bug) or `tx_flux_parent` (which will have been removed by the update script to clean up the effects of that bug). If any such content is found, the user now sees a listing of all inaccessible records with the option to edit them. Instructions on how to resolve these issues are included with that list.

As we don't use workspaces (never worked for us except on the most basic websites...) we didn't test if any of these changes will interfere with workspace handling. However, it seems unlikely as we didn't change anything in regard to workspaces.

While working on these fixes I found a few more issues which need separate handling (out of scope for this pull request):
- `ContentService::initializeRecordByNewAndOldAndLanguageUids` searches for copies using `t3_origuid` when looking for a container to register translated elements on in the target language. It uses the first non-deleted container it can find. This does not seem to be the correct way for a few reasons:
  - Copies are just that: Copies. There is no actual link to their original and thus the copied container may not be the correct one to insert the translation to. IMHO content "translated in copy mode" should not attempt to register to any container at all. However, this appears to have been a commonly requested feature in the past, so this may not be simply removed. I could imagine providing an option to disable that behaviour instead.
  - Real translations (linked by `l18n_parent`) are only found because they also set `t3_origuid`. It would be better to search for a real translation first and only continue searching for copies if none could be found.
- Furthermore, when creating translations:
  - There seem to be no checks if `tx_flux_column` actually exists for the `tx_flux_parent` to be assigned. This may lead to another issue of disappearing content (not checked).
  - There seem to be no check for the found `tx_flux_parent` to be the same FCE as the translation original. This as well may lead to disappearing content.
- In general, content may disappear from BE if inaccessible/wrong `tx_flux_parent`, `tx_flux_column`  FCEs or CTypes are being used. Such issues could be caused by backend editors. Since proper handling for this issue introduces a way to find and list elements affected by #1125 it may make sense to add more checks for other cases of disappearing content and include them as well to that list (together with instructions/explanations).

Pulling resolves #1125 and maybe other issues as well (check #1125 for referenced issues).

Pull request #976 will have to be revised as it already attempted to fix the translation bug and thus conflicts with our commit. Our fix seems to be more complete, however, and should be deployable without any ill side-effects, I hope (please review the changes, just in case, thanks :) ).
