### PR TITLE
[BUGFIX] Creating new element which is not a fluidcontent_content element failed.

### DIFF
--- a/Classes/Backend/DynamicFlexForm.php
+++ b/Classes/Backend/DynamicFlexForm.php
@@ -106,6 +106,17 @@ class DynamicFlexForm
         if ((integer) $record['uid']) {
             $limitedRecordData = ['uid' => $record['uid']];
         } else {
+            if (is_array($tca['config']['ds']) && count($tca['config']['ds']) > 0) {
+                // check if for CType exists a registered data structure
+                // then we don't need to build the custom identifier
+                $searchFor = ',' . $record['CType'];
+                $searchForLen = -strlen($searchFor);
+                foreach($tca['config']['ds'] as $ds => $value ) {
+                    if (substr($ds, $searchForLen) === $searchFor) {
+                        return [];
+                    }
+                }
+            }
             $defaultFields = GeneralUtility::trimExplode(',', $GLOBALS['TCA'][$tableName]['ctrl']['useColumnsForDefaultValues']);
             $defaultFields = array_combine($defaultFields, $defaultFields);
             $limitedRecordData = array_intersect_key($record, $defaultFields);


### PR DESCRIPTION
create an element - for example the standard login form, you got an error.

#1478104554: Identifier {"type":"flux","tableName":"tt_content","fieldName":"pi_flexform","record":{"colPos":"0","sys_language_uid":"0","CType":"login","tx_flux_column":"","tx_flux_parent":"0","tx_fed_fcefile":"","pi_flexform":""}} could not be resolved (More information)

TYPO3\CMS\Core\Configuration\FlexForm\Exception\InvalidIdentifierException thrown in file
/typo3/sysext/core/Classes/Configuration/FlexForm/FlexFormTools.php in line 667.

To avoid this error, now it is checked if for CType exists a registered data structure. Then it is not necessary to create the custom identifier.