### PR TITLE
[TASK] Update DragDrop.js

### DIFF
--- a/Classes/Backend/Preview.php
+++ b/Classes/Backend/Preview.php
@@ -11,6 +11,7 @@ namespace FluidTYPO3\Flux\Backend;
 use FluidTYPO3\Flux\Provider\ProviderInterface;
 use FluidTYPO3\Flux\Service\FluxService;
 use FluidTYPO3\Flux\Service\RecordService;
+use FluidTYPO3\Flux\Utility\CompatibilityRegistry;
 use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\View\PageLayoutView;
 use TYPO3\CMS\Backend\View\PageLayoutViewDrawItemHookInterface;
@@ -26,6 +27,8 @@ use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
  */
 class Preview implements PageLayoutViewDrawItemHookInterface
 {
+
+    const GRID_CSS = 'flux_grid.css';
 
     /**
      * @var boolean
@@ -131,7 +134,7 @@ class Preview implements PageLayoutViewDrawItemHookInterface
             /** @var PageRenderer $pageRenderer */
             $pageRenderer = $doc->getPageRenderer();
             $pageRenderer->addCssFile(
-                $doc->backPath . ExtensionManagementUtility::extRelPath('flux') . 'Resources/Public/css/grid.css'
+                $doc->backPath . ExtensionManagementUtility::extRelPath('flux') . 'Resources/Public/css/' . CompatibilityRegistry::get(self::GRID_CSS)
             );
 
             // /typo3/sysext/backend/Resources/Public/JavaScript/LayoutModule/DragDrop.js

--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -263,11 +263,24 @@ class ContentService implements SingletonInterface
                 $row['tx_flux_column'] = $relativeToRecord['tx_flux_column'];
                 $row['colPos'] = $relativeToRecord['colPos'];
                 $row['sorting'] = is_array($sorting) ? $sorting['sortNumber'] : $sorting;
-            } elseif (0 < (integer) $relativeTo) {
-                // moving to first position in colPos, means that $relativeTo is the target colPos. PID is already set!
-                $row['tx_flux_parent'] = null;
-                $row['tx_flux_column'] = null;
-                $row['colPos'] = $relativeTo;
+            } elseif (0 <= (integer) $relativeTo) {
+                if (empty($parameters['copy']['paste']) === false && $parameters['copy']['paste'] > self::COLPOS_FLUXCONTENT) {
+                    // Special case for drag and drop on first position of a column.
+                    // The $parameters['copy']['paste'] contains the colPos value
+                    list ($parent, $column) = $this->getTargetAreaStoredInSession($parameters['copy']['paste']);
+                    // get sorting number - between current top element and zero
+                    // $uid = 0 to fetch the lowest sortnumber
+                    $sorting = $tceMain->getSortNumber('tt_content', 0, $row['pid']);
+                    $row['tx_flux_parent'] = $parent;
+                    $row['tx_flux_column'] = $column;
+                    $row['colPos'] = self::COLPOS_FLUXCONTENT;
+                    $row['sorting'] = is_array($sorting) ? $sorting['sortNumber'] : $sorting;
+                } else {
+                    // moving to first position in colPos, means that $relativeTo is the pid of the containing page
+                    $row['tx_flux_parent'] = null;
+                    $row['tx_flux_column'] = null;
+                    $row['colPos'] = $relativeTo;
+                }
             } else {
                 $row['tx_flux_parent'] = null;
                 $row['tx_flux_column'] = null;

--- a/Resources/Public/css/grid.7.6.css
+++ b/Resources/Public/css/grid.7.6.css
@@ -1,0 +1,151 @@
+.flux-grid { width: 100%; table-layout: fixed}
+.flux-grid td { vertical-align: top; }
+.flux-grid-hidden { display: none; }
+.t3-page-ce-dragitem:hover .t3-page-ce-wrapper-new-ce { cursor: move; }
+
+.flux-grid tr:first-child:last-child td:first-child:last-child {
+	width: 100%;
+}
+.flux-grid tr:first-child:last-child td {
+	min-width: 174px;
+}
+@media (max-width: 750px) {
+	.flux-grid tr:first-child:last-child td {
+		min-width: 50%;
+	}
+}
+@media (max-width: 550px) {
+	.flux-grid tr:first-child:last-child td {
+		min-width: 100%;
+	}
+}
+.t3-page-lang-column .flux-grid td {
+	min-width: 100% !important;
+}
+.flux-grid-column > .t3-grid-cell {
+	margin-left: 10px;
+}
+.flux-grid-column:last-child > .t3-grid-cell {
+	margin-right: 10px;
+}
+
+/* copied from TYPO3 v8.6.0 */
+.t3-page-ce.active-drag {
+	z-index: 4500;
+}
+.t3-page-ce * {
+	border-spacing: 0;
+}
+.t3-page-ce > .t3-page-ce {
+	margin-left: 0;
+	margin-right: 0;
+}
+.t3-page-ce .t3-page-ce-body-inner {
+	padding: 10px;
+	word-wrap: break-word;
+}
+.t3-page-ce .t3-page-ce-header {
+	transition: background 0.15s ease-in;
+	padding: 5px;
+	border: 1px solid #ccc;
+	border-bottom: 0;
+	border-radius: 2px 2px 0 0;
+	background: #eaeaea;
+}
+.t3-page-ce .t3-page-ce-header-icons-left {
+	float: left;
+}
+.t3-page-ce .t3-page-ce-header-icons-left > a {
+	display: inline-block;
+	padding: 4px 4px;
+}
+.t3-page-ce .t3-page-ce-header-icons-right {
+	transition: opacity 0.15s ease-in;
+	opacity: 0.3;
+	float: right;
+}
+.t3-page-ce .t3-page-ce-body {
+	margin-bottom: 10px;
+	border: 1px solid #ccc;
+	border-top: 0;
+	border-radius: 0 0 2px 2px;
+	background-color: #fff;
+}
+.t3-page-ce .t3-page-ce-footer {
+	font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+	font-size: 11px;
+	padding: 5px 10px;
+	background: #fafafa;
+}
+.t3-page-ce:hover .t3-page-ce-header {
+	background: #d0d0d0;
+}
+.t3-page-ce:hover .t3-page-ce-header,
+.t3-page-ce:hover .t3-page-ce-body {
+	border-color: #aaa;
+}
+.t3-page-ce:hover .t3-page-ce-body {
+	box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.15);
+}
+.t3-page-ce:hover .t3-page-ce-header-icons-right {
+	opacity: 1;
+}
+.t3-page-ce-danger:hover .t3-page-ce-header {
+	background-color: #a32e2e;
+	border-color: #a32e2e;
+}
+.t3-page-ce-danger:hover .t3-page-ce-body {
+	border-color: #a32e2e;
+}
+.t3-page-ce-danger .t3-page-ce-header {
+	background-color: #c83c3c;
+	border-color: #c83c3c;
+}
+.t3-page-ce-danger .t3-page-ce-header:hover {
+	background-color: #a32e2e;
+	border-color: #a32e2e;
+}
+.t3-page-ce-danger .t3-page-ce-body {
+	border-color: #c83c3c;
+}
+.t3-page-ce-hidden {
+	opacity: 0.4;
+	transition: opacity 0.15s ease-in;
+}
+.t3-page-ce-hidden:hover {
+	opacity: 1.0;
+}
+.t3-page-ce-dropzone-available.active {
+	border: 1px dashed #e8a33d !important;
+	border-radius: 2px !important;
+	background-color: #fbefdd !important;
+	height: 27px !important;
+}
+.t3-page-ce-dropzone-available.active.t3-page-ce-dropzone-possible {
+	border: 1px dashed #79a548 !important;
+	border-radius: 2px !important;
+	background-color: #d1e2bd !important;
+	margin: -38px 0 -37px 0 !important;
+	padding: 50px 10px !important;
+	z-index: 500 !important;
+	position: relative !important;
+	opacity: 0.65 !important;
+}
+.t3-page-ce-dragitem.dragitem-shadow {
+	opacity: 0.65;
+	box-shadow: 0 1px 24px rgba(0, 0, 0, 0.5);
+}
+.t3-page-ce.ui-draggable-handle {
+	height: auto!important;
+}
+.t3-page-ce-dragitem .t3-page-ce-header-draggable:hover {
+	cursor: move;
+}
+.t3-is-dragged .t3-page-ce-body {
+	max-height: 225px;
+	overflow: hidden;
+}
+.t3-page-ce-dropzone-available.active,
+.t3-page-ce-dropzone-possible {
+	max-height: 225px;
+}

