### PR TITLE
[BUGFIX] Apply TCE wrapper patch on data structure fetched from cache

### DIFF
--- a/Classes/Backend/DynamicFlexForm.php
+++ b/Classes/Backend/DynamicFlexForm.php
@@ -243,12 +243,13 @@ class DynamicFlexForm
 
                     $cacheKey = $this->calculateFormCacheKey($formId);
                     if ($cache->has($cacheKey)) {
-                        $dataStructArray = $this->patchTceformsWrapper($cache->get($cacheKey));
+                        $dataStructArray = $cache->get($cacheKey);
                         return;
                     }
                     // This provider has requested static DS caching; stop attempting
                     // to process any other DS and cache this DS as final result:
                     $provider->postProcessDataStructure($row, $dataStructArray, $conf);
+                    $dataStructArray = $this->patchTceformsWrapper($dataStructArray);
                     $cache->set($cacheKey, $dataStructArray);
                     return;
                 } else {

--- a/Classes/Backend/DynamicFlexForm.php
+++ b/Classes/Backend/DynamicFlexForm.php
@@ -243,7 +243,7 @@ class DynamicFlexForm
 
                     $cacheKey = $this->calculateFormCacheKey($formId);
                     if ($cache->has($cacheKey)) {
-                        $dataStructArray = $cache->get($cacheKey);
+                        $dataStructArray = $this->patchTceformsWrapper($cache->get($cacheKey));
                         return;
                     }
                     // This provider has requested static DS caching; stop attempting


### PR DESCRIPTION
The method had one case where the TCE wrapper patch method would not be called
on the data that was fetched from cache.

This commit fixes this case, which seems to be the only one that was forgotten.