### PR TITLE
[BUGFIX] Localization in flux:grid columns

### DIFF
--- a/Classes/Backend/Controller/LocalizationController.php
+++ b/Classes/Backend/Controller/LocalizationController.php
@@ -1,0 +1,36 @@
+<?php
+namespace FluidTYPO3\Flux\Backend\Controller;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+
+use FluidTYPO3\Flux\Backend\Domain\Repository\LocalizationRepository;
+use FluidTYPO3\Flux\Utility\CompatibilityRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * LocalizationController handles the AJAX requests for record localization
+ */
+class LocalizationController extends \TYPO3\CMS\Backend\Controller\Page\LocalizationController
+{
+    /**
+     * @var LocalizationRepository
+     */
+    protected $localizationRepository;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        // Overwrite the localizationRepository to the flux related one
+        $this->localizationRepository = GeneralUtility::makeInstance(CompatibilityRegistry::get(\FluidTYPO3\Flux\Backend\Domain\Repository\LocalizationRepository::class));
+    }
+}

--- a/Classes/Backend/Domain/Repository/LegacyLocalizationRepository.php
+++ b/Classes/Backend/Domain/Repository/LegacyLocalizationRepository.php
@@ -1,0 +1,83 @@
+<?php
+namespace FluidTYPO3\Flux\Backend\Domain\Repository;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+
+use FluidTYPO3\Flux\Service\ContentService;
+use FluidTYPO3\Flux\Utility\CompatibilityRegistry;
+
+/**
+ * Repository for record localizations legacy version for TYPO3 7.6
+ */
+class LegacyLocalizationRepository extends LocalizationRepository
+{
+    /**
+     * Get records for copy process
+     * We must use a legacy class, because the result of this method
+     * is in TYPO3 7.6 a mysqli_result object and in TYPO3 8 it's a \Doctrine\DBAL\Driver\Statement
+     *
+     * @param int $pageId
+     * @param int $colPos
+     * @param int $destLanguageId
+     * @param int $languageId
+     * @param string $fields
+     *
+     * @return bool|\mysqli_result|object
+     * @throws \InvalidArgumentException
+     */
+    public function getRecordsToCopyDatabaseResult($pageId, $colPos, $destLanguageId, $languageId, $fields = '*')
+    {
+        if ($colPos < ContentService::COLPOS_FLUXCONTENT) {
+            return parent::getRecordsToCopyDatabaseResult($pageId, $colPos, $destLanguageId, $languageId, $fields);
+        }
+
+        // here starts the flux related code
+        $db = $this->getDatabaseConnection();
+
+        list($fluxParent, $fluxColumn) = $this->contentService->getTargetAreaStoredInSession($colPos);
+        $fluxColumn = '\'' . $this->getDatabaseConnection()->quoteStr($fluxColumn, 'tt_content') . '\'';
+        $fluxParent = (integer) $fluxParent;
+        $pageId = (integer) $pageId;
+
+        $record = $db->exec_SELECTgetSingleRow('*','tt_content','uid = ' . $fluxParent . $this->getExcludeQueryPart());
+        $fluxParentParent = (integer) $record[CompatibilityRegistry::get(ContentService::LANGUAGE_SOURCE_FIELD)];
+        // Get original uid of existing elements triggered language / colpos
+        $originalUids = $db->exec_SELECTgetRows(
+            't3_origuid',
+            'tt_content',
+            'sys_language_uid=' . (integer) $destLanguageId
+            . ' AND tt_content.colPos = ' . ContentService::COLPOS_FLUXCONTENT
+            . ' AND tt_content.tx_flux_parent = ' . $fluxParent
+            . ' AND tt_content.tx_flux_column = ' .$fluxColumn
+            . ' AND tt_content.pid=' . $pageId
+            . $this->getExcludeQueryPart(),
+            '',
+            '',
+            '',
+            't3_origuid'
+        );
+        $originalUidList = $db->cleanIntList(implode(',', array_keys($originalUids)));
+
+        $res = $db->exec_SELECTquery(
+            $fields,
+            'tt_content',
+            'tt_content.sys_language_uid=' . (integer) $languageId
+            . ' AND tt_content.colPos = ' . ContentService::COLPOS_FLUXCONTENT
+            . ' AND tt_content.tx_flux_parent = ' . $fluxParentParent
+            . ' AND tt_content.tx_flux_column = ' .$fluxColumn
+            . ' AND tt_content.pid=' . $pageId
+            . ' AND tt_content.uid NOT IN (' . $originalUidList . ')'
+            . $this->getExcludeQueryPart(),
+            '',
+            'tt_content.sorting'
+        );
+
+        return $res;
+    }
+}

