### PR TITLE
[BUGFIX] Adapt to FlexForm language handling deprecation

### DIFF
--- a/Classes/ViewHelpers/Form/DataViewHelper.php
+++ b/Classes/ViewHelpers/Form/DataViewHelper.php
@@ -147,12 +147,7 @@ class DataViewHelper extends AbstractViewHelper implements CompilableInterface
         if (0 === count($providers)) {
             $lang = static::getCurrentLanguageName();
             $pointer = static::getCurrentValuePointerName();
-            $dataArray = static::$configurationService->convertFlexFormContentToArray(
-                $record[$field],
-                null,
-                'lDEF',
-                'vDEF'
-            );
+            $dataArray = static::$configurationService->convertFlexFormContentToArray($record[$field]);
         } else {
             $dataArray = [];
             /** @var ProviderInterface $provider */

--- a/Classes/ViewHelpers/Form/DataViewHelper.php
+++ b/Classes/ViewHelpers/Form/DataViewHelper.php
@@ -150,8 +150,8 @@ class DataViewHelper extends AbstractViewHelper implements CompilableInterface
             $dataArray = static::$configurationService->convertFlexFormContentToArray(
                 $record[$field],
                 null,
-                $lang,
-                $pointer
+                'lDEF',
+                'vDEF'
             );
         } else {
             $dataArray = [];


### PR DESCRIPTION
In addition to https://github.com/FluidTYPO3/flux/pull/1215 above changes are required.

I use customize fluidstyledcontent templates in my project and without that fix I can not access piflexform data from within them.