### PR TITLE
[BUGFIX] Correct parameters for record moving on LTS in workspace

### DIFF
--- a/Classes/Backend/TceMain.php
+++ b/Classes/Backend/TceMain.php
@@ -362,7 +362,8 @@ class TceMain
             $uid,
             't3ver_move_id',
             sprintf(
-                't3ver_state = 3 AND deleted = 0 AND uid = %d',
+                ' %s t3ver_state = 3 AND deleted = 0 AND uid = %d',
+                version_compare(ExtensionManagementUtility::getExtensionVersion('workspaces'), '8.0.0', '<') ? 'AND' : '',
                 $uid
             )
         );

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -757,7 +757,7 @@ class PreviewView
             $templateClassJsSortableLanguageId,
             $templateDataLanguageUid,
             $label,
-            $row['uid'],
+            $row['pid'],
             $id,
             $this->drawNewIcon($row, $column),
             $this->drawPasteIcon($row, $column),


### PR DESCRIPTION
This fixes an issue where TYPO3 receives an incorrect
target page UID when a drag-and-drop action is performed.

Fix kindly sponsored by MSI Chicago - http://www.msichicago.org/