### PR TITLE
Backport EM Update script and TS Cache to legacy branch

### DIFF
--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -340,12 +340,23 @@ class FluxService implements SingletonInterface {
 	 * @return array
 	 */
 	public function getAllTypoScript() {
-		$pageId = $this->configurationManager->getCurrentPageId();
+		$pageId = $this->getCurrentPageId();
 		if (FALSE === isset(self::$typoScript[$pageId])) {
 			self::$typoScript[$pageId] = (array) $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
 			self::$typoScript[$pageId] = GeneralUtility::removeDotsFromTS(self::$typoScript[$pageId]);
 		}
 		return (array) self::$typoScript[$pageId];
+	}
+
+	/**
+	 * @return integer
+	 */
+	protected function getCurrentPageId() {
+		if ($this->configurationManager instanceof BackendConfigurationManager) {
+			return (integer) $this->configurationManager->getCurrentPageId();
+		} else {
+			return (integer) $GLOBALS['TSFE']->id;
+		}
 	}
 
 	/**

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ Flux: Fluid FlexForms
 
 [![Build Status](https://img.shields.io/travis/FluidTYPO3/flux.svg?style=flat-square&label=package)](https://travis-ci.org/FluidTYPO3/flux/) [![Coverage Status](https://img.shields.io/coveralls/FluidTYPO3/flux/development.svg?style=flat-square)](https://coveralls.io/r/FluidTYPO3/flux)  [![Documentation](http://img.shields.io/badge/documentation-online-blue.svg?style=flat-square)](https://fluidtypo3.org/documentation/templating-manual/introduction.html) [![Build Status](https://img.shields.io/travis/FluidTYPO3/fluidtypo3-testing.svg?style=flat-square&label=framework)](https://travis-ci.org/FluidTYPO3/fluidtypo3-testing/) [![Coverage Status](https://img.shields.io/coveralls/FluidTYPO3/fluidtypo3-testing/master.svg?style=flat-square)](https://coveralls.io/r/FluidTYPO3/fluidtypo3-testing)
 
+---
+
+:bangbang: **Legacy branch** :hand:
+
+*Please note that this is a legacy branch for flux in TYPO3 6.2. This version is no longer supported by the Flux team, but we are happy to keep [merging pull requests into the legacy branch](https://github.com/FluidTYPO3/flux/issues/1149#issuecomment-223269520) as long as users keep making them.*
+
+---
+
 > Flux is a replacement API for TYPO3 FlexForms - with interfaces for Fluid, PHP and TypoScript
 
 Flux lets you build and modify forms in Fluid:

--- a/Tests/Unit/Service/FluxServiceTest.php
+++ b/Tests/Unit/Service/FluxServiceTest.php
@@ -339,4 +339,18 @@ class FluxServiceTest extends AbstractTestCase {
 		);
 	}
 
+	/**
+	 * @test
+	 */
+	public function testGetAllTypoScriptCache() {
+		$fluxService = $this->createFluxServiceInstance(array('getCurrentPageId'));
+
+		$configurationManager = $this->getMock('FluidTYPO3\Flux\Configuration\ConfigurationManager', array('getConfiguration'));
+		$fluxService->injectConfigurationManager($configurationManager);
+		$configurationManager->expects($this->once())->method('getConfiguration');
+
+		$this->assertNotNull($fluxService->getAllTypoScript());
+		$this->assertNotNull($fluxService->getAllTypoScript());
+	}
+
 }

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -6,24 +6,37 @@
  * Performs update tasks for extension flux
  */
  // @codingStandardsIgnoreStart
-class ext_update {
+class ext_update
+{
 
 	/**
 	 * @return boolean
 	 */
 	public function access() {
-		return TRUE;
+		return true;
 	}
 
 	/**
 	 * @return string
 	 */
 	public function main() {
-		$GLOBALS['TYPO3_DB']->exec_UPDATEquery('tt_content', 'colPos = -42', array('colPos' => 18181));
+		$content = '';
+
+		$GLOBALS['TYPO3_DB']->exec_UPDATEquery('tt_content', 'colPos = -42', ['colPos' => 18181]);
+		$content .= 'Switch to positive colPos (see #477): ' .
+			$GLOBALS['TYPO3_DB']->sql_affected_rows() . ' rows affected' . PHP_EOL;
+
+		// Fix records with wrong references (see #1176)
+		$GLOBALS['TYPO3_DB']->exec_UPDATEquery('tt_content', 'tx_flux_parent > 0 AND tx_flux_column = \'\'', ['tx_flux_parent' => 0]);
+		$content .= 'Fix records with wrong references (see #1176): ' .
+			$GLOBALS['TYPO3_DB']->sql_affected_rows() . ' rows affected' . PHP_EOL;
+
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_reflection');
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_reflection_tags');
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_object');
 		$GLOBALS['TYPO3_DB']->exec_TRUNCATEquery('cf_extbase_object_tags');
-		return $GLOBALS['TYPO3_DB']->sql_affected_rows() . ' rows have been updated. System object caches cleared.';
+		$content .= 'System object caches cleared.' . PHP_EOL;
+
+		return nl2br($content);
 	}
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@
  ***************************************************************/
 
 $EM_CONF[$_EXTKEY] = array(
-	'title' => 'Flux: Fluid FlexForms',
+	'title' => 'Flux: Fluid FlexForms (Legacy Branch)',
 	'description' => 'Backend form and frontend content rendering assistance API with focus on productivity.',
 	'category' => 'misc',
 	'shy' => 0,


### PR DESCRIPTION
Hey guys,

this PR will backport 

* EM Update script for flux parent patch (#1176)
* Cache TypoScript config to improve performance (#1140)

to the legacy branch.

I have also added a note about the legacy branch to the Readme.