--- a/Resources/Public/css/grid.css
+++ b/Resources/Public/css/grid.css
@@ -1,4 +1,4 @@
-.flux-grid { width: 100%; }
+.flux-grid { width: 100%; table-layout:fixed;}
 .flux-grid td { vertical-align: top; }
 .flux-grid-hidden { display: none; }
 .t3-page-ce-dragitem:hover .t3-page-ce-wrapper-new-ce { cursor: move; }

--- a/Resources/Public/js/DragDrop.js
+++ b/Resources/Public/js/DragDrop.js
@@ -15,171 +15,269 @@ requirejs.undef("TYPO3/CMS/Backend/LayoutModule/DragDrop");
  * this JS code does the drag+drop logic for the Layout module (Web => Page)
  * based on jQuery UI
  */
-define(['jquery', 'jquery-ui/sortable'], function ($) {
-    'use strict';
+define(['jquery', 'jquery-ui/droppable'], function ($) {
+	'use strict';
 
-    /**
-     *
-     * @type {{contentIdentifier: string, dragIdentifier: string, dropZoneAvailableIdentifier: string, dropPossibleClass: string, sortableItemsIdentifier: string, columnIdentifier: string, columnHolderIdentifier: string, addContentIdentifier: string, langClassPrefix: string}}
-     * @exports TYPO3/CMS/Backend/LayoutModule/DragDrop
-     */
-    var DragDrop = {
-        contentIdentifier: '.t3js-page-ce',
-        dragIdentifier: '.t3js-page-ce-draghandle',
-        dropZoneAvailableIdentifier: '.t3js-page-ce-dropzone-available',
-        dropPossibleClass: 't3-page-ce-dropzone-possible',
-        sortableItemsIdentifier: '.t3js-page-ce-sortable',
-        columnIdentifier: '.t3js-page-column',
-        columnHolderIdentifier: '.t3js-page-columns',
-        addContentIdentifier: '.t3js-page-new-ce',
-        langClassPrefix: '.t3js-sortable-lang-'
-    };
+	/**
+	 *
+	 * @type {{contentIdentifier: string, dragIdentifier: string, dragHeaderIdentifier: string, dropZoneIdentifier: string, columnIdentifier: string, validDropZoneClass: string, dropPossibleHoverClass: string, addContentIdentifier: string, originalStyles: string}}
+	 * @exports TYPO3/CMS/Backend/LayoutModule/DragDrop
+	 */
+	var DragDrop = {
+		contentIdentifier: '.t3js-page-ce',
+		dragIdentifier: '.t3-page-ce-dragitem',
+		dragHeaderIdentifier: '.t3js-page-ce-draghandle',
+		dropZoneIdentifier: '.t3js-page-ce-dropzone-available',
+		columnIdentifier: '.t3js-page-column',
+		validDropZoneClass: 'active',
+		dropPossibleHoverClass: 't3-page-ce-dropzone-possible',
+		addContentIdentifier: '.t3js-page-new-ce',
+		clone: true,
+		originalStyles: ''
+	};
 
-    /**
-     * initializes Drag+Drop for all content elements on the page
-     */
-    DragDrop.initialize = function() {
-        // setting the style of all divs with data-language-uid to 'postion:relative' in order to prevend during dragging a wrong positioning
-        $('div[data-language-uid]').css('position','relative');
+	/**
+	 * initializes Drag+Drop for all content elements on the page
+	 */
+	DragDrop.initialize = function() {
+		$(DragDrop.contentIdentifier).draggable({
+			handle: this.dragHeaderIdentifier,
+			scope: 'tt_content',
+			cursor: 'move',
+			distance: 20,
+			addClasses: 'active-drag',
+			revert: 'invalid',
+			zIndex: 2000,
+			start: function (evt, ui) {
+				DragDrop.onDragStart($(this));
+			},
+			stop: function (evt, ui) {
+				DragDrop.onDragStop($(this));
+			}
+		});
 
-        $('td[data-language-uid]').each(function() {
-            var connectWithClassName = DragDrop.langClassPrefix + $(this).data('language-uid');
-            $(connectWithClassName).sortable({
-                items: DragDrop.sortableItemsIdentifier,
-                connectWith: connectWithClassName,
-                handle: DragDrop.dragIdentifier,
-                distance: 1,
-                cursor: 'move',
-                helper: 'clone',
-                cursorAt: { left: -10, top: -10 },
-                placeholder: DragDrop.dropPossibleClass,
-                tolerance: 'pointer',
-                start: function(e, ui) {
-                    DragDrop.onSortStart($(this), ui);
-                    $(this).addClass('t3-is-dragged');
-                },
-                stop: function(e, ui) {
-                    DragDrop.onSortStop($(this), ui);
-                    $(this).removeClass('t3-is-dragged');
-                },
-                change: function(e, ui) {
-                    DragDrop.onSortChange($(this), ui);
-                },
-                update: function(e, ui) {
-                    if (this === ui.item.parent()[0]) {
-                        DragDrop.onSortUpdate($(this), ui);
-                    }
-                }
-            }).disableSelection();
-        });
-    };
+		$(DragDrop.dropZoneIdentifier).droppable({
+			accept: this.contentIdentifier,
+			scope: 'tt_content',
+			tolerance: 'pointer',
+			over: function (evt, ui) {
+				DragDrop.onDropHoverOver($(ui.draggable), $(this));
+			},
+			out: function (evt, ui) {
+				DragDrop.onDropHoverOut($(ui.draggable), $(this));
+			},
+			drop: function (evt, ui) {
+				DragDrop.onDrop($(ui.draggable), $(this), evt);
+			}
+		});
+	};
 
-    /**
-     * Called when an item is about to be moved
-     *
-     * @param {Object} $container
-     * @param {Object} ui
-     */
-    DragDrop.onSortStart = function($container, ui) {
-        var $item = $(ui.item),
-            $helper = $(ui.helper),
-            $placeholder = $(ui.placeholder);
+	/**
+	 * called when a draggable is selected to be moved
+	 * @param $element a jQuery object for the draggable
+	 * @private
+	 */
+	DragDrop.onDragStart = function ($element) {
+		// Add css class for the drag shadow
+		DragDrop.originalStyles = $element.get(0).style.cssText;
+		$element.css('max-height','0px');
+		$element.children(DragDrop.dragIdentifier).addClass('dragitem-shadow');
+		// 'dragdrop.copy.message' only exists in TYPO3 Version > 7
+		if ('dragdrop.copy.message' in TYPO3.lang) {
+			$element.append('<div class="ui-draggable-copy-message">' + TYPO3.lang['dragdrop.copy.message'] + '</div>');
+			DragDrop.copyAction = true;
+		}
+		// Hide create new element button
+		$element.children(DragDrop.dropZoneIdentifier).addClass('drag-start');
+		$element.closest(DragDrop.columnIdentifier).removeClass('active');
+		$element.parents(DragDrop.columnHolderIdentifier).find(DragDrop.addContentIdentifier).hide();
+		$element.find(DragDrop.dropZoneIdentifier).hide();
+		$element.parents(DragDrop.contentIdentifier).last().css('z-index',2000);
 
-        //$placeholder.height($item.height() - $helper.find(DragDrop.addContentIdentifier).height()-20);
-        $placeholder.height(40);
-        DragDrop.changeDropzoneVisibility($container, $item, $helper);
+		// make the drop zones visible
+		$(DragDrop.dropZoneIdentifier).each(function () {
+			if (
+				$(this).parent().find('.icon-actions-document-new').length
+			) {
+				$(this).addClass(DragDrop.validDropZoneClass);
+			} else {
+				$(this).closest(DragDrop.contentIdentifier).find('> ' + DragDrop.addContentIdentifier + ', > > ' + DragDrop.addContentIdentifier).show();
+			}
+		});
+	};
 
-        // show all dropzones, except the own
-        $helper.find(DragDrop.dropZoneAvailableIdentifier).removeClass('active');
-        $container.parents(DragDrop.columnHolderIdentifier).find(DragDrop.addContentIdentifier).hide();
-    };
+	/**
+	 * called when a draggable is released
+	 * @param $element a jQuery object for the draggable
+	 * @private
+	 */
+	DragDrop.onDragStop = function ($element) {
+		// Remove css class for the drag shadow
+		$element.children(DragDrop.dragIdentifier).removeClass('dragitem-shadow');
+		// Show create new element button
+		$element.children(DragDrop.dropZoneIdentifier).removeClass('drag-start');
+		$element.closest(DragDrop.columnIdentifier).addClass('active');
+		$element.parents(DragDrop.columnHolderIdentifier).find(DragDrop.addContentIdentifier).show();
+		$element.find(DragDrop.dropZoneIdentifier).show();
+		$element.parents(DragDrop.contentIdentifier).last().css('z-index','');
+		$element.find('.ui-draggable-copy-message').remove();
 
-    /**
-     * Called when the sorting stopped
-     *
-     * @param {Object} $container
-     * @param {Object} ui
-     */
-    DragDrop.onSortStop = function($container, ui) {
-        var $allColumns = $container.parents(DragDrop.columnHolderIdentifier);
-        $allColumns.find(DragDrop.addContentIdentifier).show();
-        $allColumns.find(DragDrop.dropZoneAvailableIdentifier + '.active').removeClass('active');
-    };
+		// Reset inline style
+		$element.get(0).style.cssText = DragDrop.originalStyles;
 
-    /**
-     * Called when the index of the element in the sortable list has changed
-     *
-     * @param {Object} $container
-     * @param {Object} ui
-     */
-    DragDrop.onSortChange = function($container, ui) {
-        var $helper = $(ui.helper),
-            $placeholder = $(ui.placeholder);
+		$(DragDrop.dropZoneIdentifier + '.' + DragDrop.validDropZoneClass).removeClass(DragDrop.validDropZoneClass);
+	};
 
-        DragDrop.changeDropzoneVisibility($container, $placeholder, $helper);
-    };
+	/**
+	 * adds CSS classes when hovering over a dropzone
+	 * @param $draggableElement
+	 * @param $droppableElement
+	 * @private
+	 */
+	DragDrop.onDropHoverOver = function ($draggableElement, $droppableElement) {
+		if ($droppableElement.hasClass(DragDrop.validDropZoneClass)) {
+			$droppableElement.addClass(DragDrop.dropPossibleHoverClass);
+		}
+	};
 
-    /**
-     *
-     * @param {Object} $container
-     * @param {Object} $subject
-     * @param {Object} $helper
-     */
-    DragDrop.changeDropzoneVisibility = function($container, $subject, $helper) {
-        var $prev = $subject.prev(':visible'),
-            droppableClassName = DragDrop.langClassPrefix + $container.data('language-uid');
+	/**
+	 * removes the CSS classes after hovering out of a dropzone again
+	 * @param $draggableElement
+	 * @param $droppableElement
+	 * @private
+	 */
+	DragDrop.onDropHoverOut = function ($draggableElement, $droppableElement) {
+		$droppableElement.removeClass(DragDrop.dropPossibleHoverClass);
+	};
 
-        if ($prev.length === 0) {
-            $prev = $subject.prevUntil(':visible').last().prev();
+	/**
+	 * this method does the whole logic when a draggable is dropped on to a dropzone
+	 * sending out the request and afterwards move the HTML element in the right place.
+	 *
+	 * @param $draggableElement
+	 * @param $droppableElement
+	 * @param {Event} evt the event
+	 * @private
+	 */
+	DragDrop.onDrop = function ($draggableElement, $droppableElement, evt) {
+		var newColumn = DragDrop.getColumnPositionForElement($droppableElement);
 
-        }
-        $container.parents(DragDrop.columnHolderIdentifier).find(droppableClassName).find(DragDrop.contentIdentifier + ':not(.ui-sortable-helper)').not($prev).find(DragDrop.dropZoneAvailableIdentifier).addClass('active');
-        $prev.find('> '+DragDrop.dropZoneAvailableIdentifier + '.active').removeClass('active');
-        $helper.find(DragDrop.dropZoneAvailableIdentifier + '.active').removeClass('active');
-    };
+		$droppableElement.removeClass(DragDrop.dropPossibleHoverClass);
+		var $pasteAction = typeof $draggableElement === 'number';
 
-    /**
-     * Called when the new position of the element gets stored
-     *
-     * @param {Object} $container
-     * @param {Object} ui
-     */
-    DragDrop.onSortUpdate = function($container, ui) {
-        var $selectedItem = $(ui.item),
-            contentElementUid = parseInt($selectedItem.data('uid')),
-            parameters = {};
+		// send an AJAX requst via the AjaxDataHandler
+		var contentElementUid = $pasteAction ? $draggableElement : parseInt($draggableElement.data('uid'));
+		if (contentElementUid > 0) {
+			var parameters = {};
+			// add the information about a possible column position change
+			var targetFound = $droppableElement.closest(DragDrop.contentIdentifier).data('uid');
+			// the item was moved to the top of the colPos, so the page ID is used here
+			var targetPid = 0;
+			var pasteTarget = '';
+			if (typeof targetFound === 'undefined') {
+				targetFound = $droppableElement.closest('[data-colpos-pastetop]').data('colpos');
+				if (typeof targetFound !== 'undefined') {
+					// pasteTop
+					pasteTarget = targetFound;
+				}
+				// the actual page is needed
+				targetPid = $('[data-page]').first().data('page');
 
-        // send an AJAX requst via the AjaxDataHandler
-        if (contentElementUid > 0) {
+			} else {
+				// the negative value of the content element after where it should be moved
+				targetPid = 0 - parseInt(targetFound);
+			}
+			var language = parseInt($droppableElement.closest('[data-language-uid]').data('language-uid'));
+			var colPos = 0;
+			if (targetPid !== 0) {
+				colPos = newColumn;
+			}
+			parameters['cmd'] = {tt_content: {}};
+			parameters['data'] = {tt_content: {}};
+			var copyAction = (evt && evt.originalEvent.ctrlKey || $droppableElement.hasClass('t3js-paste-copy'));
+			if (copyAction) {
+				parameters['cmd']['tt_content'][contentElementUid] = {
+					copy: {
+						action: 'paste',
+						target: targetPid,
+						paste: pasteTarget,
+						update: {
+							colPos: colPos,
+							sys_language_uid: language
+						}
+					}
+				};
+				DragDrop.ajaxAction($droppableElement, $draggableElement, parameters, copyAction, $pasteAction);
+			} else {
+				parameters['data']['tt_content'][contentElementUid] = {
+					colPos: colPos,
+					sys_language_uid: language
+				};
+				if ($pasteAction) {
+					parameters = {
+						CB: {
+							paste: 'tt_content|' + targetPid,
+							update: {
+								colPos: colPos,
+								sys_language_uid: language
+							}
+						}
+					};
+				} else {
+					parameters['cmd']['tt_content'][contentElementUid] = {move: targetPid};
+				}
+				// fire the request, and show a message if it has failed
+				DragDrop.ajaxAction($droppableElement, $draggableElement, parameters, copyAction, $pasteAction);
+			}
+		}
+	};
 
-            // add the information about a possible column position change
-            parameters['data'] = {tt_content: {}};
-            parameters['data']['tt_content'][contentElementUid] = {colPos: parseInt($container.data('colpos'))};
-        }
+	/**
+	 * this method does the actual AJAX request for both, the  move and the copy action.
+	 *
+	 * @param $droppableElement
+	 * @param $draggableElement
+	 * @param parameters
+	 * @param $copyAction
+	 * @param $pasteAction
+	 * @private
+	 */
+	DragDrop.ajaxAction = function ($droppableElement, $draggableElement, parameters, $copyAction, $pasteAction) {
+		require(['TYPO3/CMS/Backend/AjaxDataHandler'], function (DataHandler) {
+			DataHandler.process(parameters).done(function (result) {
+				if (!result.hasErrors) {
+					// insert draggable on the new position
+					if (!$pasteAction) {
+						if (!$droppableElement.parent().hasClass(DragDrop.contentIdentifier.substring(1))) {
+							$draggableElement.detach().css({top: 0, left: 0})
+									.insertAfter($droppableElement.closest(DragDrop.dropZoneIdentifier));
+						} else {
+							$draggableElement.detach().css({top: 0, left: 0})
+									.insertAfter($droppableElement.closest(DragDrop.contentIdentifier));
+						}
+					}
+					if ($('.t3js-page-lang-column').length || $copyAction || $pasteAction) {
+						self.location.reload(true);
+					}
+				}
+			});
+		});
+	};
 
-        var targetContentElementUid = $selectedItem.prev().data('uid');
-        // the item was moved to the top of the colPos, so the page ID is used here
-        if (typeof targetContentElementUid === 'undefined') {
-            // the actual page is needed
-            targetContentElementUid = parseInt($container.find(DragDrop.contentIdentifier).first().data('page'));
-        } else {
-            // the negative value of the content element after where it should be moved
-            targetContentElementUid = parseInt(targetContentElementUid) * -1;
-        }
+	/**
+	 * returns the next "upper" container colPos parameter inside the code
+	 * @param $element
+	 * @return int|null the colPos
+	 */
+	DragDrop.getColumnPositionForElement = function ($element) {
+		var $columnContainer = $element.closest('[data-colpos]');
+		if ($columnContainer.length && $columnContainer.data('colpos') !== 'undefined') {
+			return $columnContainer.data('colpos');
+		} else {
+			return false;
+		}
+	};
 
-        parameters['cmd'] = {tt_content: {}};
-        parameters['cmd']['tt_content'][contentElementUid] = {move: targetContentElementUid};
-        // fire the request, and show a message if it has failed
-        require(['TYPO3/CMS/Backend/AjaxDataHandler'], function(DataHandler) {
-            DataHandler.process(parameters).done(function(result) {
-                if (result.hasErrors) {
-                    $container.sortable('cancel');
-                }
-            });
-        });
-    };
-
-    $(DragDrop.initialize);
-
-        return DragDrop;
+	$(DragDrop.initialize);
+	return DragDrop;
 });

--- a/Tests/Unit/Backend/TceMainTest.php
+++ b/Tests/Unit/Backend/TceMainTest.php
@@ -168,7 +168,8 @@ class TceMainTest extends AbstractTestCase
         $tceMainParent = $this->getCallerInstance();
         $record = Records::$contentRecordWithoutParentAndWithoutChildren;
         $command = 'update';
-        $result = $instance->processCmdmap_preProcess($command, 'tt_content', $record['uid'], $record, $tceMainParent);
+        $pasteUpdate = false;
+        $result = $instance->processCmdmap_preProcess($command, 'tt_content', $record['uid'], $record, $tceMainParent, $pasteUpdate);
         $this->assertNull($result);
     }
 
@@ -181,7 +182,8 @@ class TceMainTest extends AbstractTestCase
         $tceMainParent = $this->getCallerInstance();
         $record = null;
         $command = 'update';
-        $result = $instance->processCmdmap_preProcess($command, 'tt_content', 'NEW532cf4', $record, $tceMainParent);
+        $pasteUpdate = false;
+        $result = $instance->processCmdmap_preProcess($command, 'tt_content', 'NEW532cf4', $record, $tceMainParent, $pasteUpdate);
         $this->assertNull($result);
     }
 
