### PR TITLE
[BUGFIX] Fix design for collapsing columns

### DIFF
--- a/Classes/Hooks/ContentIconHookSubscriber.php
+++ b/Classes/Hooks/ContentIconHookSubscriber.php
@@ -14,6 +14,8 @@ use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Backend\View\PageLayoutView;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
+use TYPO3\CMS\Core\Imaging\Icon;
+use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -32,8 +34,11 @@ class ContentIconHookSubscriber
      * @var array
      */
     protected $templates = [
-        'iconWrapper' => '</div><span class="t3-icon t3-icon-empty t3-icon-empty-empty fluidcontent-icon">%s</span>
-            <div class="fluidcontent-hack">'
+        'iconWrapper' => '</div><span class="t3-icon t3-icon-empty t3-icon-empty-empty fluidcontent-icon">%s</span><div class="fluidcontent-hack">',
+        'gridToggle' => '</div><div class="fluidcontent-toggler">
+                            <div class="btn-group btn-group-sm" role="group">
+                            <a class="btn btn-default %s" title="%s" data-toggler-uid="%s">%s</a> 
+                        </div>'
     ];
 
     /**
@@ -86,6 +91,7 @@ class ContentIconHookSubscriber
      */
     public function addSubIcon(array $parameters, $caller = null)
     {
+        $provider = null;
         $this->attachAssets();
         list ($table, $uid, $record) = $parameters;
         $icon = null;
@@ -111,11 +117,14 @@ class ContentIconHookSubscriber
                                 if (strpos($icon, 'EXT:') === 0) {
                                     $icon = '/' . substr(GeneralUtility::getFileAbsFileName($icon), strlen(PATH_site));
                                 }
-                                $label = trim($form->getLabel());
+                                $label = $GLOBALS['LANG']->sL(trim($form->getLabel()));
                                 $icon = '<img width="16" height="16" src="' . $icon . '" alt="' . $label . '"
 									title="' . $label . '" class="" />';
                                 $icon = sprintf($this->templates['iconWrapper'], $icon);
                             }
+                        }
+                        if ($provider->getGrid($record)->hasChildren()) {
+                            $icon .= $this->drawGridToggle($record);
                         }
                     }
                 }
@@ -123,6 +132,46 @@ class ContentIconHookSubscriber
             }
         }
         return $icon;
+    }
+
+    /**
+     * @param array $row
+     *
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    protected function drawGridToggle(array $row)
+    {
+        $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+
+        $icon = $iconFactory->getIcon('actions-view-list-collapse', Icon::SIZE_SMALL)->render();
+        $icon .= $iconFactory->getIcon('actions-view-list-expand', Icon::SIZE_SMALL)->render();
+        $label = $GLOBALS['LANG']->sL('LLL:EXT:flux/Resources/Private/Language/locallang.xlf:toggle_content');
+
+        return sprintf($this->templates['gridToggle'], $this->isRowCollapsed($row)?  'toggler-expand' : 'toggler-collapse', $label, $row['uid'], $icon);
+    }
+
+    /**
+     * @param array $row
+     * @return string
+     */
+    protected function isRowCollapsed(array $row)
+    {
+        $collapsed = false;
+        $cookie = $this->getCookie();
+        if (null !== $_COOKIE) {
+            $cookie = json_decode(urldecode($cookie));
+            $collapsed = in_array($row['uid'], (array) $cookie);
+        }
+        return $collapsed;
+    }
+
+    /**
+     * @return string|NULL
+     */
+    protected function getCookie()
+    {
+        return true === isset($_COOKIE['fluxCollapseStates']) ? $_COOKIE['fluxCollapseStates'] : null;
     }
 
     /**
@@ -145,8 +194,6 @@ class ContentIconHookSubscriber
      */
     protected function attachAssets()
     {
-        $GLOBALS['TBE_STYLES']['stylesheet'] = $doc->backPath .
-            ExtensionManagementUtility::extRelPath('flux') .
-            'Resources/Public/css/icon.css';
+        $GLOBALS['TBE_STYLES']['stylesheet'] = ExtensionManagementUtility::extRelPath('flux') . 'Resources/Public/css/icon.css';
     }
 }

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -87,10 +87,7 @@ class PreviewView
 						</div>
 						<div class="t3-page-ce-dropzone-available t3js-page-ce-dropzone-available"></div>
 					</div>',
-        'gridToggle' => '<div class="grid-visibility-toggle">
-							<div class="toggle-content" data-uid="%s">
-								<span class="t3-icon t3-icon-actions t3-icon-view-table-%s"></span>
-							</div>
+        'gridToggle' => '<div class="grid-visibility-toggle" data-toggle-uid="%s">
 							%s
 						</div>',
         'link' => '<a href="%s" title="%s"
