### PR TITLE
[FOLLOWUP][BUGFIX] Use correct relative-to argument for sorting

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -250,7 +250,7 @@ class ContentService implements SingletonInterface
                 // Get the desired sorting value after the relative record.
                 $relativeUid = abs($relativeTo);
                 $relativeToRecord = $this->loadRecordFromDatabase($relativeUid);
-                $sorting = $tceMain->getSortNumber('tt_content', $relativeUid, $relativeTo);
+                $sorting = $tceMain->getSortNumber('tt_content', $row['uid'], $relativeTo);
                 $row['tx_flux_parent'] = $relativeToRecord['tx_flux_parent'];
                 $row['tx_flux_column'] = $relativeToRecord['tx_flux_column'];
                 $row['colPos'] = $relativeToRecord['colPos'];


### PR DESCRIPTION
The uid of the element to be moved must be specified here.