### PR TITLE
[BUGFIX] Reproduce solution in http://forge.typo3.org/issues/78353 on…

### DIFF
--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -516,6 +516,12 @@ class PreviewView
             ContentService::COLPOS_FLUXCONTENT,
             $view->tt_contentConfig['showHidden'] ? '' : 'AND hidden = 0 '
         );
+        if (GeneralUtility::compat_version('8.4.0') && !GeneralUtility::compat_version('8.5.0')) {
+            // Patching to avoid http://forge.typo3.org/issues/78353 by specifically targeting only the 8.4.x branch
+            // which is the only branch to display the symptom. Bug is fixed in coming 8.5.0 and does not exist in
+            // LTS - @TODO: remove this patch when 8.4.x is no longer supported, but no need to hurry.
+            $condition .= ' AND ';
+        }
         $queryParts = $view->makeQueryArray('tt_content', $row['pid'], $condition);
         $result = $this->getDatabaseConnection()->exec_SELECT_queryArray($queryParts);
         $rows = [];


### PR DESCRIPTION
… 8.4.x

The patch on http://forge.typo3.org/issues/78353 is unfortunately
not present on the 8.4.x branches of TYPO3. Luckily, a fairly
simple "hack" can be used, targeting this specific version to add
an additional AND suffix to the custom condition we use when
pulling content records in a given Flux content area.