### PR TITLE
Fix localisation of page values in legacy branch

### DIFF
--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -464,7 +464,9 @@ class AbstractProvider implements ProviderInterface {
 	 */
 	protected function getPageValues() {
 		$record = $GLOBALS['TSFE']->page;
-		$localisation = $this->recordService->get('pages_language_overlay', '*', "pid = '" . $record['uid'] . "'");
+		if ($GLOBALS['TSFE']->sys_language_uid != 0) {
+			$localisation = $this->recordService->get('pages_language_overlay', '*', 'pid = "' . $record['uid'] . '" AND sys_language_uid = "' . $GLOBALS['TSFE']->sys_language_uid . '"');
+		}
 		if (FALSE === empty($localisation)) {
 			$record = RecursiveArrayUtility::merge($record, reset($localisation));
 		}

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -593,6 +593,29 @@ abstract class AbstractProviderTest extends AbstractTestCase {
 	/**
 	 * @test
 	 */
+	public function testMaintainUidAndPidOfThePage() {
+		$GLOBALS['TSFE'] = (object) array(
+			'page' => array(
+				'title' => 'foo',
+				'uid' => 1,
+				'pid' => 0
+			), 'sys_language_uid' => 1);
+		$recordService = $this->getMock('FluidTYPO3\\Service\\RecordService', array('get'));
+		$recordService->expects($this->once())->method('get')->willReturn(array(
+			array('title' => 'bar',
+				'subtitle' => 'baz',
+				'uid' => 10,
+				'pid' => 20
+			)
+		));
+		$subject = $this->getAccessibleMockForAbstractClass('FluidTYPO3\\Flux\\Provider\\AbstractProvider');
+		$subject->_set('recordService', $recordService);
+		$this->assertEquals(array('title' => 'bar', 'subtitle' => 'baz', 'uid' => 1, 'pid' => 0), $this->callInaccessibleMethod($subject, 'getPageValues'));
+	}
+
+	/**
+	 * @test
+	 */
 	public function canSetTemplatePathAndFilename() {
 		$provider = $this->getConfigurationProviderInstance();
 		$record = $this->getBasicRecord();

--- a/Tests/Unit/Provider/AbstractProviderTest.php
+++ b/Tests/Unit/Provider/AbstractProviderTest.php
@@ -569,13 +569,25 @@ abstract class AbstractProviderTest extends AbstractTestCase {
 	/**
 	 * @test
 	 */
-	public function testAppliesLocalisationToPageValues() {
-		$GLOBALS['TSFE'] = (object) array('page' => array('foo' => 'bar'));
+	public function testApplyLocalisationToPageValues() {
+		$GLOBALS['TSFE'] = (object) array('page' => array('title' => 'foo'), 'sys_language_uid' => 1);
 		$recordService = $this->getMock('FluidTYPO3\\Service\\RecordService', array('get'));
-		$recordService->expects($this->once())->method('get')->willReturn(array(array('also' => 'baz')));
+		$recordService->expects($this->once())->method('get')->willReturn(array(array('title' => 'bar', 'subtitle' => 'baz')));
 		$subject = $this->getAccessibleMockForAbstractClass('FluidTYPO3\\Flux\\Provider\\AbstractProvider');
 		$subject->_set('recordService', $recordService);
-		$this->assertEquals(array('foo' => 'bar', 'also' => 'baz'), $this->callInaccessibleMethod($subject, 'getPageValues'));
+		$this->assertEquals(array('title' => 'bar', 'subtitle' => 'baz'), $this->callInaccessibleMethod($subject, 'getPageValues'));
+	}
+
+	/**
+	 * @test
+	 */
+	public function testDontApplyLocalisationToPageValuesInDefaultLanguage() {
+		$GLOBALS['TSFE'] = (object) array('page' => array('title' => 'foo'), 'sys_language_uid' => 0);
+		$recordService = $this->getMock('FluidTYPO3\\Service\\RecordService', array('get'));
+		$recordService->expects($this->never())->method('get');
+		$subject = $this->getAccessibleMockForAbstractClass('FluidTYPO3\\Flux\\Provider\\AbstractProvider');
+		$subject->_set('recordService', $recordService);
+		$this->assertEquals(array('title' => 'foo'), $this->callInaccessibleMethod($subject, 'getPageValues'));
 	}
 
 	/**


### PR DESCRIPTION
This PR ports the fixes of issue #954 into the legacy branch (Do not load language overlays of a page if the currently used language language is the default language).
