### PR TITLE
[BUGFIX] Split TCA post processing hook into two

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -36,8 +36,17 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['proc
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['moveRecordClass'][] = \FluidTYPO3\Flux\Backend\TceMain::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = \FluidTYPO3\Flux\Backend\TceMain::class . '->clearCacheCommand';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tstemplate.php']['includeStaticTypoScriptSources']['flux'] = \FluidTYPO3\Flux\Backend\TypoScriptTemplate::class . '->preprocessIncludeStaticTypoScriptSources';
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['extTablesInclusion-PostProcessing']['flux'] = \FluidTYPO3\Flux\Backend\TableConfigurationPostProcessor::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['tt_content_drawItem']['flux'] = \FluidTYPO3\Flux\Utility\CompatibilityRegistry::get(\FluidTYPO3\Flux\Backend\Preview::class);
+
+// The following is a dual registration of the same TCA-manipulating hook; the reason for registering it twice for two
+// different hooks is that extTablesInclusion-PostProcessing does not get executed in FE, resulting in errors due to
+// features provided by this hook subscriber not being loaded. We use the postBeUser since it gets executed also when
+// no user is logged in, and sits sufficiently early to load TCA as well as for the necessary context to be available.
+if (TYPO3_MODE === 'BE') {
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['extTablesInclusion-PostProcessing']['flux'] = \FluidTYPO3\Flux\Backend\TableConfigurationPostProcessor::class;
+} else {
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/index_ts.php']['postBeUser']['flux'] = \FluidTYPO3\Flux\Backend\TableConfigurationPostProcessor::class . '->processData';
+}
 
 
 if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_INSTALL)) {


### PR DESCRIPTION
The extTablesInclusion-PostProcessing hook behaves
unpredictably in FE when no BE user is logged in and
caches expire. In order to trigger the hook consistently,
the same hook subscriber must be registered in two
places, depending on BE or not BE context.

Specifically, prevents missing TCA in the case described
above - and allows template-as-CType registrations to
function correctly.