### PR TITLE
Fixescapeoutput

### DIFF
--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -27,6 +27,11 @@ class GetViewHelper extends AbstractViewHelper
     use CompileWithRenderStatic;
 
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * @var FluxService
      */
     protected static $configurationService;

--- a/Classes/ViewHelpers/Content/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Content/RenderViewHelper.php
@@ -18,6 +18,11 @@ use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
 class RenderViewHelper extends GetViewHelper
 {
     /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Default implementation for use in compiled templates
      *
      * @param array $arguments

--- a/Classes/ViewHelpers/Form/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Form/RenderViewHelper.php
@@ -23,6 +23,10 @@ use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
  */
 class RenderViewHelper extends AbstractViewHelper
 {
+    /**
+     * @var boolean
+     */
+    protected $escapeOutput = false;
 
     /**
      * @var FluxService


### PR DESCRIPTION
Needs https://github.com/FluidTYPO3/flux/pull/1217 first, then a rebase. Other fix included to make the PR testable as-is. Fixes escaped output of nested content rendering.