### PR TITLE
[BUGFIX] Do not perform direct DB writes in moveRecord

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -178,7 +178,7 @@ class ContentService implements SingletonInterface
             if (0 > $relativeUid) {
                 $record['sorting'] = $tceMain->resorting($table, $relativeRecord['pid'], 'sorting', abs($relativeUid));
             }
-            $this->updateRecordInDatabase($record);
+            $this->updateRecordInDataMap($record, null, $tceMain);
             $tceMain->registerDBList[$table][$record['uid']];
         }
     }
@@ -235,7 +235,7 @@ class ContentService implements SingletonInterface
                 $row['tx_flux_column'] = $column;
                 $row['sorting'] = $tceMain->getSortNumber('tt_content', 0, $row['pid']);
             } elseif (0 <= (integer) $relativeTo && false === empty($parameters[1])) {
-                list($prefix, $column, $prefix2, , , $relativePosition, $relativeUid, $area) =
+                list($prefix, $column, $prefix2, , , , $relativeUid, $area) =
                     GeneralUtility::trimExplode('-', $parameters[1]);
                 $relativeUid = (integer) $relativeUid;
                 if ('colpos' === $prefix && 'page' === $prefix2) {
@@ -249,15 +249,8 @@ class ContentService implements SingletonInterface
                 $row['tx_flux_parent'] = $relativeToRecord['tx_flux_parent'];
                 $row['tx_flux_column'] = $relativeToRecord['tx_flux_column'];
                 $row['colPos'] = $relativeToRecord['colPos'];
-                $row['sorting'] = $tceMain->resorting(
-                    'tt_content',
-                    $relativeToRecord['pid'],
-                    'sorting',
-                    abs($relativeTo)
-                );
             } elseif (0 < (integer) $relativeTo) {
                 // moving to first position in colPos, means that $relativeTo is the pid of the containing page
-                $row['sorting'] = $tceMain->getSortNumber('tt_content', 0, $relativeTo);
                 $row['tx_flux_parent'] = null;
                 $row['tx_flux_column'] = null;
             } else {
@@ -272,32 +265,6 @@ class ContentService implements SingletonInterface
         if (0 < $row['tx_flux_parent']) {
             $row['colPos'] = self::COLPOS_FLUXCONTENT;
         }
-        $this->updateRecordInDatabase($row);
-        $this->updateMovePlaceholder($row);
-    }
-
-    /**
-     * @param array $row
-     * @return void
-     */
-    protected function updateMovePlaceholder(array $row)
-    {
-        $movePlaceholder = $this->getMovePlaceholder($row['uid']);
-        if (false !== $movePlaceholder) {
-            $movePlaceholder['tx_flux_parent'] = $row['tx_flux_parent'];
-            $movePlaceholder['tx_flux_column'] = $row['tx_flux_column'];
-            $movePlaceholder['colPos'] = $row['colPos'];
-            $this->updateRecordInDatabase($movePlaceholder);
-        }
-    }
-
-    /**
-     * @param integer $recordUid
-     * @return array
-     */
-    protected function getMovePlaceholder($recordUid)
-    {
-        return BackendUtility::getMovePlaceholder('tt_content', $recordUid);
     }
 
     /**
@@ -348,7 +315,7 @@ class ContentService implements SingletonInterface
                 $translatedParents = (array) $this->workspacesAwareRecordService->get(
                     'tt_content',
                     'uid,sys_language_uid',
-                    "t3_origuid = '" . $oldRecord['tx_flux_parent'] . "'" . BackendUtility::deleteClause('tt_content')
+                    BackendUtility::deleteClause('tt_content')
                 );
                 foreach ($translatedParents as $translatedParent) {
                     if ($translatedParent['sys_language_uid'] == $newLanguageUid) {
@@ -363,7 +330,7 @@ class ContentService implements SingletonInterface
                     $sortbyFieldName => $tceMain->resorting('tt_content', $row['pid'], $sortbyFieldName, $oldUid),
                     'tx_flux_parent' => $translatedParent ? $translatedParent['uid'] : $oldRecord['tx_flux_parent']
                 ];
-                $this->updateRecordInDatabase($overrideValues, $newUid);
+                $this->updateRecordInDataMap($overrideValues, $newUid, $tceMain);
             }
         }
     }
@@ -399,28 +366,26 @@ class ContentService implements SingletonInterface
     /**
      * @param array $row
      * @param integer $uid
+     * @param DataHandler $dataHandler
      * @return void
      */
-    protected function updateRecordInDatabase(array $row, $uid = null)
+    protected function updateRecordInDataMap(array $row, $uid = null, DataHandler $dataHandler)
     {
         if (null === $uid) {
             $uid = $row['uid'];
         }
         $uid = (integer) $uid;
-        if (false === empty($uid)) {
-            $row['uid'] = $uid;
-            $this->workspacesAwareRecordService->update('tt_content', $row);
-            // reload our record for the next bits to have access to all fields
-            $row = $this->recordService->getSingle('tt_content', '*', $uid);
+        if (empty($uid)) {
+            throw new \RuntimeException('Attempt to update unidentified record in data map');
         }
-        $versionedRecordUid = (integer) (isset($row['t3ver_oid']) && !empty($row['t3ver_oid']) ? $row['t3ver_oid'] : 0);
-        if (0 < $versionedRecordUid) {
-            // temporary record; duplicate key values of original record into temporary one.
-            // Note: will continue to call this method until all temporary records in chain have been processed.
-            $placeholder = $this->recordService->getSingle('tt_content', '*', $row['t3ver_oid']);
-            $placeholder['tx_flux_parent'] = (integer) $row['tx_flux_parent'];
-            $placeholder['tx_flux_column'] = $row['tx_flux_column'];
-            $this->updateRecordInDatabase($placeholder, $row['t3ver_oid']);
+        unset($row['uid']);
+        if (isset($dataHandler->datamap['tt_content'][$uid])) {
+            $dataHandler->datamap['tt_content'][$uid] = array_replace(
+                $dataHandler->datamap['tt_content'][$uid],
+                $row
+            );
+        } else {
+            $dataHandler->datamap['tt_content'][$uid] = $row;
         }
     }
 
@@ -445,6 +410,7 @@ class ContentService implements SingletonInterface
     {
         $previousLocalizedRecordUid = $this->getPreviousLocalizedRecordUid($uid, $languageUid, $reference);
         $localizedRecord = BackendUtility::getRecordLocalization('tt_content', $uid, $languageUid);
+        $sortingRow = $GLOBALS['TCA']['tt_content']['ctrl']['sortby'];
         if (null === $previousLocalizedRecordUid) {
             // moving to first position in tx_flux_column
             $localizedRecord[0][$sortingRow] = $reference->getSortNumber(
@@ -453,7 +419,6 @@ class ContentService implements SingletonInterface
                 $defaultLanguageRecord['pid']
             );
         } else {
-            $sortingRow = $GLOBALS['TCA']['tt_content']['ctrl']['sortby'];
             $localizedRecord[0][$sortingRow] = $reference->resorting(
                 'tt_content',
                 $defaultLanguageRecord['pid'],
@@ -461,7 +426,7 @@ class ContentService implements SingletonInterface
                 $previousLocalizedRecordUid
             );
         }
-        $this->updateRecordInDatabase($localizedRecord[0]);
+        $this->updateRecordInDataMap($localizedRecord[0], null, $reference);
     }
 
     /**
@@ -473,7 +438,7 @@ class ContentService implements SingletonInterface
      *
      * @param integer $uid Uid of default language record
      * @param integer $language Language of localization
-     * @param TYPO3\CMS\Core\DataHandling\DataHandler $datahandler
+     * @param DataHandler $reference
      * @return integer uid of record after which the localized record should be inserted
      */
     protected function getPreviousLocalizedRecordUid($uid, $language, DataHandler $reference)

--- a/Tests/Unit/Service/ContentServiceTest.php
+++ b/Tests/Unit/Service/ContentServiceTest.php
@@ -54,7 +54,7 @@ class ContentServiceTest extends AbstractTestCase
      */
     public function canInitializeBlankRecord()
     {
-        $methods = array('loadRecordsFromDatabase', 'loadRecordFromDatabase', 'updateRecordInDatabase');
+        $methods = array('loadRecordsFromDatabase', 'loadRecordFromDatabase', 'updateRecordInDataMap');
         $mock = $this->createMock($methods);
         $row = array('uid' => -1);
         $tceMain = $this->getMockBuilder('TYPO3\CMS\Core\DataHandling\DataHandler')->getMock();
@@ -68,7 +68,7 @@ class ContentServiceTest extends AbstractTestCase
      */
     public function moveRecordWithNegativeRelativeToLoadsRelativeCopiesValuesSetsColumnPositionAndUpdatesRelativeToValue()
     {
-        $methods = array('loadRecordFromDatabase', 'updateRecordInDatabase', 'getTargetAreaStoredInSession');
+        $methods = array('loadRecordFromDatabase', 'getTargetAreaStoredInSession');
         $mock = $this->createMock($methods);
         $row = array(
             'pid' => 1
@@ -81,7 +81,7 @@ class ContentServiceTest extends AbstractTestCase
         $relativeTo = -1;
         $tceMain = GeneralUtility::makeInstance('TYPO3\CMS\Core\DataHandling\DataHandler');
         $mock->expects($this->once())->method('loadRecordFromDatabase')->with(1)->will($this->returnValue($relativeRecord));
-        $mock->expects($this->once())->method('updateRecordInDatabase');
+        #$mock->expects($this->once())->method('updateRecordInDataMap');
         $mock->moveRecord($row, $relativeTo, array(), $tceMain);
         $this->assertEquals($relativeRecord['tx_flux_column'], $row['tx_flux_column']);
         $this->assertEquals($relativeRecord['tx_flux_parent'], $row['tx_flux_parent']);
@@ -91,7 +91,7 @@ class ContentServiceTest extends AbstractTestCase
 
     public function pasteAfterAsCopyRelativeToRecord()
     {
-        $methods = array('loadRecordFromDatabase', 'updateRecordInDatabase');
+        $methods = array('loadRecordFromDatabase', 'updateRecordInDataMap');
         $mock = $this->createMock($methods);
         $command = 'copy';
         $row = array(
@@ -120,7 +120,7 @@ class ContentServiceTest extends AbstractTestCase
      */
     public function pasteAfterAsReferenceRelativeToRecord()
     {
-        $methods = array('loadRecordFromDatabase', 'updateRecordInDatabase');
+        $methods = array('loadRecordFromDatabase', 'updateRecordInDataMap');
         $mock = $this->createMock($methods);
 
         $command = 'copy';
@@ -157,7 +157,7 @@ class ContentServiceTest extends AbstractTestCase
      */
     public function pasteAfterAsMoveRelativeToRecord()
     {
-        $methods = array('loadRecordFromDatabase', 'updateRecordInDatabase');
+        $methods = array('loadRecordFromDatabase', 'updateRecordInDataMap');
         $mock = $this->createMock($methods);
         $command = 'move';
         $row = array(
@@ -178,7 +178,7 @@ class ContentServiceTest extends AbstractTestCase
      */
     public function pasteAfterAsMoveIntoContentArea()
     {
-        $methods = array('loadRecordFromDatabase', 'updateRecordInDatabase');
+        $methods = array('loadRecordFromDatabase', 'updateRecordInDataMap');
         $mock = $this->createMock($methods);
         $command = 'move';
         $row = array(
@@ -236,7 +236,7 @@ class ContentServiceTest extends AbstractTestCase
     /**
      * @test
      */
-    public function testUpdateRecordInDatabaseWithVersionedRecord()
+    public function testupdateRecordInDataMapWithVersionedRecord()
     {
         $row = array(
             'uid' => 123,
@@ -244,27 +244,8 @@ class ContentServiceTest extends AbstractTestCase
             'tx_flux_parent' => '3',
             'tx_flux_column' => 'area'
         );
-        $recordService = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\RecordService')->setMethods(array('getSingle'))->getMock();
-        $recordService->expects($this->at(0))->method('getSingle')->will($this->returnValue($row));
-        $recordService->expects($this->at(1))->method('getSingle')->will($this->returnValue(array()));
-        $workspaceSercice = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService')->setMethods(array('update'))->getMock();
-        $workspaceSercice->expects($this->exactly(2))->method('update');
         $mock = $this->objectManager->get($this->createInstanceClassName());
-        $mock->injectRecordService($recordService);
-        $mock->injectWorkspacesAwareRecordService($workspaceSercice);
-        $this->callInaccessibleMethod($mock, 'updateRecordInDatabase', $row);
-    }
-
-    /**
-     * @test
-     */
-    public function testUpdateMovePlaceholderWithPlaceholder()
-    {
-        $row = array('tx_flux_parent' => '', 'tx_flux_column' => '', 'colPos' => 0, 'uid' => 123);
-        $mock = $this->getMockBuilder($this->createInstanceClassName())->setMethods(array('getMovePlaceholder', 'updateRecordInDatabase'))->getMock();
-        $mock->expects($this->once())->method('getMovePlaceholder')->will($this->returnValue($row));
-        $mock->expects($this->once())->method('updateRecordInDatabase');
-        $this->callInaccessibleMethod($mock, 'updateMovePlaceholder', $row);
+        $this->callInaccessibleMethod($mock, 'updateRecordInDataMap', $row, null, $this->getMockBuilder(DataHandler::class)->getMock());
     }
 
     /**
@@ -283,7 +264,7 @@ class ContentServiceTest extends AbstractTestCase
                 'when no delete field exists which it INTENTIONALLY does not do in our tests for this very reason.'
             );
         }
-        $mock = $this->getMockBuilder($this->createInstanceClassName())->setMethods(array('loadRecordFromDatabase', 'updateRecordInDatabase'))->getMock();
+        $mock = $this->getMockBuilder($this->createInstanceClassName())->setMethods(array('loadRecordFromDatabase', 'updateRecordInDataMap'))->getMock();
         $recordService = $this->getMockBuilder('FluidTYPO3\\Flux\\Service\\WorkspacesAwareRecordService')->setMethods(array('get'))->getMock();
         $recordService->expects($this->any())->method('get')->willReturn(null);
         $mock->injectWorkspacesAwareRecordService($recordService);
@@ -291,10 +272,10 @@ class ContentServiceTest extends AbstractTestCase
         $row = array('pid' => 1, 'uid' => 1, 'language' => 1);
         $mock->expects($this->once())->method('loadRecordFromDatabase')->will($this->returnValue($row));
         if (true === $expectsInitialization) {
-            $mock->expects($this->once())->method('updateRecordInDatabase');
+            $mock->expects($this->once())->method('updateRecordInDataMap');
             $dataHandler->expects($this->once())->method('resorting');
         } else {
-            $mock->expects($this->never())->method('updateRecordInDatabase');
+            $mock->expects($this->never())->method('updateRecordInDataMap');
             $dataHandler->expects($this->never())->method('resorting');
         }
         $this->callInaccessibleMethod(
@@ -334,10 +315,10 @@ class ContentServiceTest extends AbstractTestCase
         $mock = $this->getMockBuilder(
             $this->createInstanceClassName()
         )->setMethods(
-            array('loadRecordFromDatabase', 'updateRecordInDatabase', 'updateMovePlaceholder', 'getTargetAreaStoredInSession')
+            array('loadRecordFromDatabase', 'updateRecordInDataMap', 'updateMovePlaceholder', 'getTargetAreaStoredInSession')
         )->getMock();
         $mock->expects($this->any())->method('loadRecordFromDatabase')->will($this->returnValue($row));
-        $mock->expects($this->any())->method('updateRecordInDatabase');
+        $mock->expects($this->any())->method('updateRecordInDataMap');
         $mock->expects($this->any())->method('updateMovePlaceholder');
         $dataHandler = $this->getMockBuilder('TYPO3\\CMS\\Core\\DataHandling\\DataHandler')->setMethods(array('resorting'))->getMock();
         $dataHandler->expects($this->any())->method('resorting');
@@ -375,7 +356,7 @@ class ContentServiceTest extends AbstractTestCase
      */
     public function moveRecordWithPositiveRelativeToLoadsRelativeCopiesValuesSetsColumnPositionAndUpdatesRelativeToValue()
     {
-        $methods = array('loadRecordFromDatabase', 'updateRecordInDatabase', 'getTargetAreaStoredInSession');
+        $methods = array('loadRecordFromDatabase', 'getTargetAreaStoredInSession');
         $mock = $this->createMock($methods);
         $row = array(
             'pid' => 1,
@@ -393,7 +374,6 @@ class ContentServiceTest extends AbstractTestCase
             'c3930735166bc98255fc33755fac2beb6ea705b8'
         );
         $tceMain = GeneralUtility::makeInstance('TYPO3\CMS\Core\DataHandling\DataHandler');
-        $mock->expects($this->once())->method('updateRecordInDatabase');
         $mock->moveRecord($row, $relativeTo, $parameters, $tceMain);
         $this->assertEquals(null, $row['tx_flux_column']);
         $this->assertEquals(null, $row['tx_flux_parent']);


### PR DESCRIPTION
This patch solves a problem where updating a record
while editing a workspace also caused some of those
edits to be performed on the live content record as
well. By switching from directly updating the database
over to updating the DataHandler data map array, the
issue is avoided.

Fix kindly sponsored by MSI Chicago - http://www.msichicago.org/