### PR TITLE
[TASK] Make tests with PHP 7.1 mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ php:
 env: TYPO3_VERSION=">=7.6.13, <7.6.99"
 
 matrix:
-  allow_failures:
-    - php: "7.1"
   include:
     - php: "7.0"
       env: COVERAGE="NO" TYPO3_VERSION=">=7.6.13, <7.6.99"


### PR DESCRIPTION
This commit doesn't allow failures with 7.1 anymore.

RC6 is the last release candidate and the test-suite is fine
beginning with #1231.