### PR TITLE
[BUGFIX] Add `tt_content` in list of tables affected by `new` command

### DIFF
--- a/Classes/Configuration/BackendConfigurationManager.php
+++ b/Classes/Configuration/BackendConfigurationManager.php
@@ -115,7 +115,7 @@ class BackendConfigurationManager extends CoreBackendConfigurationManager implem
     protected function getPageIdFromRecordIdentifiedInEditUrlArgument()
     {
         list ($table, $id, $command) = $this->getEditArguments();
-        if ('pages' === $table && 'new' === $command) {
+        if (in_array($table, ['pages', 'tt_content']) && 'new' === $command) {
             // if TYPO3 wants to insert a new page, URL argument is already the PID value.
             return $id;
         } elseif (0 !== $id && 'pages' !== $table) {

--- a/Classes/Configuration/BackendConfigurationManager.php
+++ b/Classes/Configuration/BackendConfigurationManager.php
@@ -118,7 +118,7 @@ class BackendConfigurationManager extends CoreBackendConfigurationManager implem
         if ('pages' === $table && 'new' === $command) {
             // if TYPO3 wants to insert a new page, URL argument is already the PID value.
             return $id;
-        } elseif (0 <> $id && 'pages' !== $table) {
+        } elseif (0 !== $id && 'pages' !== $table) {
             // if any identified record is being edited, load it and return the PID value.
             // if the (new) record is relative to another, $id is negative UID of relative record, hence abs().
             return $this->getPageIdFromRecordUid($table, abs($id));

--- a/Tests/Unit/Configuration/BackendConfigurationManagerTest.php
+++ b/Tests/Unit/Configuration/BackendConfigurationManagerTest.php
@@ -228,7 +228,7 @@ class BackendConfigurationManagerTest extends AbstractTestCase
     {
         return array(
             array(array('tt_content', 1, 'update'), true),
-            array(array('tt_content', -1, 'new'), true),
+            array(array('tt_content', -1, 'new'), false),
             array(array('pages', 0, 'update'), false),
             array(array('pages', 1, 'update'), false),
             array(array('pages', 1, 'delete'), false),


### PR DESCRIPTION
This commit fixes a severe issue that would return a completely wrong page id for a given record upon creation.

This could lead to really severe issue. For instance the wrong TypoScript tree was loaded for a new content using FluidContent, only on creation.

I did only add `tt_content` to the list, but I really think we should consider modify this condition to be only checking the command type to be `new`, as every record just can't have a pid when it is not even created in database yet.