### PR TITLE
[BUGFIX] Avoid "variable already set" Exception

### DIFF
--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -181,18 +181,18 @@ abstract class AbstractFluxController extends ActionController
     protected function initializeViewHelperVariableContainer()
     {
         $viewHelperVariableContainer = $this->view->getRenderingContext()->getViewHelperVariableContainer();
-        $viewHelperVariableContainer->add(FormViewHelper::class, 'provider', $this->provider);
-        $viewHelperVariableContainer->add(
+        $viewHelperVariableContainer->addOrUpdate(FormViewHelper::class, 'provider', $this->provider);
+        $viewHelperVariableContainer->addOrUpdate(
             FormViewHelper::class,
             'extensionName',
             $this->request->getControllerExtensionKey()
         );
-        $viewHelperVariableContainer->add(
+        $viewHelperVariableContainer->addOrUpdate(
             FormViewHelper::class,
             'pluginName',
             $this->request->getPluginName()
         );
-        $viewHelperVariableContainer->add(FormViewHelper::class, 'record', $this->getRecord());
+        $viewHelperVariableContainer->addOrUpdate(FormViewHelper::class, 'record', $this->getRecord());
     }
 
     /**


### PR DESCRIPTION
Avoids an exception if for whatever reason, the
initializeView method on a Flux controller gets
called twice. Overriding the variables is safe.

Close: #1243