### PR TITLE
[BUGFIX] Fix moving relative to other element

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -228,12 +228,13 @@ class ContentService implements SingletonInterface
         // the $relativeTo variable was passed by EXT:gridelements in which case
         // it is invalid (not a negative/positive integer but a string).
         if (false === strpos($relativeTo, 'x')) {
-            if (0 - MiscellaneousUtility::UNIQUE_INTEGER_OVERHEAD > $relativeTo) {
+            if (MiscellaneousUtility::UNIQUE_INTEGER_OVERHEAD < $relativeTo) {
                 // Fake relative to value - we can get the target from a session variable
                 list ($parent, $column) = $this->getTargetAreaStoredInSession($relativeTo);
                 $row['tx_flux_parent'] = $parent;
                 $row['tx_flux_column'] = $column;
-                $row['sorting'] = $tceMain->getSortNumber('tt_content', 0, $row['pid']);
+                $row['colPos'] = self::COLPOS_FLUXCONTENT;
+                $row['sorting'] = 0;
             } elseif (0 <= (integer) $relativeTo && false === empty($parameters[1])) {
                 list($prefix, $column, $prefix2, , , , $relativeUid, $area) =
                     GeneralUtility::trimExplode('-', $parameters[1]);

--- a/Classes/Utility/MiscellaneousUtility.php
+++ b/Classes/Utility/MiscellaneousUtility.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Flux\Utility;
  */
 
 use FluidTYPO3\Flux\Form;
+use FluidTYPO3\Flux\Service\ContentService;
 use TYPO3\CMS\Core\Imaging\GraphicalFunctions;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -21,8 +22,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class MiscellaneousUtility
 {
 
-    /** Overhead used by unique integer generation. Allows 10 billion records before collision */
-    const UNIQUE_INTEGER_OVERHEAD = 10000000000;
+    /** Overhead used by unique integer generation. */
+    const UNIQUE_INTEGER_OVERHEAD = ContentService::COLPOS_FLUXCONTENT;
 
     /**
      * @var array
@@ -44,7 +45,7 @@ class MiscellaneousUtility
         $integers = array_map('ord', str_split($areaName));
         $integers[] = $contentElementUid;
         $integers[] = self::UNIQUE_INTEGER_OVERHEAD;
-        return 0 - array_sum($integers);
+        return array_sum($integers);
     }
 
     /**

--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Flux\ViewHelpers\Content;
 
 use FluidTYPO3\Flux\Service\FluxService;
 use FluidTYPO3\Flux\Service\WorkspacesAwareRecordService;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
@@ -150,11 +151,12 @@ class GetViewHelper extends AbstractViewHelper implements CompilableInterface
         // Depending on the TYPO3 setting config.sys_language_overlay, the $record could be either one of the
         // localized version or default version.
         $conditions = sprintf(
-            "(tx_flux_parent = '%s' AND tx_flux_column = '%s' AND pid = %d AND colPos = 18181) %s",
+            "(tx_flux_parent = '%s' AND tx_flux_column = '%s' AND pid = %d AND colPos = 18181) %s %s",
             $id,
             $area,
             $record['pid'],
-            $contentObjectRenderer->enableFields('tt_content')
+            $contentObjectRenderer->enableFields('tt_content'),
+            BackendUtility::versioningPlaceholderClause('tt_content')
         );
         $rows = static::$recordService->get('tt_content', '*', $conditions, '', $order, $offset . ',' . $limit);
 

--- a/Tests/Unit/Utility/MiscellaneousUtilityTest.php
+++ b/Tests/Unit/Utility/MiscellaneousUtilityTest.php
@@ -172,10 +172,10 @@ class MiscellaneousUtilityTest extends AbstractTestCase
     public function getGenerateUniqueIntegerForFluxAreaTestValues()
     {
         return array(
-            array(1, 'test', -10000000449),
-            array(321, 'foobar', -10000000954),
-            array(8, 'xyzbazbar', -10000000997),
-            array(123, 'verylongstringverylongstringverylongstring', -10000004770)
+            array(1, 'test', 18630),
+            array(321, 'foobar', 19135),
+            array(8, 'xyzbazbar', 19178),
+            array(123, 'verylongstringverylongstringverylongstring', 22951)
         );
     }
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -10,6 +10,7 @@ $TCA['tt_content']['columns']['colPos']['config']['items'][] = array(
 	\FluidTYPO3\Flux\Service\ContentService::COLPOS_FLUXCONTENT
 );
 
+$GLOBALS['TCA']['tt_content']['ctrl']['shadowColumnsForNewPlaceholders'] .= ',tx_flux_column,tx_flux_parent';
 $GLOBALS['TCA']['tt_content']['ctrl']['useColumnsForDefaultValues'] .= ',tx_flux_column,tx_flux_parent';
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', array(


### PR DESCRIPTION
Adds a few further bug fixes:

* Switched to post-processing move hooks since these
   are the only ones to receive the necessary input values.
* Implemented necessary saving of record after post hooks,
   since record has already been saved by core.
* Turned colPos into a positive value to make the core read
   it as such.
* Corrected PreviewView to insert the target colPos value.
* Added version copy shadow columns configuration to make
   newly created versions inherit column positions.
* Fixed FE preview output to exclude versioned placeholders.

This should be the last required fix for drag and drop support
in the backend. Moving of both original records and placeholders
is now fully supported; however, bugs still remain in the publish
process (which reverts the colPos to an incorrect value).

Fix kindly sponsored by MSI Chicago - http://www.msichicago.org/