### PR TITLE
[TASK] Increase default cache lifetime to 30 days

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -96,6 +96,9 @@ if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_INSTALL)) {
 if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['flux'])) {
 	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['flux'] = array(
 		'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
-		'groups' => array('system')
+		'groups' => array('system'),
+		'options' => [
+			'defaultLifetime' => 2592000,
+		],
 	);
 }


### PR DESCRIPTION
This allows various cached Flux data sets to remain
cached for 30 days without needing special care
from the site administrator.