### PR TITLE
[BUGFIX] Fix child content display in BE workspace

### DIFF
--- a/Tests/Unit/View/PreviewViewTest.php
+++ b/Tests/Unit/View/PreviewViewTest.php
@@ -95,31 +95,6 @@ class PreviewViewTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider getWorkspaceVersionOfRecordOrRecordItselfTestValues
-     * @param array $record
-     * @param $workspaceId
-     * @param array $expected
-     */
-    public function testGetWorkspaceVersionOfRecordOrRecordItself(array $record, $workspaceId, array $expected)
-    {
-        $instance = $this->getMockBuilder($this->createInstanceClassName())->setMethods(array('getActiveWorkspaceId'))->getMock();
-        $instance->expects($this->once())->method('getActiveWorkspaceId')->willReturn($workspaceId);
-        $result = $this->callInaccessibleMethod($instance, 'getWorkspaceVersionOfRecordOrRecordItself', $record);
-        $this->assertEquals($expected, $result);
-    }
-
-    /**
-     * @return array
-     */
-    public function getWorkspaceVersionOfRecordOrRecordItselfTestValues()
-    {
-        return array(
-            array(array(), 0, array()),
-            array(array(), 1, array())
-        );
-    }
-
-    /**
      * @test
      */
     public function testDrawRecord()
@@ -144,39 +119,6 @@ class PreviewViewTest extends AbstractTestCase
         $result = $this->callInaccessibleMethod($instance, 'getNewLink', array(), 123, 'myareaname');
         $this->assertContains('123', $result);
         $this->assertContains('myareaname', $result);
-    }
-
-    /**
-     * @dataProvider getProcessRecordOverlaysTestValues
-     * @param array $input
-     * @param array $expected
-     */
-    public function testProcessRecordOverlays(array $input, array $expected)
-    {
-        $instance = $this->getMockBuilder($this->createInstanceClassName())->setMethods(array('getWorkspaceVersionOfRecordOrRecordItself'))->getMock();
-        $instance->expects($this->any())->method('getWorkspaceVersionOfRecordOrRecordItself')->willReturnArgument(0);
-        $view = new PageLayoutView();
-        $result = $this->callInaccessibleMethod($instance, 'processRecordOverlays', $input, $view);
-        $this->assertEquals($expected, $result);
-    }
-
-    /**
-     * @return array
-     */
-    public function getProcessRecordOverlaysTestValues()
-    {
-        return array(
-            array(array(), array()),
-            array(array(array('foo' => 'bar')), array(array('foo' => 'bar', 'isDisabled' => false))),
-            array(
-                array(array('t3ver_state' => VersionState::MOVE_PLACEHOLDER)),
-                array(array('t3ver_state' => VersionState::MOVE_PLACEHOLDER, 'isDisabled' => false))
-            ),
-            array(
-                array(array('t3ver_state' => VersionState::DELETE_PLACEHOLDER)),
-                array()
-            ),
-        );
     }
 
     /**


### PR DESCRIPTION
Fixes an issue where child content would be shown as
duplicated (same tt_content UID in multiple places).
The following symptoms are fixed:

* New child content shows as duplicated
* Edited child content shows as duplicated
* Published changes not shown in workspace
* "Show hidden" option not respected correctly

The fixes are achieved by:

* Adding the current PID restriction to SQL query
* Adding workspaces fields restrictions to SQL query
* Correcting the referencing of $moduleData from
   undefined class property to correct local variable.

Fix kindly sponsored by MSI Chicago - http://www.msichicago.org/