### PR TITLE
[FEATURE] Form option to cause static caching

### DIFF
--- a/Classes/Form.php
+++ b/Classes/Form.php
@@ -24,6 +24,7 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 class Form extends Form\AbstractFormContainer implements Form\FieldContainerInterface
 {
 
+    const OPTION_STATIC = 'static';
     const OPTION_SORTING = 'sorting';
     const OPTION_TRANSLATION = 'translation';
     const OPTION_GROUP = 'group';

--- a/Classes/ViewHelpers/Form/Option/StaticViewHelper.php
+++ b/Classes/ViewHelpers/Form/Option/StaticViewHelper.php
@@ -1,0 +1,42 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers\Form\Option;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Flux\Form;
+use FluidTYPO3\Flux\ViewHelpers\Form\OptionViewHelper;
+
+/**
+ * Form static caching option ViewHelper
+ *
+ * Use this only when your Flux form is 100% static and
+ * will work when cached.
+ */
+class StaticViewHelper extends OptionViewHelper
+{
+
+    /**
+     * @var string
+     */
+    public static $option = Form::OPTION_STATIC;
+
+    /**
+     * Initialize arguments
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument(
+            'value',
+            'boolean',
+            'Configures caching of the DS resulting from the form. Default when used is TRUE which enables caching',
+            false,
+            true
+        );
+    }
+}

--- a/Tests/Unit/Backend/DynamicFlexFormTest.php
+++ b/Tests/Unit/Backend/DynamicFlexFormTest.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Flux\Tests\Unit\Backend;
  */
 
 use FluidTYPO3\Flux\Backend\DynamicFlexForm;
+use FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\Tests\Unit\AbstractTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
@@ -54,10 +55,12 @@ class DynamicFlexFormTest extends AbstractTestCase
         $config = array();
         $row = array($fieldName => '');
         $instance = new DynamicFlexForm();
-        $provider1 = $this->getMockBuilder('FluidTYPO3\\Flux\\Provider\\Provider')->setMethods(array('postProcessDataStructure'))->getMock();
-        $provider2 = $this->getMockBuilder('FluidTYPO3\\Flux\\Provider\\Provider')->setMethods(array('postProcessDataStructure'))->getMock();
+        $provider1 = $this->getMockBuilder('FluidTYPO3\\Flux\\Provider\\Provider')->setMethods(array('postProcessDataStructure', 'getForm'))->getMock();
+        $provider2 = $this->getMockBuilder('FluidTYPO3\\Flux\\Provider\\Provider')->setMethods(array('postProcessDataStructure', 'getForm'))->getMock();
         $provider1->expects($this->any())->method('postProcessDataStructure');
         $provider2->expects($this->any())->method('postProcessDataStructure');
+        $provider1->expects($this->any())->method('getForm')->with($row)->willReturn(Form::create());
+        $provider2->expects($this->any())->method('getForm')->with($row)->willReturn(Form::create());
         $providers = array($provider1, $provider2);
         $service = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\FluxService')->setMethods(array('resolveConfigurationProviders'))->getMock();
         $service->expects($this->any())->method('resolveConfigurationProviders')

--- a/Tests/Unit/ViewHelpers/Form/Option/StaticViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Form/Option/StaticViewHelperTest.php
@@ -1,0 +1,19 @@
+<?php
+namespace FluidTYPO3\Flux\Tests\Unit\ViewHelpers\Form\Option;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Flux\Tests\Unit\ViewHelpers\AbstractFormViewHelperTestCase;
+
+/**
+ * StaticViewHelperTest
+ */
+class StaticViewHelperTest extends AbstractFormViewHelperTestCase
+{
+
+}


### PR DESCRIPTION
Setting `<flux:form.option name="static" value="1" />` causes
the DS to be cached statically. Useful when the form extracted
from the template is always the same (e.g. not dynamic).