### PR TITLE
[BUGFIX] Work around pre-TS ConfigurationManager use

### DIFF
--- a/Classes/Configuration/ConfigurationManager.php
+++ b/Classes/Configuration/ConfigurationManager.php
@@ -11,7 +11,6 @@ namespace FluidTYPO3\Flux\Configuration;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager as CoreConfigurationManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager;
 
 /**
  * Flux ConfigurationManager implementation

--- a/Classes/Configuration/FrontendConfigurationManager.php
+++ b/Classes/Configuration/FrontendConfigurationManager.php
@@ -1,0 +1,26 @@
+<?php
+namespace FluidTYPO3\Flux\Configuration;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+/**
+ * Custom implementation of configuration manager, solely to
+ * avoid issue described on https://forge.typo3.org/issues/79098
+ * which applies when using content type registrations based
+ * on template files.
+ */
+class FrontendConfigurationManager extends \TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager
+{
+    /**
+     * @return array
+     */
+    public function getTypoScriptSetup()
+    {
+        return (array) parent::getTypoScriptSetup();
+    }
+}

--- a/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -25,7 +25,7 @@ class ConfigurationManagerTest extends AbstractTestCase
         $environmentServiceMock = $this->getMockBuilder('TYPO3\CMS\Extbase\Service\EnvironmentService')->setMethods(array('isEnvironmentInFrontendMode'))->getMock();
         $environmentServiceMock->expects($this->once())->method('isEnvironmentInFrontendMode')->will($this->returnValue(true));
         $objectManagerMock = $this->getMockBuilder('TYPO3\CMS\Extbase\Object\ObjectManager')->setMethods(array('get'))->getMock();
-        $objectManagerMock->expects($this->once())->method('get')->with('TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager');
+        $objectManagerMock->expects($this->once())->method('get')->with('FluidTYPO3\Flux\Configuration\FrontendConfigurationManager');
         $mock = $this->getMockBuilder($this->createInstanceClassName())->getMock();
         ObjectAccess::setProperty($mock, 'environmentService', $environmentServiceMock, true);
         ObjectAccess::setProperty($mock, 'objectManager', $objectManagerMock, true);


### PR DESCRIPTION
Adds a workaround for https://forge.typo3.org/issues/79098
which will for some time be required to avoid a fatal
php error when using the new API to register template files
as new content types.