### PR TITLE
[BUGFIX] Restore broken "paste as copy" operation

### DIFF
--- a/Classes/View/PageLayoutView.php
+++ b/Classes/View/PageLayoutView.php
@@ -25,4 +25,16 @@ class PageLayoutView extends \TYPO3\CMS\Backend\View\PageLayoutView
     {
         return $this->pageinfo;
     }
+
+    /**
+     * Public access version of parent's method
+     *
+     * @param array $rowArray
+     */
+    public function generateTtContentDataArray(array $rowArray)
+    {
+        parent::generateTtContentDataArray($rowArray);
+    }
+
+
 }

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -526,7 +526,13 @@ class PreviewView
         $result = $this->getDatabaseConnection()->exec_SELECT_queryArray($queryParts);
         $rows = [];
         if ($result) {
-            $rows = $view->getResult($result);
+            while (($row = $this->getDatabaseConnection()->sql_fetch_assoc($result)) !== false) {
+                BackendUtility::workspaceOL('tt_content', $row, -99, false);
+                if ($row) {
+                    $rows[] = $row;
+                }
+            }
+            $view->generateTtContentDataArray($rows);
         }
         return $rows;
     }


### PR DESCRIPTION
Restores support for pasting content elements as copies
both in temporary and live workspaces. Specifically:

* Reacts to "copy" command
* Resolves the copy that was created, performs operations on it
* Updates the move placeholder / most recent version if one exists
* Fixes display of move placeholders in nested content area
   when the move placeholder is hidden (which copies are by
   default, unless this is changed per site). Does so by reproducing
   the logic of PageLayoutView::getResult without unsetting placeholders.

Fix kindly sponsored by MSI Chicago - http://www.msichicago.org/