### PR TITLE
[BUGFIX] Create array explicitly when applying defaults

### DIFF
--- a/Classes/Hooks/WizardItemsHookSubscriber.php
+++ b/Classes/Hooks/WizardItemsHookSubscriber.php
@@ -250,6 +250,10 @@ class WizardItemsHookSubscriber implements NewContentElementWizardHookInterface
     {
         foreach ($items as $name => $item) {
             if (false === empty($defaultValues['tx_flux_column'])) {
+                if (false === is_array($items[$name]['tt_content_defValues'])) {
+                    $items[$name]['tt_content_defValues'] = [];
+                }
+
                 $items[$name]['tt_content_defValues']['tx_flux_column'] = $defaultValues['tx_flux_column'];
                 $items[$name]['params'] .= '&defVals[tt_content][tx_flux_column]=' .
                     rawurlencode($defaultValues['tx_flux_column']);

--- a/Tests/Unit/Hooks/WizardItemsHookSubscriberTest.php
+++ b/Tests/Unit/Hooks/WizardItemsHookSubscriberTest.php
@@ -11,12 +11,13 @@ namespace FluidTYPO3\Flux\Hooks;
 use FluidTYPO3\Flux\Form\Container\Column;
 use FluidTYPO3\Flux\Form\Container\Grid;
 use FluidTYPO3\Flux\Form\Container\Row;
+use FluidTYPO3\Flux\Provider\Provider;
+use FluidTYPO3\Flux\Service\FluxService;
+use FluidTYPO3\Flux\Service\WorkspacesAwareRecordService;
 use FluidTYPO3\Flux\Tests\Unit\AbstractTestCase;
 use TYPO3\CMS\Backend\Controller\ContentElement\NewContentElementController;
+use TYPO3\CMS\Core\Database\DatabaseConnection;
 
-/**
- * WizardItemsHookSubscriberTest
- */
 class WizardItemsHookSubscriberTest extends AbstractTestCase
 {
 
@@ -30,40 +31,56 @@ class WizardItemsHookSubscriberTest extends AbstractTestCase
      */
     public function processesWizardItems($items, $whitelist, $blacklist, $expectedList)
     {
-        $instance = $this->getMockBuilder(
-            'FluidTYPO3\\Flux\\Hooks\\WizardItemsHookSubscriber')
-        ->setMethods(
-            array('getAreaNameAndParentFromRelativeRecordOrDefaults')
-        )->getMock();
+        $instance = $this->getMockBuilder(WizardItemsHookSubscriber::class)
+            ->setMethods(['getAreaNameAndParentFromRelativeRecordOrDefaults'])
+            ->getMock();
         $instance->expects($this->once())->method('getAreaNameAndParentFromRelativeRecordOrDefaults')
-            ->willReturn(array(1, 'area'));
-        $emulatedPageAndContentRecord = array('uid' => 1, 'tx_flux_column' => 'area');
-        $controller = $this->getMockBuilder(NewContentElementController::class)->setMethods(array('init'))->disableOriginalConstructor()->getMock();
+            ->willReturn([1, 'area']);
+        $emulatedPageAndContentRecord = ['uid' => 1, 'tx_flux_column' => 'area'];
+
+        $controller = $this->getMockBuilder(NewContentElementController::class)
+            ->setMethods(['init'])
+            ->disableOriginalConstructor()
+            ->getMock();
         $controller->colPos = 0;
         $controller->uid_pid = -1;
+
         $grid = new Grid();
         $row = new Row();
+
         $column = new Column();
         $column->setColumnPosition(0);
         $column->setName('area');
         $column->setVariable('allowedContentTypes', $whitelist);
         $column->setVariable('deniedContentTypes', $blacklist);
+
         $row->add($column);
         $grid->add($row);
-        $provider1 = $this->objectManager->get('FluidTYPO3\\Flux\\Provider\\Provider');
-        $provider1->setTemplatePaths(array());
-        $provider1->setTemplateVariables(array());
+
+        $provider1 = $this->objectManager->get(Provider::class);
+        $provider1->setTemplatePaths([]);
+        $provider1->setTemplateVariables([]);
         $provider1->setGrid($grid);
-        $provider2 = $this->getMockBuilder('FluidTYPO3\\Flux\\Provider\\Provider')->setMethods(array('getGrid'))->getMock();
+
+        $provider2 = $this->getMockBuilder(Provider::class)->setMethods(['getGrid'])->getMock();
         $provider2->expects($this->exactly(2))->method('getGrid')->will($this->returnValue(null));
-        $configurationService = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\FluxService')->setMethods(array('resolveConfigurationProviders'))->getMock();
+
+        $configurationService = $this->getMockBuilder(FluxService::class)
+            ->setMethods(['resolveConfigurationProviders'])
+            ->getMock();
+
         $configurationService->expects($this->exactly(2))->method('resolveConfigurationProviders')
-            ->will($this->returnValue(array($provider1, $provider2)));
-        $recordService = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService')->setMethods(array('getSingle'))->getMock();
+            ->will($this->returnValue([$provider1, $provider2]));
+
+        $recordService = $this->getMockBuilder(WorkspacesAwareRecordService::class)
+            ->setMethods(['getSingle'])
+            ->getMock();
+
         $recordService->expects($this->exactly(2))->method('getSingle')->will($this->returnValue($emulatedPageAndContentRecord));
         $instance->injectConfigurationService($configurationService);
         $instance->injectRecordService($recordService);
         $instance->manipulateWizardItems($items, $controller);
+
         $this->assertEquals($expectedList, $items);
     }
 
@@ -72,47 +89,47 @@ class WizardItemsHookSubscriberTest extends AbstractTestCase
      */
     public function getTestElementsWhiteAndBlackListsAndExpectedList()
     {
-        $items = array(
-            'plugins' => array('title' => 'Nice header'),
-            'plugins_test1' => array('tt_content_defValues' => array('CType' => 'test1')),
-            'plugins_test2' => array('tt_content_defValues' => array('CType' => 'test2'))
-        );
-        return array(
-            array(
+        $items = [
+            'plugins' => ['title' => 'Nice header'],
+            'plugins_test1' => ['tt_content_defValues' => ['CType' => 'test1']],
+            'plugins_test2' => ['tt_content_defValues' => ['CType' => 'test2']]
+        ];
+        return [
+            [
                 $items,
                 null,
                 null,
-                array(
-                    'plugins' => array('title' => 'Nice header'),
-                    'plugins_test1' => array('tt_content_defValues' => array('CType' => 'test1')),
-                    'plugins_test2' => array('tt_content_defValues' => array('CType' => 'test2'))
-                ),
-            ),
-            array(
+                [
+                    'plugins' => ['title' => 'Nice header'],
+                    'plugins_test1' => ['tt_content_defValues' => ['CType' => 'test1']],
+                    'plugins_test2' => ['tt_content_defValues' => ['CType' => 'test2']]
+                ],
+            ],
+            [
                 $items,
                 'test1',
                 null,
-                array(
-                    'plugins' => array('title' => 'Nice header'),
-                    'plugins_test1' => array('tt_content_defValues' => array('CType' => 'test1'))
-                ),
-            ),
-            array(
+                [
+                    'plugins' => ['title' => 'Nice header'],
+                    'plugins_test1' => ['tt_content_defValues' => ['CType' => 'test1']]
+                ],
+            ],
+            [
                 $items,
                 null,
                 'test1',
-                array(
-                    'plugins' => array('title' => 'Nice header'),
-                    'plugins_test2' => array('tt_content_defValues' => array('CType' => 'test2'))
-                ),
-            ),
-            array(
+                [
+                    'plugins' => ['title' => 'Nice header'],
+                    'plugins_test2' => ['tt_content_defValues' => ['CType' => 'test2']]
+                ],
+            ],
+            [
                 $items,
                 'test1',
                 'test1',
-                array(),
-            ),
-        );
+                [],
+            ],
+        ];
     }
 
     /**
@@ -121,10 +138,10 @@ class WizardItemsHookSubscriberTest extends AbstractTestCase
     public function applyDefaultValuesAppliesValues()
     {
         $instance = new WizardItemsHookSubscriber();
-        $defaultValues = array('tx_flux_column' => 'foobararea', 'tx_flux_parent' => 321);
-        $items = array(
-            array('tt_content_defValues' => '', 'params' => '')
-        );
+        $defaultValues = ['tx_flux_column' => 'foobararea', 'tx_flux_parent' => 321];
+        $items = [
+            ['tt_content_defValues' => '', 'params' => '']
+        ];
         $result = $this->callInaccessibleMethod($instance, 'applyDefaultValues', $items, $defaultValues);
         $this->assertEquals($defaultValues['tx_flux_column'], $result[0]['tt_content_defValues']['tx_flux_column']);
         $this->assertEquals($defaultValues['tx_flux_parent'], $result[0]['tt_content_defValues']['tx_flux_parent']);
@@ -137,32 +154,33 @@ class WizardItemsHookSubscriberTest extends AbstractTestCase
      */
     public function testManipulateWizardItemsWithDefaultValues()
     {
-        $defaultValues = array('tx_flux_column' => 'foobararea', 'tx_flux_parent' => 321);
-        $items = array(
-            array('tt_content_defValues' => '', 'params' => '')
-        );
-        $instance = $this->getMockBuilder(
-            $this->createInstanceClassName()
-        )->setMethods(
-            array(
-                'getDefaultValues', 'getWhiteAndBlackListsFromPageAndContentColumn',
-                'applyDefaultValues', 'applyWhitelist', 'applyBlacklist', 'trimItems'
+        $defaultValues = ['tx_flux_column' => 'foobararea', 'tx_flux_parent' => 321];
+        $items = [
+            ['tt_content_defValues' => '', 'params' => '']
+        ];
+        $instance = $this->getMockBuilder($this->createInstanceClassName())
+            ->setMethods(
+                [
+                    'getDefaultValues', 'getWhiteAndBlackListsFromPageAndContentColumn',
+                    'applyDefaultValues', 'applyWhitelist', 'applyBlacklist', 'trimItems'
+                ]
             )
-        )->getMock();
-        $GLOBALS['TYPO3_DB'] = $this->getMockBuilder(
-            'TYPO3\\CMS\\Core\\Database\\DatabaseConnection'
-        )->setMethods(
-            array('exec_SELECTgetSingleRow')
-        )->disableOriginalConstructor()->getMock();
+            ->getMock();
+
+        $GLOBALS['TYPO3_DB'] = $this->getMockBuilder(DatabaseConnection::class)
+            ->setMethods(['exec_SELECTgetSingleRow'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $GLOBALS['TYPO3_DB']->expects($this->any())->method('exec_SELECTgetSingleRow')->willReturn(null);
-        $lists = array(array(), array());
+        $lists = [[], []];
         $instance->expects($this->once())->method('getWhiteAndBlackListsFromPageAndContentColumn')->will($this->returnValue($lists));
         $instance->expects($this->once())->method('applyDefaultValues')->will($this->returnValue($items));
         $instance->expects($this->once())->method('applyWhitelist')->will($this->returnValue($items));
         $instance->expects($this->once())->method('applyBlacklist')->will($this->returnValue($items));
         $instance->expects($this->once())->method('trimItems')->will($this->returnValue($items));
         $instance->expects($this->once())->method('getDefaultValues')->will($this->returnValue($defaultValues));
-        $controller = $this->getMockBuilder(NewContentElementController::class)->setMethods(array('init'))->disableOriginalConstructor()->getMock();
+        $controller = $this->getMockBuilder(NewContentElementController::class)->setMethods(['init'])->disableOriginalConstructor()->getMock();
         $instance->manipulateWizardItems($items, $controller);
         $this->assertNotEmpty($items);
     }
@@ -174,13 +192,16 @@ class WizardItemsHookSubscriberTest extends AbstractTestCase
      */
     public function testGetAreaNameAndParentFromRelativeRecordOrDefaults($relativeUid, array $expected)
     {
-        $defaults = array('tx_flux_column' => 'defaultarea', 'tx_flux_parent' => 999);
-        $inRecord = array('tx_flux_column' => 'recordarea', 'tx_flux_parent' => 111);
-        $recordService = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService')->setMethods(array('getSingle'))->getMock();
+        $defaults = ['tx_flux_column' => 'defaultarea', 'tx_flux_parent' => 999];
+        $inRecord = ['tx_flux_column' => 'recordarea', 'tx_flux_parent' => 111];
+
+        $recordService = $this->getMockBuilder(WorkspacesAwareRecordService::class)->setMethods(['getSingle'])->getMock();
         $recordService->expects($this->any())->method('getSingle')->willReturn($inRecord);
-        $instance = $this->getMockBuilder('FluidTYPO3\\Flux\\Hooks\\WizardItemsHookSubscriber')->setMethods(array('getDefaultValues'))->getMock();
+
+        $instance = $this->getMockBuilder(WizardItemsHookSubscriber::class)->setMethods(['getDefaultValues'])->getMock();
         $instance->expects($this->once())->method('getDefaultValues')->willReturn($defaults);
         $instance->injectRecordService($recordService);
+
         $result = $this->callInaccessibleMethod($instance, 'getAreaNameAndParentFromRelativeRecordOrDefaults', $relativeUid);
         $this->assertEquals($expected, $result);
     }
@@ -190,10 +211,10 @@ class WizardItemsHookSubscriberTest extends AbstractTestCase
      */
     public function getAreaNameAndParentFromRelativeRecordOrDefaults()
     {
-        return array(
-            array(0, array(999, 'defaultarea')),
-            array(1, array(999, 'defaultarea')),
-            array(-1, array(111, 'recordarea'))
-        );
+        return [
+            [0, [999, 'defaultarea']],
+            [1, [999, 'defaultarea']],
+            [-1, [111, 'recordarea']]
+        ];
     }
 }


### PR DESCRIPTION
PHP 7.1 doesn't allow creating array lazily / on-demand.

Fixes one of the PHP 7.1 builds

Contains a second commit that transforms the soup that was the WizardItemsHookSubscriberTest
into a more readable dish.