### PR TITLE
[BUGFIX] Implement memoizer for frequently called FluxService methods

### DIFF
--- a/Classes/View/ViewContext.php
+++ b/Classes/View/ViewContext.php
@@ -237,4 +237,17 @@ class ViewContext
     {
         $this->request = $request;
     }
+
+    /**
+     * @return string
+     */
+    public function getHash()
+    {
+        return sha1(
+            $this->packageName .
+            $this->templatePathAndFilename .
+            serialize($this->variables) .
+            serialize($this->templatePaths)
+        );
+    }
 }


### PR DESCRIPTION
This implements memoizers to avoid doing expensive processing
when the output of a method depends is static when the same
input is provided.

Saves SQL requests and TS parsing aplenty.