### PR TITLE
[BUGFIX] Paste into icon is shown twice in TYPO3v8.6

### DIFF
--- a/Classes/Backend/TceMain.php
+++ b/Classes/Backend/TceMain.php
@@ -256,9 +256,11 @@ class TceMain
      * @param string $id The records id (if any)
      * @param string $relativeTo Filled if command is relative to another element
      * @param DataHandler $reference Reference to the parent object (TCEmain)
+     * @param boolean $pasteUpdate
+     * @param array $pasteDataMap
      * @return void
      */
-    public function processCmdmap_postProcess(&$command, $table, $id, &$relativeTo, &$reference)
+    public function processCmdmap_postProcess(&$command, $table, $id, &$relativeTo, &$reference, $pasteUpdate, &$pasteDataMap)
     {
         $record = $this->resolveRecordForOperation($table, $id);
 
@@ -271,6 +273,10 @@ class TceMain
             $clipboardCommand = (array) $this->getClipboardCommand();
             if (!empty($clipboardCommand['paste']) && strpos($clipboardCommand['paste'], 'tt_content|') === 0) {
                 $properties = (array) $clipboardCommand['update'];
+                if ($properties['colPos'] > ContentService::COLPOS_FLUXCONTENT) {
+                    $properties['colPos'] = ContentService::COLPOS_FLUXCONTENT;
+                    $pasteDataMap[$table][$id]['colPos'] = ContentService::COLPOS_FLUXCONTENT;
+                }
                 $clipboardCommand = GeneralUtility::trimExplode('|', $clipboardCommand['paste']);
             }
 

--- a/Classes/Form/AbstractFormField.php
+++ b/Classes/Form/AbstractFormField.php
@@ -212,7 +212,7 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
         $configuration = $this->buildConfiguration();
         $fieldStructureArray = [
             'label' => $this->getLabel(),
-            'exclude' => intval($this->getExclude()),
+            'exclude' =>                                                                                                                                intval($this->getExclude()),
             'config' => $configuration,
             'displayCond' => $this->getDisplayCondition()
         ];

--- a/Classes/Form/AbstractFormField.php
+++ b/Classes/Form/AbstractFormField.php
@@ -212,7 +212,7 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
         $configuration = $this->buildConfiguration();
         $fieldStructureArray = [
             'label' => $this->getLabel(),
-            'exclude' =>                                                                                                                                intval($this->getExclude()),
+            'exclude' => intval($this->getExclude()),
             'config' => $configuration,
             'displayCond' => $this->getDisplayCondition()
         ];

--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -234,7 +234,7 @@ class ContentService implements SingletonInterface
                 list ($parent, $column) = $this->getTargetAreaStoredInSession($relativeTo);
                 $row['tx_flux_parent'] = $parent;
                 $row['tx_flux_column'] = $column;
-                $row['colPos'] = self::COLPOS_FLUXCONTENT;
+                $row['colPos'] = static::COLPOS_FLUXCONTENT;
                 $row['sorting'] = 0;
             } elseif (0 <= (integer) $relativeTo && false === empty($parameters[1])) {
                 // Special case for clipboard commands only. This special case also requires a new
@@ -278,7 +278,7 @@ class ContentService implements SingletonInterface
             $row['tx_flux_column'] = null;
         }
         if (0 < $row['tx_flux_parent']) {
-            $row['colPos'] = self::COLPOS_FLUXCONTENT;
+            $row['colPos'] = static::COLPOS_FLUXCONTENT;
         }
     }
 

--- a/Classes/Utility/ClipBoardUtility.php
+++ b/Classes/Utility/ClipBoardUtility.php
@@ -80,7 +80,7 @@ class ClipBoardUtility
             $icon = MiscellaneousUtility::getIcon('actions-insert-reference');
             $title = LocalizationUtility::translate('paste_reference', 'Flux');
         } else {
-            $icon = MiscellaneousUtility::getIcon('actions-document-paste-after');
+            $icon = MiscellaneousUtility::getIcon('actions-document-paste-into');
             $title = LocalizationUtility::translate('paste', 'Flux');
         }
 

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -395,8 +395,8 @@ class PreviewView
             $parentRow['pid'],
             $parentRow['uid'],
             $record['uid'],
-            $this->drawNewIcon($parentRow, $column, $record['uid']).
-            (CompatibilityRegistry::get(static::class . '->drawPasteIcon') ? $this->drawPasteIcon($parentRow, $column, false, $record) : '').
+            $this->drawNewIcon($parentRow, $column, $record['uid']) .
+            (CompatibilityRegistry::get(static::class . '->drawPasteIcon') ? $this->drawPasteIcon($parentRow, $column, false, $record) : '') .
             $this->drawPasteIcon($parentRow, $column, true, $record)
         );
     }

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -396,7 +396,7 @@ class PreviewView
             $parentRow['uid'],
             $record['uid'],
             $this->drawNewIcon($parentRow, $column, $record['uid']).
