### PR TITLE
[FEATURE] Add richtextConfiguration option on Text fields

### DIFF
--- a/Classes/Form/Field/Text.php
+++ b/Classes/Form/Field/Text.php
@@ -15,6 +15,7 @@ use FluidTYPO3\Flux\Form\FieldInterface;
  */
 class Text extends Input implements FieldInterface
 {
+    const DEFAULT_RTE_CONFIG = 'default';
 
     /**
      * @var integer
@@ -39,6 +40,11 @@ class Text extends Input implements FieldInterface
     /**
      * @var string
      */
+    protected $richtextConfiguration;
+
+    /**
+     * @var string
+     */
     protected $renderType = '';
 
     /**
@@ -56,11 +62,14 @@ class Text extends Input implements FieldInterface
         $configuration['cols'] = $this->getColumns();
         $configuration['eval'] = $this->getValidate();
         $defaultExtras = $this->getDefaultExtras();
+        $this->computeRichtextConfiguration();
         if (true === $this->getEnableRichText() && true === empty($defaultExtras)) {
             $typoScript = $this->getConfigurationService()->getAllTypoScript();
             $configuration['defaultExtras'] = $typoScript['plugin']['tx_flux']['settings']['flexform']['rteDefaults'];
+            $configuration['richtextConfiguration'] = $this->getRichtextConfiguration();
         } else {
             $configuration['defaultExtras'] = $defaultExtras;
+            $configuration['richtextConfiguration'] = $this->getRichtextConfiguration();
         }
         $renderType = $this->getRenderType();
         if (false === empty($renderType)) {
@@ -172,5 +181,42 @@ class Text extends Input implements FieldInterface
     public function setFormat($format)
     {
         $this->format = $format;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRichtextConfiguration()
+    {
+        return $this->richtextConfiguration;
+    }
+
+    /**
+     * @param string $richtextConfiguration
+     * @return Text
+     */
+    public function setRichtextConfiguration($richtextConfiguration)
+    {
+        $this->richtextConfiguration = $richtextConfiguration;
+        return $this;
+    }
+
+    /**
+     * @return void
+     */
+    protected function computeRichtextConfiguration()
+    {
+        if (true === empty($this->richtextConfiguration)) {
+            $typoScript = $this->getConfigurationService()->getAllTypoScript();
+            $richtextConfigurationFromTS = $typoScript['plugin']['tx_flux']['settings']['flexform']['richtextConfiguration'];
+
+            if (true === empty($richtextConfigurationFromTS)) {
+                $this->richtextConfiguration = static::DEFAULT_RTE_CONFIG;
+
+                return;
+            }
+
+            $this->richtextConfiguration = $richtextConfigurationFromTS;
+        }
     }
 }

--- a/Classes/ViewHelpers/Field/TextViewHelper.php
+++ b/Classes/ViewHelpers/Field/TextViewHelper.php
@@ -65,6 +65,15 @@ class TextViewHelper extends AbstractFieldViewHelper
             false,
             ''
         );
+        $this->registerArgument(
+            'richtextConfiguration',
+            'string',
+            'Specifies which configuration to use in combination with EXT:rte_ckeditor.' .
+            'The default value is \'default\', since that\'s the standard configuration the CMS uses. ' .
+            'More information: https://docs.typo3.org/typo3cms/TCAReference/ColumnsConfig/Properties/TextRichtextConfiugration.html',
+            false,
+            'default'
+        );
     }
 
     /**
@@ -81,6 +90,7 @@ class TextViewHelper extends AbstractFieldViewHelper
         $text->setRows($arguments['rows']);
         $text->setDefaultExtras($arguments['defaultExtras']);
         $text->setEnableRichText($arguments['enableRichText']);
+        $text->setRichtextConfiguration($arguments['richtextConfiguration']);
         $text->setRenderType($arguments['renderType']);
         $text->setFormat($arguments['format']);
         return $text;


### PR DESCRIPTION
Enables switching the CKEditor configuration based on the current field.

This option falls back to `default` and can be overriden through TypoScript:

```
plugin.tx_flux.settings.flexform.richtextConfiguration = MySite
```

Closes: #1388