### PR TITLE
Dont assign random flux parent to translations

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
 
 /**
  * Flux FlexForm integration Service
@@ -309,7 +310,12 @@ class ContentService implements SingletonInterface
     ) {
         if (0 < $newUid && 0 < $oldUid && 0 < $newLanguageUid) {
             $oldRecord = $this->loadRecordFromDatabase($oldUid);
-            if ($oldRecord[$languageFieldName] !== $newLanguageUid && $oldRecord['pid'] === $row['pid']) {
+            if (
+              $oldRecord[$languageFieldName] !== $newLanguageUid
+              && $oldRecord['pid'] === $row['pid']
+              && MathUtility::canBeInterpretedAsInteger($oldRecord['tx_flux_parent'])
+              && $oldRecord['tx_flux_parent'] > 0
+            ) {
                 // look for the translated version of the parent record indicated
                 // in this new, translated record. Below, we adjust the parent UID
                 // so it has the UID of the translated parent if one exists.

--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -309,6 +309,8 @@ class ContentService implements SingletonInterface
         DataHandler $tceMain
     ) {
         if (0 < $newUid && 0 < $oldUid && 0 < $newLanguageUid) {
+            // Get the origin record of the current record to find out if it has any
+            // parameters we need to adapt in the current record.
             $oldRecord = $this->loadRecordFromDatabase($oldUid);
             if (
               $oldRecord[$languageFieldName] !== $newLanguageUid
@@ -316,9 +318,9 @@ class ContentService implements SingletonInterface
               && MathUtility::canBeInterpretedAsInteger($oldRecord['tx_flux_parent'])
               && $oldRecord['tx_flux_parent'] > 0
             ) {
-                // look for the translated version of the parent record indicated
-                // in this new, translated record. Below, we adjust the parent UID
-                // so it has the UID of the translated parent if one exists.
+                // If the origin record has a flux parent assigned, then look for the
+                // translated, very last version this parent record and, if any valid record was found,
+                // assign its UID as flux parent to the current record.
                 $translatedParents = (array) $this->workspacesAwareRecordService->get(
                     'tt_content',
                     'uid,sys_language_uid',

--- a/Tests/Unit/Service/ContentServiceTest.php
+++ b/Tests/Unit/Service/ContentServiceTest.php
@@ -254,9 +254,10 @@ class ContentServiceTest extends AbstractTestCase
      * @param integer $newUid
      * @param integer $oldUid
      * @param integer $newLanguageUid
+     * @param integer $fluxParentUid
      * @param boolean $expectsInitialization
      */
-    public function testInitializeRecordByNewAndOldAndLanguageUids($newUid, $oldUid, $newLanguageUid, $expectsInitialization)
+    public function testInitializeRecordByNewAndOldAndLanguageUids($newUid, $oldUid, $newLanguageUid, $fluxParentUid, $expectsInitialization)
     {
         if (GeneralUtility::compat_version('8.4.0')) {
             $this->markTestSkipped(
@@ -269,7 +270,12 @@ class ContentServiceTest extends AbstractTestCase
         $recordService->expects($this->any())->method('get')->willReturn(null);
         $mock->injectWorkspacesAwareRecordService($recordService);
         $dataHandler = $this->getMockBuilder('TYPO3\\CMS\\Core\\DataHandling\\DataHandler')->setMethods(array('resorting'))->getMock();
-        $row = array('pid' => 1, 'uid' => 1, 'language' => 1);
+        $row = array(
+          'uid' => 2,
+          'pid' => 1,
+          'tx_flux_parent' => $fluxParentUid,
+          'language' => 1
+        );
         $mock->expects($this->once())->method('loadRecordFromDatabase')->will($this->returnValue($row));
         if (true === $expectsInitialization) {
             $mock->expects($this->once())->method('updateRecordInDataMap');
@@ -296,8 +302,10 @@ class ContentServiceTest extends AbstractTestCase
     public function getLanguageInitializationTestValues()
     {
         return array(
-            array(1, 2, 2, true),
-            array(1, 2, 1, false)
+          array(3, 2, 1, 0, FALSE),
+          array(3, 2, 1, 1, FALSE),
+          array(3, 2, 2, 0, FALSE),
+          array(3, 2, 2, 1, TRUE),
         );
     }
 

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -19,11 +19,23 @@ class ext_update {
 	 * @return string
 	 */
 	public function main() {
+		$content = '';
+
 		$GLOBALS['TYPO3_DB']->exec_UPDATEquery('tt_content', 'colPos = -42', array('colPos' => 18181));
+		$content .= 'Switch to positive colPos (see #477): ' .
+			$GLOBALS['TYPO3_DB']->sql_affected_rows() . ' rows affected' . PHP_EOL;
+
+		// Fix records with wrong references (see #1176)
+		$GLOBALS['TYPO3_DB']->exec_UPDATEquery('tt_content', 'tx_flux_parent > 0 AND tx_flux_column = \'\'', array('tx_flux_parent' => 0));
+		$content .= 'Fix records with wrong references (see #1176): ' .
+			$GLOBALS['TYPO3_DB']->sql_affected_rows() . ' rows affected' . PHP_EOL;
+
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_reflection');
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_reflection_tags');
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_object');
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_object_tags');
-		return $GLOBALS['TYPO3_DB']->sql_affected_rows() . ' rows have been updated. System object caches cleared.';
+		$content .= 'System object caches cleared.' . PHP_EOL;
+
+		return nl2br($content);
 	}
 }


### PR DESCRIPTION
This is a bugfix for #1176

While translating records the newly created record currently
always gets assigned a flux parent record even if the origin
had no parent record. When searching for the nonexisting
parent record the database will return a rather random record.

So any translated record without a flux parent got this
random record assigned. If this random record is deleted by an editor
TYPO3 will check for any related records and delete these as well.
This may result in the deletion of all previously translated records.

Test for the existence of a parent record value in the origin record
to prevent the wrong relation.
