### PR TITLE
[BUGFIX] Use "enableRichtext" when rte_ckeditor is in use.

### DIFF
--- a/Classes/Form/Field/Text.php
+++ b/Classes/Form/Field/Text.php
@@ -58,7 +58,13 @@ class Text extends Input implements FieldInterface
         $defaultExtras = $this->getDefaultExtras();
         if (true === $this->getEnableRichText() && true === empty($defaultExtras)) {
             $typoScript = $this->getConfigurationService()->getAllTypoScript();
-            $configuration['defaultExtras'] = $typoScript['plugin']['tx_flux']['settings']['flexform']['rteDefaults'];
+            if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('rte_ckeditor')) {
+                // New CK editor in RTE requires different configuration
+                $configuration['enableRichtext'] = 1;
+                $configuration['richtextConfiguration'] = $typoScript['plugin']['tx_flux']['settings']['flexform']['richtextConfiguration'] ? : 'default';
+            } else {
+                $configuration['defaultExtras'] = $typoScript['plugin']['tx_flux']['settings']['flexform']['rteDefaults'];
+            }
         } else {
             $configuration['defaultExtras'] = $defaultExtras;
         }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -53,6 +53,7 @@ if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_INSTALL)) {
 		plugin.tx_flux.settings {
 			flexform {
 				rteDefaults = richtext:rte_transform[flag=rte_enabled|mode=ts_css]
+				richtextConfiguration = default
 			}
 		}
 	');


### PR DESCRIPTION
New TYPO3 version 8.x use rte_ckeditor extension by default instead
of rtehmlarea. For this extension a different TCA/Flex configuration
is required.

Close: #1421