### PR TITLE
Dont assign random flux parent to translations in legacy branch

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
 
 /**
  * Flux FlexForm integration Service
@@ -290,7 +291,7 @@ class ContentService implements SingletonInterface {
 	protected function initializeRecordByNewAndOldAndLanguageUids($row, $newUid, $oldUid, $newLanguageUid, $languageFieldName, DataHandler $tceMain) {
 		if (0 < $newUid && 0 < $oldUid && 0 < $newLanguageUid) {
 			$oldRecord = $this->loadRecordFromDatabase($oldUid);
-			if ($oldRecord[$languageFieldName] !== $newLanguageUid && $oldRecord['pid'] === $row['pid']) {
+			if ($oldRecord[$languageFieldName] !== $newLanguageUid && $oldRecord['pid'] === $row['pid'] && MathUtility::canBeInterpretedAsInteger($oldRecord['tx_flux_parent']) && $oldRecord['tx_flux_parent'] > 0) {
 				// look for the translated version of the parent record indicated
 				// in this new, translated record. Below, we adjust the parent UID
 				// so it has the UID of the translated parent if one exists.

--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -290,12 +290,18 @@ class ContentService implements SingletonInterface {
 	 */
 	protected function initializeRecordByNewAndOldAndLanguageUids($row, $newUid, $oldUid, $newLanguageUid, $languageFieldName, DataHandler $tceMain) {
 		if (0 < $newUid && 0 < $oldUid && 0 < $newLanguageUid) {
+			// Get the origin record of the current record to find out if it has any
+			// parameters we need to adapt in the current record.
 			$oldRecord = $this->loadRecordFromDatabase($oldUid);
 			if ($oldRecord[$languageFieldName] !== $newLanguageUid && $oldRecord['pid'] === $row['pid'] && MathUtility::canBeInterpretedAsInteger($oldRecord['tx_flux_parent']) && $oldRecord['tx_flux_parent'] > 0) {
-				// look for the translated version of the parent record indicated
-				// in this new, translated record. Below, we adjust the parent UID
-				// so it has the UID of the translated parent if one exists.
-				$translatedParents = (array) $this->workspacesAwareRecordService->get('tt_content', 'uid,sys_language_uid', "t3_origuid = '" . $oldRecord['tx_flux_parent'] . "'" . BackendUtility::deleteClause('tt_content'));
+				// If the origin record has a flux parent assigned, then look for the
+				// translated, very last version this parent record and, if any valid record was found,
+				// assign its UID as flux parent to the current record.
+				$translatedParents = (array) $this->workspacesAwareRecordService->get(
+					'tt_content',
+					'uid,sys_language_uid',
+					't3_origuid=' . $oldRecord['tx_flux_parent'] . BackendUtility::deleteClause('tt_content')
+				);
 				foreach ($translatedParents as $translatedParent) {
 					if ($translatedParent['sys_language_uid'] == $newLanguageUid) {
 						// set $translatedParent to the right language ($newLanguageUid):

--- a/Tests/Unit/Service/ContentServiceTest.php
+++ b/Tests/Unit/Service/ContentServiceTest.php
@@ -258,15 +258,21 @@ class ContentServiceTest extends AbstractTestCase {
 	 * @param integer $newUid
 	 * @param integer $oldUid
 	 * @param integer $newLanguageUid
+	 * @param integer $fluxParentUid
 	 * @param boolean $expectsInitialization
 	 */
-	public function testInitializeRecordByNewAndOldAndLanguageUids($newUid, $oldUid, $newLanguageUid, $expectsInitialization) {
+	public function testInitializeRecordByNewAndOldAndLanguageUids($newUid, $oldUid, $newLanguageUid, $fluxParentUid, $expectsInitialization) {
 		$mock = $this->getMock($this->createInstanceClassName(), array('loadRecordFromDatabase', 'updateRecordInDatabase'));
 		$recordService = $this->getMock('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService', array('get'));
 		$recordService->expects($this->any())->method('get')->willReturn(NULL);
 		$mock->injectWorkspacesAwareRecordService($recordService);
 		$dataHandler = $this->getMock('TYPO3\\CMS\\Core\\DataHandling\\DataHandler', array('resorting'));
-		$row = array('pid' => 1, 'uid' => 1, 'language' => 1);
+		$row = array(
+			'uid' => 2,
+			'pid' => 1,
+			'tx_flux_parent' => $fluxParentUid,
+			'language' => 1
+		);
 		$mock->expects($this->once())->method('loadRecordFromDatabase')->will($this->returnValue($row));
 		if (TRUE === $expectsInitialization) {
 			$mock->expects($this->once())->method('updateRecordInDatabase');
@@ -284,8 +290,10 @@ class ContentServiceTest extends AbstractTestCase {
 	 */
 	public function getLanguageInitializationTestValues() {
 		return array(
-			array(1, 2, 2, TRUE),
-			array(1, 2, 1, FALSE)
+			array(3, 2, 1, 0, FALSE),
+			array(3, 2, 1, 1, FALSE),
+			array(3, 2, 2, 0, FALSE),
+			array(3, 2, 2, 1, TRUE),
 		);
 	}
 


### PR DESCRIPTION
Backport of PR #1188 into the legacy branch, which is a bugfix for issue #1176