--- a/Classes/Backend/Domain/Repository/LocalizationRepository.php
+++ b/Classes/Backend/Domain/Repository/LocalizationRepository.php
@@ -1,0 +1,258 @@
+<?php
+namespace FluidTYPO3\Flux\Backend\Domain\Repository;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+
+use FluidTYPO3\Flux\Service\ContentService;
+use FluidTYPO3\Flux\Utility\CompatibilityRegistry;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+/**
+ * Repository for record localizations
+ */
+class LocalizationRepository extends \TYPO3\CMS\Backend\Domain\Repository\Localization\LocalizationRepository
+{
+    /**
+     * @var ContentService
+     */
+    protected $contentService;
+
+    public function __construct()
+    {
+        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+        $this->contentService = $objectManager->get(ContentService::class);
+    }
+
+    /**
+     * Fetch the language from which the records of a colPos in a certain language were initially localized
+     *
+     * @param int $pageId
+     * @param int $colPos
+     * @param int $localizedLanguage
+     *
+     * @return array|false
+     */
+    public function fetchOriginLanguage($pageId, $colPos, $localizedLanguage)
+    {
+        if ($colPos <= ContentService::COLPOS_FLUXCONTENT) {
+            parent::fetchOriginLanguage($pageId, $colPos, $localizedLanguage);
+        }
+
+        // here starts the flux related code
+        list($fluxParent, $fluxColumn) = $this->contentService->getTargetAreaStoredInSession($colPos);
+        $db = $this->getDatabaseConnection();
+
+        $record = $db->exec_SELECTgetSingleRow(
+            'tt_content_orig.sys_language_uid',
+            'tt_content,tt_content AS tt_content_orig,sys_language',
+            'tt_content.colPos = ' . ContentService::COLPOS_FLUXCONTENT
+            . ' AND tt_content.tx_flux_parent = ' . (integer)$fluxParent
+            . ' AND tt_content.tx_flux_column = \'' . $this->getDatabaseConnection()->quoteStr($fluxColumn,
+                'tt_content') . '\''
+            . ' AND tt_content.pid = ' . (int)$pageId
+            . ' AND tt_content.sys_language_uid = ' . (int)$localizedLanguage
+            . ' AND tt_content.' . CompatibilityRegistry::get(ContentService::LANGUAGE_SOURCE_FIELD) . ' = tt_content_orig.uid'
+            . ' AND tt_content_orig.sys_language_uid=sys_language.uid'
+            . $this->getExcludeQueryPart()
+            . $this->getAllowedLanguagesForBackendUser(),
+            'tt_content_orig.sys_language_uid'
+        );
+
+        return $record;
+    }
+
+    /**
+     * @param int $pageId
+     * @param int $colPos
+     * @param int $languageId
+     *
+     * @return int
+     */
+    public function getLocalizedRecordCount($pageId, $colPos, $languageId)
+    {
+        if ($colPos <= ContentService::COLPOS_FLUXCONTENT) {
+            return parent::getLocalizedRecordCount($pageId, $colPos, $languageId);
+        }
+
+        // here starts the flux related code
+        list($fluxParent, $fluxColumn) = $this->contentService->getTargetAreaStoredInSession($colPos);
+        $db = $this->getDatabaseConnection();
+
+        $record = $db->exec_SELECTgetSingleRow('*', 'tt_content',
+            'uid = ' . (integer)$fluxParent . $this->getExcludeQueryPart() . $this->getAllowedLanguagesForBackendUser());
+
+        $rows = false;
+        if ($record !== null) {
+
+            $rows = (int)$db->exec_SELECTcountRows(
+                'uid',
+                'tt_content',
+                'tt_content.sys_language_uid=' . (integer)$languageId
+                . ' AND tt_content.colPos = ' . ContentService::COLPOS_FLUXCONTENT
+                . ' AND tt_content.tx_flux_parent = ' . (integer)$fluxParent
+                . ' AND tt_content.tx_flux_column = \'' . $this->getDatabaseConnection()->quoteStr($fluxColumn,
+                    'tt_content') . '\''
+                . ' AND tt_content.pid=' . (integer)$pageId
+                . ' AND tt_content.' . CompatibilityRegistry::get(ContentService::LANGUAGE_SOURCE_FIELD) . ' <> 0'
+                . $this->getExcludeQueryPart()
+            );
+        }
+        return $rows;
+    }
+
+    /**
+     * Fetch all available languages
+     *
+     * @param int $pageId
+     * @param int $colPos
+     * @param int $languageId
+     *
+     * @return array
+     * @throws \InvalidArgumentException
+     */
+    public function fetchAvailableLanguages($pageId, $colPos, $languageId)
+    {
+        if ($colPos <= ContentService::COLPOS_FLUXCONTENT) {
+            return parent::fetchAvailableLanguages($pageId, $colPos, $languageId);
+        }
+
+        // here starts the flux related code
+        list($fluxParent, $fluxColumn) = $this->contentService->getTargetAreaStoredInSession($colPos);
+        $result = $this->getDatabaseConnection()->exec_SELECTgetRows(
+            'sys_language.uid',
+            'tt_content,sys_language',
+            'tt_content.sys_language_uid=sys_language.uid'
+            . ' AND tt_content.colPos = ' . ContentService::COLPOS_FLUXCONTENT
+            . ' AND tt_content.tx_flux_parent = ' . (integer)$fluxParent
+            . ' AND tt_content.tx_flux_column = \'' . $this->getDatabaseConnection()->quoteStr($fluxColumn, 'tt_content') . '\''
+            . ' AND tt_content.pid = ' . (int)$pageId
+            . ' AND sys_language.uid <> ' . (int)$languageId
+            . $this->getExcludeQueryPart()
+            . $this->getAllowedLanguagesForBackendUser(),
+            'sys_language.uid',
+            'sys_language.title'
+        );
+
+        return $result;
+    }
+
+    /**
+     * /**
+     * Get records for copy process
+     *
+     * @param int $pageId
+     * @param int $colPos
+     * @param int $destLanguageId
+     * @param int $languageId
+     * @param string $fields
+     *
+     * @return \Doctrine\DBAL\Driver\Statement
+     * @throws \InvalidArgumentException
+     */
+    public function getRecordsToCopyDatabaseResult($pageId, $colPos, $destLanguageId, $languageId, $fields = '*')
+    {
+        if ($colPos <= ContentService::COLPOS_FLUXCONTENT) {
+            return parent::getRecordsToCopyDatabaseResult($pageId, $colPos, $destLanguageId, $languageId, $fields);
+        }
+
+        // here starts the flux related code
+        $db = $this->getDatabaseConnection();
+
+        list($fluxParent, $fluxColumn) = $this->contentService->getTargetAreaStoredInSession($colPos);
+
+        $record = $db->exec_SELECTgetSingleRow('*','tt_content','uid = ' . (integer) $fluxParent);
+            $fluxParentParent = $record[CompatibilityRegistry::get(ContentService::LANGUAGE_SOURCE_FIELD)];
+        
+        $originalUids = [];
+
+        // Get original uid of existing elements triggered language / colpos
+        $queryBuilder = $this->getQueryBuilderWithWorkspaceRestriction('tt_content');
+
+        $originalUidsStatement = $queryBuilder
+            ->select(CompatibilityRegistry::get(ContentService::LANGUAGE_SOURCE_FIELD))
+            ->from('tt_content')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'sys_language_uid',
+                    $queryBuilder->createNamedParameter($destLanguageId, \PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    'tt_content.colPos',
+                    $queryBuilder->createNamedParameter(ContentService::COLPOS_FLUXCONTENT, \PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    'tt_content.tx_flux_parent',
+                    $queryBuilder->createNamedParameter($fluxParent, \PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    'tt_content.tx_flux_column',
+                    $queryBuilder->createNamedParameter($fluxColumn, \PDO::PARAM_STR)
+                ),
+                $queryBuilder->expr()->eq(
+                    'tt_content.pid',
+                    $queryBuilder->createNamedParameter($pageId, \PDO::PARAM_INT)
+                )
+            )
+            ->execute();
+
+        while ($origUid = $originalUidsStatement->fetchColumn(0)) {
+            $originalUids[] = (int)$origUid;
+        }
+
+        $queryBuilder->select(...GeneralUtility::trimExplode(',', $fields, true))
+            ->from('tt_content')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'tt_content.sys_language_uid',
+                    $queryBuilder->createNamedParameter($languageId, \PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    'tt_content.colPos',
+                    $queryBuilder->createNamedParameter(ContentService::COLPOS_FLUXCONTENT, \PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    'tt_content.tx_flux_parent',
+                    $queryBuilder->createNamedParameter($fluxParentParent, \PDO::PARAM_INT)
+                ),
+                $queryBuilder->expr()->eq(
+                    'tt_content.tx_flux_column',
+                    $queryBuilder->createNamedParameter($fluxColumn, \PDO::PARAM_STR)
+                ),
+                $queryBuilder->expr()->eq(
+                    'tt_content.pid',
+                    $queryBuilder->createNamedParameter($pageId, \PDO::PARAM_INT)
+                )
+            )
+            ->orderBy('tt_content.sorting');
+
+        if (!empty($originalUids)) {
+            $queryBuilder
+                ->andWhere(
+                    $queryBuilder->expr()->notIn(
+                        'tt_content.uid',
+                        $queryBuilder->createNamedParameter($originalUids, Connection::PARAM_INT_ARRAY)
+                    )
+                );
+        }
+
+        return $queryBuilder->execute();
+    }
+
+    /**
+     * Returns the database connection
+     *
+     * @return \TYPO3\CMS\Core\Database\DatabaseConnection
+     */
+    protected function getDatabaseConnection()
+    {
+        return $GLOBALS['TYPO3_DB'];
+    }
+}

--- a/Classes/Backend/TceMain.php
+++ b/Classes/Backend/TceMain.php
@@ -12,6 +12,7 @@ use FluidTYPO3\Flux\Provider\ProviderInterface;
 use FluidTYPO3\Flux\Service\ContentService;
 use FluidTYPO3\Flux\Service\FluxService;
 use FluidTYPO3\Flux\Service\RecordService;
+use FluidTYPO3\Flux\Utility\CompatibilityRegistry;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\DatabaseConnection;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
@@ -47,6 +48,11 @@ class TceMain
      * @var ContentService
      */
     protected $contentService;
+
+    /**
+     * @var array
+     */
+    protected $datamap = [];
 
     /**
      * @var boolean
@@ -241,6 +247,63 @@ class TceMain
     }
 
     /**
+     * Command map process method
+     *
+     * Listen for localization commands for creating localized elements in flux columns
+     *
+     * @param string $command The TCEmain operation status, fx. 'update'
+     * @param string $table The table TCEmain is currently processing
+     * @param string $id The records id (if any)
+     * @param mixed $value
+     * @param boolean $commandIsProcessed
+     * @param DataHandler $reference Reference to the parent object (TCEmain)
+     * @param array $pasteUpdate Extended paste command
+     */
+    public function processCmdmap($command, $table, $id, &$value, &$commandIsProcessed, &$reference, $pasteUpdate) {
+        // unset internal datamap
+        $this->datamap = [];
+
+        if ($table === 'tt_content' && ($command === 'localize' || $command === 'copyToLanguage')) {
+
+            $sourceRecord = $this->resolveRecordForOperation($table, $id);
+
+            // check if a flux_parent exists
+            if ((integer)$sourceRecord['tx_flux_parent'] > 0) {
+                // to identicate the correct flux_parent:
+                // Get the record which t3_origuid|l10n_source is related to the flux_parent of the current record
+                $fluxParentRecord = $this->getDatabaseConnection()->exec_SELECTgetSingleRow('*', 'tt_content',
+                    CompatibilityRegistry::get(ContentService::LANGUAGE_SOURCE_FIELD) . ' = ' . (integer)$sourceRecord['tx_flux_parent']
+                    . ' AND sys_language_uid = ' . (integer)$value
+                    . $this->contentService->getExcludeQueryPart()
+                    . $this->contentService->getAllowedLanguagesForBackendUser());
+
+                if ($fluxParentRecord !== null) {
+
+                    // now create the localized element
+                    // we need the new uid of the localized element
+                    $newId = $reference->localize($table, $id, $value);
+                    if (!empty($newId)) {
+                        // we create an internal datamap to use it later for the DataHandler's $pasteDataMap
+                        // in the processCmdmap_postProcess
+                        //
+                        // the array contains the necessary values for flux
+                        // - uid of the new localized element
+                        // - tx_flux_parent of $fluxParentRecord
+                        $this->datamap = [
+                            'uid' => $newId,
+                            'tx_flux_parent' => $fluxParentRecord['uid'],
+                        ];
+                    } else {
+                        // todo: throw an error here?
+                    }
+                    $commandIsProcessed = true;
+                }
+            }
+
+        }
+    }
+
+    /**
      * Command post processing method
      *
      * Like other pre/post methods this method calls the corresponding
@@ -267,6 +330,18 @@ class TceMain
         if ($table === 'tt_content') {
             if ('localize' === $command) {
                 $this->contentService->fixPositionInLocalization($id, $relativeTo, $record, $reference);
+            }
+
+            if ('localize' === $command|| 'copyToLanguage' === $command)  {
+
+                if (count($this->datamap) > 0) {
+                    // update DataHandler->datamap with $this->datamap values
+                    $this->contentService->updateRecordInDataMap($this->datamap, null, $reference);
+                    // we must set here $pasteDataMap, because the overlaying values stored in DataHandler->datamap
+                    // are ignored later in the DataHandler
+                    // see https://github.com/TYPO3/TYPO3.CMS/blob/5ef31ecdde74ae11e33290d59751c5292291e303/typo3/sysext/core/Classes/DataHandling/DataHandler.php#L3248
+                    $pasteDataMap = $reference->datamap;
+                }
             }
 
             $properties = [];

--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -24,6 +24,7 @@ class ContentService implements SingletonInterface
 {
 
     const COLPOS_FLUXCONTENT = 18181;
+    const LANGUAGE_SOURCE_FIELD = 'l10n_source';
 
     /**
      * @var RecordService
@@ -394,7 +395,7 @@ class ContentService implements SingletonInterface
      * @param DataHandler $dataHandler
      * @return void
      */
-    protected function updateRecordInDataMap(array $row, $uid = null, DataHandler $dataHandler)
+    public function updateRecordInDataMap(array $row, $uid = null, DataHandler $dataHandler)
     {
         if (null === $uid) {
             $uid = $row['uid'];
@@ -440,23 +441,31 @@ class ContentService implements SingletonInterface
             $defaultRecordUid = $uid;
         }
         $localizedRecord = BackendUtility::getRecordLocalization('tt_content', $defaultRecordUid, $languageUid);
+
+        // if localize elements which were localized with the copy mode the 'l18n_parent' is 0
+        // so we can't get the localizedRecord here
+        if (count($localizedRecord) > 0) {
         $sortingRow = $GLOBALS['TCA']['tt_content']['ctrl']['sortby'];
+            $sorting = [
+                'uid' => $localizedRecord[0]['uid']
+            ];
         if (null === $previousLocalizedRecordUid) {
             // moving to first position in tx_flux_column
-            $localizedRecord[0][$sortingRow] = $reference->getSortNumber(
+                $sorting[$sortingRow] = $reference->getSortNumber(
                 'tt_content',
                 0,
                 $sourceRecord['pid']
             );
         } else {
-            $localizedRecord[0][$sortingRow] = $reference->resorting(
+                $sorting[$sortingRow] = $reference->resorting(
                 'tt_content',
                 $sourceRecord['pid'],
                 $sortingRow,
                 $previousLocalizedRecordUid
             );
         }
-        $this->updateRecordInDataMap($localizedRecord[0], null, $reference);
+            $this->updateRecordInDataMap($sorting, null, $reference);
+        }
     }
 
     /**
@@ -512,5 +521,56 @@ class ContentService implements SingletonInterface
             $GLOBALS['TYPO3_DB']->sql_free_result($res);
         }
         return $previousLocalizedRecordUid;
+    }
+
+    /**
+     * Builds an additional where clause to exclude deleted records and setting the versioning placeholders
+     *
+     * @return string
+     */
+    public function getExcludeQueryPart()
+    {
+        return BackendUtility::deleteClause('tt_content') . BackendUtility::versioningPlaceholderClause('tt_content');
+    }
+
+    /**
+     * Builds an additional where clause to exclude hidden languages and limit a backend user to its allowed languages,
+     * if the user is not an admin.
+     *
+     * @return string
+     */
+    public function getAllowedLanguagesForBackendUser()
+    {
+        $backendUser = $this->getBackendUser();
+        $additionalWhere = '';
+        if (!$backendUser->isAdmin()) {
+            $additionalWhere .= ' AND sys_language.hidden=0';
+
+            if (!empty($backendUser->user['allowed_languages'])) {
+                $additionalWhere .= ' AND sys_language.uid IN(' . implode(',', GeneralUtility::intExplode(',', $backendUser->user['allowed_languages'])) . ')';
+            }
+        }
+
+        return $additionalWhere;
+    }
+
+    /**
+     * Returns the database connection
+     *
+     * @return \TYPO3\CMS\Core\Database\DatabaseConnection
+     */
+    protected function getDatabaseConnection()
+    {
+        return $GLOBALS['TYPO3_DB'];
+    }
+
+    /**
+     * Returns the current BE user.
+     *
+     * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+     */
+    protected function getBackendUser()
+    {
+        return $GLOBALS['BE_USER'];
     }
 }

--- a/Classes/View/PageLayoutView.php
+++ b/Classes/View/PageLayoutView.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Flux\View;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Flux\Service\ContentService;
+
 class PageLayoutView extends \TYPO3\CMS\Backend\View\PageLayoutView
 {
     /**
@@ -35,4 +37,66 @@ class PageLayoutView extends \TYPO3\CMS\Backend\View\PageLayoutView
     {
         parent::generateTtContentDataArray($rowArray);
     }
+
+    /**
+     * @return PageLayoutController
+     */
+    public function getPageLayoutController()
+    {
+        return parent::getPageLayoutController();
 }
+
+    /**
+     * Checks whether translated Content Elements exist in the desired language
+     * If so, deny creating new ones via the UI
+     *
+     * @param array $contentElements
+     * @param int $language
+     * @return bool
+     */
+    public function checkIfTranslationsExistInLanguage(array $contentElements, $language)
+    {
+        return parent::checkIfTranslationsExistInLanguage($contentElements, $language);
+    }
+
+    /**
+     * Gets content records per column.
+     * This is required for correct workspace overlays.
+     *
+     * @param int $id Page Id to be used (not used at all, but part of the API, see $this->pidSelect)
+     * @param int $fluxParent Id of tx_flux_parent
+     * @param string $columnName tx_flux_column value to be considered to be shown
+     * @param string $additionalWhereClause Additional where clause for database select
+     * @return array Associative array for each column (colPos)
+     */
+    public function getContentRecordsPerFluxColumn($id, $fluxParent, $columnName, $additionalWhereClause = '')
+    {
+        $additionalWhereClause = $additionalWhereClause ? ' AND ' . $additionalWhereClause : '';
+        $columnName = '\'' . $this->getDatabase()->quoteStr($columnName, 'tt_content') . '\'';
+        $queryParts = $this->makeQueryArray('tt_content', $id,
+            'AND colPos = ' . (integer)ContentService::COLPOS_FLUXCONTENT
+            . ' AND tx_flux_parent = ' . (integer) $fluxParent
+            . ' AND tx_flux_column = ' . $columnName . $additionalWhereClause);
+        $result = $this->getDatabase()->exec_SELECT_queryArray($queryParts);
+        // Traverse any selected elements and render their display code:
+        $rowArr = $this->getResult($result);
+        $contentRecordsPerColumn = [];
+
+        foreach ($rowArr as $record) {
+            $contentRecordsPerColumn[ContentService::COLPOS_FLUXCONTENT][] = $record;
+        }
+
+        return $contentRecordsPerColumn;
+    }
+
+    /**
+     * @return DatabaseConnection
+     */
+    protected function getDatabase()
+    {
+        return $GLOBALS['TYPO3_DB'];
+    }
+
+
+}
+

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Definitions for routes provided by EXT:backend
+ * Contains all AJAX-based routes for entry points
+ *
+ * Currently the "access" property is only used so no token creation + validation is made
+ * but will be extended further.
+ */
+use FluidTYPO3\Flux\Backend\Controller\LocalizationController;
+
+return [
+
+    // Get languages in page and colPos
+    'languages_page_colpos' => [
+        'path' => '/records/localize/get-languages',
+        'target' => LocalizationController::class . '::getUsedLanguagesInPageAndColumn'
+    ],
+
+    // Get summary of records to localize
+    'records_localize_summary' => [
+        'path' => '/records/localize/summary',
+        'target' => LocalizationController::class . '::getRecordLocalizeSummary'
+    ],
+    // Localize the records
+    'records_localize' => [
+        'path' => '/records/localize',
+        'target' => LocalizationController::class . '::localizeRecords'
+    ]
+
+];

--- a/Tests/Unit/View/PreviewViewTest.php
+++ b/Tests/Unit/View/PreviewViewTest.php
@@ -155,6 +155,7 @@ class PreviewViewTest extends AbstractTestCase
         $databaseConnectionMock = $this->getMockBuilder(DatabaseConnection::class)->getMock();
         $databaseConnectionMock->expects($this->any())->method('sql_fetch_assoc')->willReturn([]);
         $pageLayoutView = $this->getMockBuilder(PageLayoutView::class)->setMethods(['initializeLanguages'])->getMock();
+        $pageLayoutView->expects($this->any())->method('getDatabase')->willReturn($databaseConnectionMock);
         $previewView = $this->getMockBuilder($this->createInstanceClassName())
             ->setMethods(array('registerTargetContentAreaInSession', 'getDatabaseConnection', 'getPageLayoutView'))
             ->getMock();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -37,6 +37,24 @@ if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_INSTALL)) {
         )
     );
 
