### PR TITLE
[BUGFIX] Fix FlexForm empty nodes removal

### DIFF
--- a/Classes/Utility/MiscellaneousUtility.php
+++ b/Classes/Utility/MiscellaneousUtility.php
@@ -195,11 +195,18 @@ class MiscellaneousUtility
             }
         }
         // Remove all sheets that no longer contain any fields.
+        $nodesToBeRemoved = [];
         foreach ($dom->getElementsByTagName('sheet') as $sheetNode) {
             if (0 === $sheetNode->getElementsByTagName('field')->length) {
-                $sheetNode->parentNode->removeChild($sheetNode);
+                $nodesToBeRemoved[] = $sheetNode;
             }
         }
+
+        foreach ($nodesToBeRemoved as $node) {
+            /** @var \DOMElement $node */
+            $node->parentNode->removeChild($node);
+        }
+
         // Return empty string in case remaining flexform XML is all empty
         $dataNode = $dom->getElementsByTagName('data')->item(0);
         if (0 === $dataNode->getElementsByTagName('sheet')->length) {

--- a/Tests/Unit/Utility/MiscellaneousUtilityTest.php
+++ b/Tests/Unit/Utility/MiscellaneousUtilityTest.php
@@ -243,6 +243,15 @@ class MiscellaneousUtilityTest extends AbstractTestCase
         return array(
             array('<data><fields></fields></data>', array(), ''),
             array('<data><field index="columns">   <el index="el">   </el>   </field></data>', array(), ''),
+            array('
+                <data>
+                    <sheet index="emptySheet1"></sheet>
+                    <sheet index="emptySheet2"></sheet>
+                    <sheet index="emptySheet3"></sheet>
+                </data>',
+                array(),
+                ''
+            ),
         );
     }
 }


### PR DESCRIPTION
This PR changes the way Flux cleans a FlexForm. One of the things done by this cleaning function was to delete all the empty `sheet` elements, because it makes TYPO3 throw an exception in some cases.

But there was a problem in the way this feature was handled: looping on the elements and removing elements at the same time could cause nodes to be skipped. For instance, if three `sheet` nodes were empty in a row, the second one was skipped because the first one was removed and the looping pointer was not correctly updated.

The implemented solution to this (big) issue is to first loop on all `sheet` nodes, and store the one which _should_ be deleted first, _then_ loop again on this list and remove the nodes one by one.

One unit test has also been added to check that the solution works the desired way.