@@ -472,8 +469,7 @@ class PreviewView
      */
     protected function drawGridToggle(array $row, $content)
     {
-        $collapsedClass = true === $this->isRowCollapsed($row) ? 'expand' : 'collapse';
-        return sprintf($this->templates['gridToggle'], $row['uid'], $collapsedClass, $content);
+        return sprintf($this->templates['gridToggle'], $row['uid'], $content);
     }
 
     /**

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -72,6 +72,9 @@
 			<trans-unit id="paste_reference">
 				<source>Paste as reference in this position</source>
 			</trans-unit>
+			<trans-unit id="toggle_content">
+				<source>Show or hide the grid</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Public/css/grid.css
+++ b/Resources/Public/css/grid.css
@@ -1,9 +1,6 @@
-.toggle-content { cursor: pointer; float: right; margin-top: -15px; }
 .flux-grid { width: 100%; }
 .flux-grid td { vertical-align: top; }
 .flux-grid-hidden { display: none; }
-.t3-page-ce .toggle-content { visibility: hidden; }
-.t3-page-ce:hover .toggle-content { visibility: visible; }
 .t3-page-ce-dragitem:hover .t3-page-ce-wrapper-new-ce { cursor: move; }
 
 .flux-grid tr:first-child:last-child td:first-child:last-child {

--- a/Resources/Public/css/icon.css
+++ b/Resources/Public/css/icon.css
@@ -1,4 +1,4 @@
-/* Hack icon iinto page and list */
+/* Hack icon into page and list */
 .t3-js-clickmenutrigger {
 	z-index: 2;
 	position: relative
@@ -30,4 +30,20 @@
 .t3-page-ce-header .fluidcontent-icon {
 	margin-top: 3px;
 	left: 10px;
+}
+.fluidcontent-toggler {
+	opacity: 0.3;
+	float: right;
+	margin-left: 10px;
+}
+.t3-page-ce:hover .fluidcontent-toggler {
+	opacity: 1;
+}
+
+.toggle-content { cursor: pointer; }
+[data-toggler-uid].toggler-expand .icon-actions-view-list-collapse {
+	display :none;
+}
+[data-toggler-uid].toggler-collapse .icon-actions-view-list-expand {
+	display :none;
 }

--- a/Resources/Public/js/fluxCollapse.js
+++ b/Resources/Public/js/fluxCollapse.js
@@ -55,38 +55,44 @@ define(['jquery'], function ($) {
     var FluxCollapse = {
 
         init: function () {
-            $('.toggle-content').on('click', this.fluxCollapse);
+            $('[data-toggler-uid]').on('click', this.fluxCollapse);
         },
 
         fluxCollapse: function (event) {
             var cookie = Cookies.get('fluxCollapseStates');
-            if (cookie == '') {
+            if (!Array.isArray(cookie)) {
                 cookie = [];
             }
 
-            var toggle = $(event.target),
-                toggleContent = toggle.closest('.toggle-content', null, true),
-                fluxGrid = toggleContent.next('.t3-grid-container').find('> .flux-grid'),
-                uid = toggleContent.data('uid');
-
+            var i, toggle = $(this),
+                toggleContent = $('[data-toggle-uid='+toggle.data('togglerUid')+']'),
+                fluxGrid = toggleContent.find('> .t3-grid-container > .flux-grid'),
+                uid = toggleContent.data('toggleUid');
             if (fluxGrid.hasClass('flux-grid-hidden')) {
                 fluxGrid.removeClass('flux-grid-hidden');
-                toggle.removeClass('t3-icon-view-table-expand').addClass('t3-icon-view-table-collapse');
-                for (var i in cookie) {
+                toggle.removeClass('toggler-expand').addClass('toggler-collapse');
+                for (i in cookie) {
                     if (cookie.hasOwnProperty(i)) {
                         if (cookie[i] == uid) {
-                            delete(cookie[i]);
+                            delete cookie[i];
                         }
                     }
                 }
             } else {
                 fluxGrid.addClass('flux-grid-hidden');
-                toggle.removeClass('t3-icon-view-table-collapse').addClass('t3-icon-view-table-expand');
+                toggle.removeClass('toggler-collapse').addClass('toggler-expand');
                 if (cookie.indexOf(uid) < 0) {
                     cookie.push(uid);
                 }
             }
-            Cookies.set('fluxCollapseStates', cookie);
+            // remove deleted uids
+            var cookieCompress = [];
+            for (i in cookie) {
+                if (cookie[i] !== null && cookie[i] !== undefined) {
+                    cookieCompress.push(cookie[i]);
+                }
+            }
+            Cookies.set('fluxCollapseStates', cookieCompress);
         }
     };
 

--- a/Tests/Unit/View/PreviewViewTest.php
+++ b/Tests/Unit/View/PreviewViewTest.php
@@ -213,7 +213,7 @@ class PreviewViewTest extends AbstractTestCase
      */
     protected function assertPreviewContainsToggle($preview)
     {
-        $this->assertStringStartsWith('<div class="grid-visibility-toggle">', $preview);
+        $this->assertStringStartsWith('<div class="grid-visibility-toggle" ', $preview);
     }
 
     /**


### PR DESCRIPTION
Displaying the toggler in the header of the element.
Right next to the edit / hide / delete / buttons.

Bugfix in fluxCollapse.js
Array.isArray() is used to check whether the cookie variable is of type "array" and to avoid javascript errors.
Optimizing Cookie handling; remove "null" items from cookie array.

![toggler](https://cloud.githubusercontent.com/assets/1583746/22149844/47f62d48-df16-11e6-85ae-460c0ff4d7f0.png)

Tested in TYPO3 7.6.15 