### PR TITLE
[FEATURE] Compile ViewHelpers using namelesscoder/typo3-cms-fluid-gap

### DIFF
--- a/Classes/ViewHelpers/AbstractFormViewHelper.php
+++ b/Classes/ViewHelpers/AbstractFormViewHelper.php
@@ -12,6 +12,7 @@ use FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\Form\ContainerInterface;
 use FluidTYPO3\Flux\Form\FormInterface;
 use FluidTYPO3\Flux\Form\Container\Grid;
+use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Fluid\Core\ViewHelper\Exception\InvalidVariableException;
@@ -22,20 +23,13 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
  */
 abstract class AbstractFormViewHelper extends AbstractViewHelper implements CompilableInterface
 {
+    use CompileWithRenderStatic;
 
     const SCOPE = FormViewHelper::class;
     const SCOPE_VARIABLE_EXTENSIONNAME = 'extensionName';
     const SCOPE_VARIABLE_FORM = 'form';
     const SCOPE_VARIABLE_CONTAINER = 'container';
     const SCOPE_VARIABLE_GRIDS = 'grids';
-
-    /**
-     * @return void
-     */
-    public function render()
-    {
-        return static::renderStatic($this->arguments, $this->buildRenderChildrenClosure(), $this->renderingContext);
-    }
 
     /**
      * @param array $arguments

--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Flux\ViewHelpers\Content;
 
 use FluidTYPO3\Flux\Service\FluxService;
 use FluidTYPO3\Flux\Service\WorkspacesAwareRecordService;
+use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -23,6 +24,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class GetViewHelper extends AbstractViewHelper
 {
+    use CompileWithRenderStatic;
 
     /**
      * @var FluxService
@@ -89,20 +91,6 @@ class GetViewHelper extends AbstractViewHelper
         );
         $this->registerArgument('loadRegister', 'array', 'List of LOAD_REGISTER variable');
         $this->registerArgument('render', 'boolean', 'Optional returning variable as original table rows', false, true);
-    }
-
-    /**
-     * Render
-     *
-     * @return string
-     */
-    public function render()
-    {
-        return static::renderStatic(
-            $this->arguments,
-            $this->buildRenderChildrenClosure(),
-            $this->renderingContext
-        );
     }
 
     /**

--- a/Classes/ViewHelpers/Form/DataViewHelper.php
+++ b/Classes/ViewHelpers/Form/DataViewHelper.php
@@ -12,6 +12,7 @@ use FluidTYPO3\Flux\Provider\ProviderInterface;
 use FluidTYPO3\Flux\Service\FluxService;
 use FluidTYPO3\Flux\Service\WorkspacesAwareRecordService;
 use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
+use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
@@ -21,6 +22,7 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\Exception;
  */
 class DataViewHelper extends AbstractViewHelper
 {
+    use CompileWithRenderStatic;
 
     /**
      * @var FluxService
@@ -61,16 +63,6 @@ class DataViewHelper extends AbstractViewHelper
         $this->registerArgument('uid', 'integer', 'UID of record to load (used if "record" attribute not used)');
         $this->registerArgument('record', 'array', 'Record containing Flux field (used if "uid" attribute not used)');
         $this->registerArgument('as', 'string', 'Optional name of variable to assign in tag content rendering');
-    }
-
-    /**
-     * Render method
-     * @return mixed
-     * @throws Exception
-     */
-    public function render()
-    {
-        return static::renderStatic($this->arguments, $this->buildRenderChildrenClosure(), $this->renderingContext);
     }
 
     /**

--- a/Classes/ViewHelpers/Pipe/AbstractPipeViewHelper.php
+++ b/Classes/ViewHelpers/Pipe/AbstractPipeViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Flux\ViewHelpers\Pipe;
 
 use FluidTYPO3\Flux\Outlet\Pipe\StandardPipe;
 use FluidTYPO3\Flux\ViewHelpers\AbstractFormViewHelper;
+use NamelessCoder\FluidGap\Traits\CompileWithRenderStatic;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
@@ -19,6 +20,7 @@ use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
  */
 abstract class AbstractPipeViewHelper extends AbstractFormViewHelper
 {
+    use CompileWithRenderStatic;
 
     const DIRECTION_IN = 'in';
     const DIRECTION_OUT = 'out';

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "fluidtypo3/fluidcontent_core": "Gives the ability to render core content elements with pure fluid."
     },
     "require": {
-        "php": ">=5.5.0"
+        "php": ">=5.5.0",
+        "namelesscoder/typo3-cms-fluid-gap": "*"
     },
     "require-dev": {
         "fluidtypo3/development": "^3.0"


### PR DESCRIPTION
Note: contains a second commit from another PR which is needed to even trigger compiling on TYPO3v8+. Will be rebased once https://github.com/FluidTYPO3/flux/pull/1204 is merged.