@@ -194,7 +196,9 @@ class TceMainTest extends AbstractTestCase
         $tceMainParent = $this->getCallerInstance();
         $record = Records::$contentRecordWithoutParentAndWithoutChildren;
         $command = 'update';
-        $result = $instance->processCmdmap_postProcess($command, 'tt_content', $record['uid'], $record, $tceMainParent);
+        $pasteUpdate = false;
+        $dataMao = [];
+        $result = $instance->processCmdmap_postProcess($command, 'tt_content', $record['uid'], $record, $tceMainParent, $pasteUpdate, $dataMao);
         $this->assertNull($result);
     }
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,6 +3,17 @@ if (!defined('TYPO3_MODE')) {
 	die('Access denied.');
 }
 
+// Configure the CompatibilityRegistry so it will return the right values based on TYPO3 version:
+
+// We need different stylesheets for the pageLayout
+\FluidTYPO3\Flux\Utility\CompatibilityRegistry::register(
+    \FluidTYPO3\Flux\Backend\Preview::GRID_CSS,
+    array(
+        '7.6.0' => 'grid.7.6.css',
+        '8.4.1' => 'grid.css'
+    )
+);
+
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['getFlexFormDSClass']['flux'] = \FluidTYPO3\Flux\Backend\DynamicFlexForm::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][\TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools::class]['flexParsing']['flux'] = \FluidTYPO3\Flux\Backend\DynamicFlexForm::class;
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = \FluidTYPO3\Flux\Backend\TceMain::class;


### PR DESCRIPTION
Using the new DragDrop.js from TYPO3 8, which have changed from the jQuery UI sortable to droppable.
Copying the TYPO3 8 css for drag and drop.
Better drag and drop feeling.
Worked also in TYPO3 7.6 ;-)

The copy feature during drag and drop (holding the cmd-key) in TYPO3 8 is disabled in TYPO3 7.6.
This is done with a check if the localized text for 'dragdrop.copy.message' exists.

Fixed a z-index bug during dragging an element outside from a grid column.
Hide the dragged element in the column. This is useful for an element which contains a flux grid.

Tested with in TYPO3 7.6 in Chrome and Firefox.
Tests with TYPO3 8 and Internet Explorer are not done. Maybe somebody else can test this patch in IE and TYPO3 8, especially the hiding of the dragged element in the column.