### PR TITLE
[BUGFIX] Setting default value of RenderType to an empty String

### DIFF
--- a/Classes/Form/AbstractMultiValueFormField.php
+++ b/Classes/Form/AbstractMultiValueFormField.php
@@ -60,7 +60,7 @@ abstract class AbstractMultiValueFormField extends AbstractFormField implements 
      * @var string
      * @see https://docs.typo3.org/typo3cms/TCAReference/Reference/Columns/Select/Index.html#rendertype
      */
-    protected $renderType = 'selectSingle';
+    protected $renderType;
 
     /**
      * Mixed - string (CSV), Traversable or array of items. Format of key/value


### PR DESCRIPTION
If In TYPO3 8.5 using an inline field with ```<flux:field.inline.fal>``` or ```<flux:field.inline>``` the output is a select box and not an inline container.
Setting the default value to an empty string is secure, cause the renderType argument of the select ViewHelper use "selectSingle" as default argument.