### PR TITLE
[BUGFIX] Cut and Paste element in empty flux:grid column

### DIFF
--- a/Classes/Backend/TceMain.php
+++ b/Classes/Backend/TceMain.php
@@ -256,9 +256,11 @@ class TceMain
      * @param string $id The records id (if any)
      * @param string $relativeTo Filled if command is relative to another element
      * @param DataHandler $reference Reference to the parent object (TCEmain)
+     * @param array $pasteUpdate Extended paste command
+     * @param array $pasteDataMap Reference to the additional data, which is inserted to the record after processCmdmap_postProcess
      * @return void
      */
-    public function processCmdmap_postProcess(&$command, $table, $id, &$relativeTo, &$reference)
+    public function processCmdmap_postProcess(&$command, $table, $id, &$relativeTo, &$reference, $pasteUpdate, &$pasteDataMap)
     {
         $record = $this->resolveRecordForOperation($table, $id);
 
@@ -299,6 +301,12 @@ class TceMain
                     if ($mostRecentVersionOfRecord) {
                         $this->contentService->moveRecord($mostRecentVersionOfRecord, $relativeTo, $clipboardCommand, $reference);
                         $this->recordService->update($table, $mostRecentVersionOfRecord);
+                    }
+
+                    if ($command === 'move') {
+                        // important! we must unset the colPos in the pasteDataMap
+                        // otherwise it will be use later in the DataHandler
+                        unset($pasteDataMap[$table][$id]['colPos']);
                     }
                 }
             }

--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -241,6 +241,11 @@ class ContentService implements SingletonInterface
                 // sorting value to re-sort after a possibly invalid sorting value is received.
                 list ($pageUid, , $relativeTo, $parentUid, $area, $column) =
                     GeneralUtility::trimExplode('-', $parameters[1]);
+                // if $area is null and $row['colPos'] > 18181 then we have a move to an empty row
+                if ($area === null && $row['colPos'] > self::COLPOS_FLUXCONTENT) {
+                    list($parentUid, $area) = $this->getTargetAreaStoredInSession($row['colPos']);
+                }
+
                 $sorting = $tceMain->getSortNumber('tt_content', $row['uid'], -(integer) $relativeTo);
                 $row['tx_flux_parent'] = $parentUid;
                 $row['tx_flux_column'] = $area;

--- a/Tests/Unit/Backend/TceMainTest.php
+++ b/Tests/Unit/Backend/TceMainTest.php
@@ -194,7 +194,9 @@ class TceMainTest extends AbstractTestCase
         $tceMainParent = $this->getCallerInstance();
         $record = Records::$contentRecordWithoutParentAndWithoutChildren;
         $command = 'update';
-        $result = $instance->processCmdmap_postProcess($command, 'tt_content', $record['uid'], $record, $tceMainParent);
+        $pasteUpdate = false;
+        $pasteDataMap = [];
+        $result = $instance->processCmdmap_postProcess($command, 'tt_content', $record['uid'], $record, $tceMainParent, $pasteUpdate, $pasteDataMap);
         $this->assertNull($result);
     }
 


### PR DESCRIPTION
The colPos was not correct. It was used the colPos > 18181
Reason:
- in moveRecord there is no areaName set in $parameters[1], so we must fetch the colPos from the $row record and use it to get the columnName from the session stored colPos values.
- command 'move' is using $pasteDataMap and there the colPos is stored. the colPos has a value > 18181 and must unset in $pasteDataMap