### PR TITLE
[FEATURE] Add richtextConfiguration option on Text fields

### DIFF
--- a/Classes/Form/Field/Text.php
+++ b/Classes/Form/Field/Text.php
@@ -15,7 +15,6 @@ use FluidTYPO3\Flux\Form\FieldInterface;
  */
 class Text extends Input implements FieldInterface
 {
-
     /**
      * @var integer
      */
@@ -39,6 +38,11 @@ class Text extends Input implements FieldInterface
     /**
      * @var string
      */
+    protected $richtextConfiguration;
+
+    /**
+     * @var string
+     */
     protected $renderType = '';
 
     /**
@@ -55,18 +59,31 @@ class Text extends Input implements FieldInterface
         $configuration['rows'] = $this->getRows();
         $configuration['cols'] = $this->getColumns();
         $configuration['eval'] = $this->getValidate();
-        $defaultExtras = $this->getDefaultExtras();
-        if (true === $this->getEnableRichText() && true === empty($defaultExtras)) {
-            $typoScript = $this->getConfigurationService()->getAllTypoScript();
-            $configuration['defaultExtras'] = $typoScript['plugin']['tx_flux']['settings']['flexform']['rteDefaults'];
+        if (true === $this->getEnableRichText()) {
+            $configuration['enableRichtext'] = true;
+            if ($this->isCkEditorActive()) {
+                $configuration['richtextConfiguration'] = $this->getRichtextConfiguration();
+            } else {
+                //rtehtmlarea
+                $defaultExtras = $this->getDefaultExtras();
+                if (true === empty($defaultExtras)) {
+                    $typoScript = $this->getConfigurationService()->getAllTypoScript();
+                    $configuration['defaultExtras'] = $typoScript['plugin']['tx_flux']['settings']['flexform']['rteDefaults'];
+                } else {
+                    $configuration['defaultExtras'] = $defaultExtras;
+                }
+            }
         } else {
-            $configuration['defaultExtras'] = $defaultExtras;
+            $configuration['defaultExtras'] = $this->getDefaultExtras();
         }
         $renderType = $this->getRenderType();
         if (false === empty($renderType)) {
             $configuration['renderType'] = $renderType;
             $configuration['format'] = $this->getFormat();
         }
+
+        //var_dump($configuration);die();
+
         return $configuration;
     }
 
@@ -172,5 +189,97 @@ class Text extends Input implements FieldInterface
     public function setFormat($format)
     {
         $this->format = $format;
+    }
+
+    /**
+     * Fetch richtext editor configuration preset
+     *
+     * The following places are looked at:
+     *
+     * 1. 'richtextConfiguration' attribute of the current tag
+     * 2. PageTSconfig: "RTE.tx_flux.preset"
+     * 3. PageTSconfig: "RTE.default.preset"
+     *
+     * @return string
+     */
+    public function getRichtextConfiguration()
+    {
+        //tag attribute
+        if (false === empty($this->richtextConfiguration)) {
+            return $this->richtextConfiguration;
+        }
+
+        $pageTSconfig = \TYPO3\CMS\Backend\Utility\BackendUtility::getPagesTSconfig($this->getPageId());
+
+        if (true === isset($pageTSconfig['RTE.']['tx_flux.']['preset'])
+            && false === empty($pageTSconfig['RTE.']['tx_flux.']['preset'])
+        ) {
+            return $pageTSconfig['RTE.']['tx_flux.']['preset'];
+        }
+
+        return $pageTSconfig['RTE.']['default.']['preset'];
+    }
+
+    /**
+     * Get the current page ID from the TYPO3 backend
+     *
+     * @return integer Page UID
+     */
+    protected function getPageId()
+    {
+        $formRecord = $this->getFormObject()->getOption('record');
+        if (isset($formRecord['pid'])) {
+            //form that has already been saved
+            return (int) $formRecord['pid'];
+        }
+
+        if (is_array($_GET['edit'])) {
+            //editing a record
+            $type = key($_GET['edit']);
+            $id   = key($_GET['edit'][$type]);
+            $mode = $_GET['edit'][$type][$id];
+
+            if ($mode === 'new') {
+                return $id;
+            }
+        }
+
+        throw new \Exception('Unable to determine page ID', 1501156095);
+    }
+
+    /**
+     * Get the current form the element is attached to
+     *
+     * @return \FluidTYPO3\Flux\Form Form object
+     */
+    protected function getFormObject()
+    {
+        $elem = $this;
+        while ($elem = $elem->getParent()) {
+            if ($elem instanceof \FluidTYPO3\Flux\Form) {
+                return $elem;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param string $richtextConfiguration
+     * @return Text
+     */
+    public function setRichtextConfiguration($richtextConfiguration)
+    {
+        $this->richtextConfiguration = $richtextConfiguration;
+        return $this;
+    }
+
+    /**
+     * Check if the CKEditor extension is active
+     *
+     * @return bool True if the extension is active
+     */
+    protected function isCkEditorActive()
+    {
+        return \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('rte_ckeditor');
     }
 }

--- a/Classes/ViewHelpers/Field/TextViewHelper.php
+++ b/Classes/ViewHelpers/Field/TextViewHelper.php
@@ -36,14 +36,14 @@ class TextViewHelper extends AbstractFieldViewHelper
         $this->registerArgument(
             'defaultExtras',
             'string',
-            'FlexForm-syntax "defaultExtras" definition, example: "richtext[*]:rte_transform[mode=ts_css]"',
+            'DEPRECATED - use richtextConfiguration instead for TYPO3 v8+. FlexForm-syntax "defaultExtras" definition, example: "richtext[*]:rte_transform[mode=ts_css]"',
             false,
             ''
         );
         $this->registerArgument(
             'enableRichText',
             'boolean',
-            'Shortcut for adding value of TS plugin.tx_flux.settings.flexform.rteDefaults to "defaultExtras"',
+            'Enable the richtext editor (RTE)',
             false,
             false
         );
@@ -65,6 +65,15 @@ class TextViewHelper extends AbstractFieldViewHelper
             false,
             ''
         );
+        $this->registerArgument(
+            'richtextConfiguration',
+            'string',
+            'Specifies which configuration to use in combination with EXT:rte_ckeditor.' .
+            'If none is given, PageTSconfig "RTE.tx_flux.preset" and "RTE.default.preset" are used.' .
+            'More information: https://docs.typo3.org/typo3cms/TCAReference/ColumnsConfig/Properties/TextRichtextConfiugration.html',
+            false,
+            null
+        );
     }
 
     /**
@@ -81,6 +90,7 @@ class TextViewHelper extends AbstractFieldViewHelper
         $text->setRows($arguments['rows']);
         $text->setDefaultExtras($arguments['defaultExtras']);
         $text->setEnableRichText($arguments['enableRichText']);
+        $text->setRichtextConfiguration($arguments['richtextConfiguration']);
         $text->setRenderType($arguments['renderType']);
         $text->setFormat($arguments['format']);
         return $text;

--- a/Tests/Unit/Form/Field/TextTest.php
+++ b/Tests/Unit/Form/Field/TextTest.php
@@ -65,7 +65,10 @@ class TextTest extends InputTest
     public function canBuildConfigurationWithoutDefaultExtrasWithEnableRichText()
     {
         /** @var Text $instance */
-        $instance = $this->createInstance();
+        $className = $this->getObjectClassName();
+        $instance = $this->getMockBuilder($className)->setMethods(['isCkEditorActive'])->getMock();
+        $instance->expects($this->any())->method('isCkEditorActive')->will($this->returnValue(false));
+
         $instance->setDefaultExtras(null)->setEnableRichText(true);
         $result = $this->performTestBuild($instance);
         $this->assertArrayHasKey('defaultExtras', $result['config']);
@@ -77,7 +80,10 @@ class TextTest extends InputTest
     public function canBuildConfigurationWithDefaultExtras()
     {
         /** @var Text $instance */
-        $instance = $this->createInstance();
+        $className = $this->getObjectClassName();
+        $instance = $this->getMockBuilder($className)->setMethods(['isCkEditorActive'])->getMock();
+        $instance->expects($this->any())->method('isCkEditorActive')->will($this->returnValue(false));
+
         $instance->setDefaultExtras('richtext[*]');
         $result = $this->performTestBuild($instance);
         $this->assertNotEmpty($result['defaultExtras']);


### PR DESCRIPTION
Enables switching the CKEditor configuration based on the current field.

This option falls back to `default` and can be overriden through TypoScript:

```
plugin.tx_flux.settings.flexform.richtextConfiguration = MySite
```

Resolves: #1388

Open issues:
- [x] Should we fallback to PageTSConfig `RTE.default.preset`?
  - yes
- [x] Should we remove `defaultExtras` completely (param def + getter/setter)?
  - no, we keep that since it can be used for other things as well.
- [x] Keep defaultExtras when CKEditor is not used, see  #1434
- [x] I wonder why the config is in TypoScript and not PageTSConfig (was introduced that way in #1426).
  - we move to PageTSconfig
- [ ] Decide if it is possible to get the current page ID in the text object
- [ ] Which PageTSconfig path to use? @cweiske suggests `RTE.tx_flux.preset`, see https://docs.typo3.org/typo3cms/CoreApiReference/Rte/Transformations/Tsconfig/ for more info