-            (CompatibilityRegistry::get(self::class) ? $this->drawPasteIcon($parentRow, $column, false, $record) : '').
+            (CompatibilityRegistry::get(static::class . '->drawPasteIcon') ? $this->drawPasteIcon($parentRow, $column, false, $record) : '').
             $this->drawPasteIcon($parentRow, $column, true, $record)
         );
     }
@@ -792,7 +792,7 @@ class PreviewView
             $pageUid,
             $id,
             $this->drawNewIcon($row, $column),
-            CompatibilityRegistry::get(self::class) ? $this->drawPasteIcon($row, $column) : '',
+            CompatibilityRegistry::get(static::class . '->drawPasteIcon') ? $this->drawPasteIcon($row, $column) : '',
             $this->drawPasteIcon($row, $column, true),
             $content
         );

--- a/Classes/View/PreviewView.php
+++ b/Classes/View/PreviewView.php
@@ -16,6 +16,7 @@ use FluidTYPO3\Flux\Service\ContentService;
 use FluidTYPO3\Flux\Service\FluxService;
 use FluidTYPO3\Flux\Service\WorkspacesAwareRecordService;
 use FluidTYPO3\Flux\Utility\ClipBoardUtility;
+use FluidTYPO3\Flux\Utility\CompatibilityRegistry;
 use FluidTYPO3\Flux\Utility\MiscellaneousUtility;
 use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
 use TYPO3\CMS\Backend\Controller\PageLayoutController;
@@ -395,7 +396,7 @@ class PreviewView
             $parentRow['uid'],
             $record['uid'],
             $this->drawNewIcon($parentRow, $column, $record['uid']).
-            $this->drawPasteIcon($parentRow, $column, false, $record).
+            (CompatibilityRegistry::get(self::class) ? $this->drawPasteIcon($parentRow, $column, false, $record) : '').
             $this->drawPasteIcon($parentRow, $column, true, $record)
         );
     }
@@ -791,7 +792,7 @@ class PreviewView
             $pageUid,
             $id,
             $this->drawNewIcon($row, $column),
-            $this->drawPasteIcon($row, $column),
+            CompatibilityRegistry::get(self::class) ? $this->drawPasteIcon($row, $column) : '',
             $this->drawPasteIcon($row, $column, true),
             $content
         );

--- a/Tests/Unit/Backend/TceMainTest.php
+++ b/Tests/Unit/Backend/TceMainTest.php
@@ -194,7 +194,9 @@ class TceMainTest extends AbstractTestCase
         $tceMainParent = $this->getCallerInstance();
         $record = Records::$contentRecordWithoutParentAndWithoutChildren;
         $command = 'update';
-        $result = $instance->processCmdmap_postProcess($command, 'tt_content', $record['uid'], $record, $tceMainParent);
+        $pasteUpdate = false;
+        $pasteMap = [];
+        $result = $instance->processCmdmap_postProcess($command, 'tt_content', $record['uid'], $record, $tceMainParent, $pasteUpdate, $pasteMap);
         $this->assertNull($result);
     }
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -27,6 +27,16 @@ if (TYPO3_MODE === 'BE') {
 if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_INSTALL)) {
 	$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] = unserialize($_EXTCONF);
 
+    // Configure the CompatibilityRegistry so it will return the right values based on TYPO3 version:
+    // PreviewView class name (expecting needed changes on TYPO3 8.6+)
+    \FluidTYPO3\Flux\Utility\CompatibilityRegistry::register(
+        \FluidTYPO3\Flux\View\PreviewView::class,
+        array(
+            '7.6.0' => true,
+            '8.6.0' => false
+        )
+    );
+
 	\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin('FluidTYPO3.Flux', 'API', array('Flux' => 'renderChildContent'), array());
 
 	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScript($_EXTKEY, 'setup', '

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -30,7 +30,7 @@ if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_INSTALL)) {
     // Configure the CompatibilityRegistry so it will return the right values based on TYPO3 version:
     // PreviewView class name (expecting needed changes on TYPO3 8.6+)
     \FluidTYPO3\Flux\Utility\CompatibilityRegistry::register(
-        \FluidTYPO3\Flux\View\PreviewView::class,
+        \FluidTYPO3\Flux\View\PreviewView::class . '->drawPasteIcon',
         array(
             '7.6.0' => true,
             '8.6.0' => false


### PR DESCRIPTION
since v8.6 the paste icons are inserted with javascript.

change the icon from "actions-document-paste-after" into "actions-document-paste-into" for TYPO3 version lower than 8.6