### PR TITLE
[BUGFIX] PostProcess records on creation

### DIFF
--- a/Classes/Hooks/WizardItemsHookSubscriber.php
+++ b/Classes/Hooks/WizardItemsHookSubscriber.php
@@ -239,7 +239,6 @@ class WizardItemsHookSubscriber implements NewContentElementWizardHookInterface
                 }
             }
         }
-
     }
 
     /**

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -637,7 +637,7 @@ class AbstractProvider implements ProviderInterface
      */
     public function postProcessRecord($operation, $id, array &$row, DataHandler $reference, array $removals = [])
     {
-        if ('update' === $operation) {
+        if ('update' === $operation || 'new' === $operation) {
             $record = $reference->datamap[$this->tableName][$id];
             $stored = $this->recordService->getSingle($this->tableName, '*', $record['uid']);
             $fieldName = $this->getFieldName((array) $record);

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -60,13 +60,13 @@ class PreviewView
 						</tbody>
 					</table>',
         'gridColumn' => '<td colspan="%s" rowspan="%s" style="%s">
-                            <div data-colpos="%s" class="t3js-sortable t3js-sortable-lang t3js-sortable-lang-%s 
+                            <div data-colpos="%s" class="t3js-sortable t3js-sortable-lang t3js-sortable-lang-%s
                                 t3-page-ce-wrapper ui-sortable" data-language-uid="%s">
                                 <div class="fce-header t3-row-header t3-page-colHeader t3-page-colHeader-label">
                                     <div>%s</div>
                                 </div>
                                 <div class="t3-page-ce t3js-page-ce" data-page="%s">
-                                    <div class="t3js-page-new-ce t3-page-ce-wrapper-new-ce" id="%s" 
+                                    <div class="t3js-page-new-ce t3-page-ce-wrapper-new-ce" id="%s"
                                         style="display: block;">
                                         %s %s %s
                                     </div>
@@ -75,7 +75,7 @@ class PreviewView
                                 %s
                             </div>
                         </td>',
-        'record' => '<div class="t3-page-ce%s %s t3js-page-ce t3js-page-ce-sortable" id="element-tt_content-%s" 
+        'record' => '<div class="t3-page-ce%s %s t3js-page-ce t3js-page-ce-sortable" id="element-tt_content-%s"
                         data-table="tt_content" data-uid="%s">
 						%s
 						<div class="t3js-page-new-ce t3-page-ce-wrapper-new-ce" id="colpos-%s-page-%s-%s-after-%s"
@@ -90,7 +90,7 @@ class PreviewView
 							</div>
 							%s
 						</div>',
-        'link' => '<a href="#" onclick="window.location.href=\'%s\'" title="%s" 
+        'link' => '<a href="#" onclick="window.location.href=\'%s\'" title="%s"
                       class="btn btn-default btn-sm">%s %s</a>'
     ];
 
@@ -384,7 +384,6 @@ class PreviewView
             $this->drawPasteIcon($parentRow, $column, false, $record).
             $this->drawPasteIcon($parentRow, $column, true, $record)
         );
-
     }
 
     /**

--- a/Classes/ViewHelpers/Field/TextViewHelper.php
+++ b/Classes/ViewHelpers/Field/TextViewHelper.php
@@ -65,7 +65,6 @@ class TextViewHelper extends AbstractFieldViewHelper
             false,
             ''
         );
-
     }
 
     /**


### PR DESCRIPTION
Execute the PostProcessing of records also when they are newly created. This is to ensure that the property 'id' of section objects is available right after creating a new content element.

Close: #1165 