### PR TITLE
[BUGFIX] Adapt custom CType registration to work on LTS

### DIFF
--- a/Classes/Backend/TableConfigurationPostProcessor.php
+++ b/Classes/Backend/TableConfigurationPostProcessor.php
@@ -65,7 +65,13 @@ class TableConfigurationPostProcessor implements TableConfigurationPostProcessin
         $contentTypeBuilder = new ContentTypeBuilder();
         foreach ($queue as $queuedRegistration) {
             /** @var ProviderInterface $provider */
-            list ($providerExtensionName, $contentType, $provider, $pluginName) = $queuedRegistration;
+            list ($providerExtensionName, $contentType, $templateFilename, $pluginName) = $queuedRegistration;
+            $provider = (new ContentTypeBuilder())->configureContentTypeFromTemplateFile(
+                $providerExtensionName,
+                $templateFilename
+            );
+
+            Core::registerConfigurationProvider($provider);
             $contentTypeBuilder->registerContentType($providerExtensionName, $contentType, $provider, $pluginName);
         }
     }

--- a/Classes/Core.php
+++ b/Classes/Core.php
@@ -365,29 +365,15 @@ class Core
      * @param string $providerExtensionName Vendor.ExtensionName format of extension scope of the template file
      * @param string $templateFilename Absolute path to template file containing Flux definition, EXT:... allowed
      * @param array $variables Optional array of variables which are assigned when rendering the Flux definition
-     * @param null|string $section
-     * @param null|string $paths
-     * @return ProviderInterface
      */
     public static function registerTemplateAsContentType(
         $providerExtensionName,
-        $templateFilename,
-        $variables = [],
-        $section = 'Configuration',
-        $paths = null
+        $templateFilename
     ) {
 
         if (strpos($templateFilename, '/') !== 0) {
             $templateFilename = GeneralUtility::getFileAbsFileName($templateFilename);
         }
-
-        $provider = (new ContentTypeBuilder())->configureContentTypeFromTemplateFile(
-            $providerExtensionName,
-            $templateFilename,
-            $variables,
-            $section,
-            $paths
-        );
 
         // Determine which plugin name and controller action to emulate with this CType, base on file name.
         $emulatedPluginName = ucfirst(pathinfo($templateFilename, PATHINFO_FILENAME));
@@ -397,13 +383,9 @@ class Core
         static::$queuedContentTypeRegistrations[$fullContentType] = [
             $providerExtensionName,
             $fullContentType,
-            $provider,
+            $templateFilename,
             $emulatedPluginName
         ];
-
-        static::registerConfigurationProvider($provider);
-
-        return $provider;
     }
 
     /**

--- a/Classes/Helper/ContentTypeBuilder.php
+++ b/Classes/Helper/ContentTypeBuilder.php
@@ -31,18 +31,12 @@ class ContentTypeBuilder
     /**
      * @param string $providerExtensionName
      * @param string $templateFilename
-     * @param array $variables
-     * @param string $section
-     * @param array|null $paths
      * @return ProviderInterface
      */
-    public function configureContentTypeFromTemplateFile(
-        $providerExtensionName,
-        $templateFilename,
-        $variables = [],
-        $section = 'Configuration',
-        $paths = null
-    ) {
+    public function configureContentTypeFromTemplateFile($providerExtensionName, $templateFilename)
+    {
+        $variables = [];
+        $section = 'Configuration';
         $controllerName = 'Content';
         // Determine which plugin name and controller action to emulate with this CType, base on file name.
         $emulatedControllerAction = lcfirst(pathinfo($templateFilename, PATHINFO_FILENAME));
@@ -240,7 +234,6 @@ class ContentTypeBuilder
      */
     protected function registerExtbasePluginForForm($providerExtensionName, $pluginName, Form $form)
     {
-        $formId = $form->getId();
         $icon = $form->getOption(Form::OPTION_ICON);
 
         ExtensionUtility::registerPlugin(

--- a/Tests/Unit/CoreTest.php
+++ b/Tests/Unit/CoreTest.php
@@ -193,7 +193,7 @@ class CoreTest extends AbstractTestCase
             'FluidTYPO3.Flux',
             $absoluteTemplatePathAndFilename
         );
-        $this->assertInstanceOf(ProviderInterface::class, $result);
+        $this->assertNull($result);
     }
 
     /**


### PR DESCRIPTION
Class loading via ObjectManager had to be delayed
since the database connection is not initialized yet
on LTS when reading ext_localconf.php files.

Logic which creates class has been moved to the
table configuration post processing hook where the
CType is also registered.