+    // PreviewView class name (expecting needed changes on TYPO3 8.6+)
+    \FluidTYPO3\Flux\Utility\CompatibilityRegistry::register(
+        \FluidTYPO3\Flux\Service\ContentService::LANGUAGE_SOURCE_FIELD,
+        array(
+            '7.6.0' => 't3_origuid',
+            '8.6.0' => 'l10n_source'
+        )
+    );
+
+    // We need For Localization in TYPO3 7.6 a modified Version see comments in LegacyLocalizationRepository
+    \FluidTYPO3\Flux\Utility\CompatibilityRegistry::register(
+        \FluidTYPO3\Flux\Backend\Domain\Repository\LocalizationRepository::class,
+        [
+            '7.6.0' => \FluidTYPO3\Flux\Backend\Domain\Repository\LegacyLocalizationRepository::class,
+            '8.6.0' => \FluidTYPO3\Flux\Backend\Domain\Repository\LocalizationRepository::class
+        ]
+    );
+
 	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin('FluidTYPO3.Flux', 'API', array('Flux' => 'renderChildContent'), array());
 
 	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScript($_EXTKEY, 'setup', '


### PR DESCRIPTION
FluidTYPO3\Flux\Backend\Controller\LocalizationController
*  extended class of `\TYPO3\CMS\Backend\Controller\Page\LocalizationController`

AjaxRoutes to \TYPO3\CMS\Backend\Controller\Page\LocalizationController
*  `flux_languages_page_colpos` -> get available languages of the flux:grid column (step 2 of 4 in the localization process)
*  `flux_records_localize_summary` -> get the uid, icon and title off all elements which would localized ( step 3 of 4  in the localization process)
*  `flux_records_localize` -> build the cmdMap with the elements uids and own commands  and additional flux specific data

FluidTYPO3\Flux\Backend\Preview
*  `Localization.js` is adjusted to work with flux:grid

FluidTYPO3\Flux\Backend\TceMain
*  `processCmdMap` to handle the localization for flux:grid elements
*  `processCmdmap_postProcess to add Data in `$pasteDataMap`

\TYPO3\CMS\Backend\Domain\Repository\LocalizationRepository
*  to handle flux related fields `tx_flux_colum` and `tx_flux_parent`

\TYPO3\CMS\View\PreviewView
*  extended the gridcolumn template with data-flux-column and data-flux-parent

resolves #1120