### PR TITLE
[BUGFIX] Allow installation in TYPO3 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": ">=7.0.0",
-        "typo3/cms": "^7.6"
+        "typo3/cms": "^7.6|^8.7"
     },
     "replace": {
         "flux": "self.version",


### PR DESCRIPTION
Beware that I raised the constraint from `^8.4.1` to `8.7`, but I think it makes absolute sense.

Ref: https://github.com/FluidTYPO3/flux/pull/1401#issuecomment-296576474