### PR TITLE
[BUGFIX] Use proper action in callSubControllerAction

### DIFF
--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -306,7 +306,7 @@ abstract class AbstractFluxController extends ActionController
         $subRequest->setArguments($arguments);
         $subRequest->setControllerExtensionName($viewContext->getExtensionName());
         $subRequest->setControllerVendorName($viewContext->getVendorName());
-        $subRequest->setControllerActionName($this->provider->getControllerActionFromRecord($row));
+        $subRequest->setControllerActionName($controllerActionName);
         try {
             $potentialControllerInstance->processRequest($subRequest, $response);
         } catch (StopActionException $error) {


### PR DESCRIPTION
The callSubControllerAction currently ignores it's given actionName
in favor of fetching it fresh from the provider. This causes issues
If you have nesting of a "grid" container with a content element inside
that has a custom action.