### PR TITLE
[BUGFIX] Pass values to query builder

### DIFF
--- a/Classes/Service/RecordService.php
+++ b/Classes/Service/RecordService.php
@@ -106,7 +106,7 @@ class RecordService implements SingletonInterface
      */
     public function preparedGet($table, $fields, $condition, $values = [])
     {
-        return $this->getQueryBuilder($table)->select(...explode(',', $fields))->from($table)->where($condition)->execute()->fetchAll();
+        return $this->getQueryBuilder($table)->select(...explode(',', $fields))->from($table)->where($condition)->setParameters($values)->execute()->fetchAll();
     }
 
     /**


### PR DESCRIPTION
Part of https://github.com/FluidTYPO3/fluidcontent/issues/415

Without that patch, accessing the web module in the TYPO3 backend will result in an SQL error:

```
An exception occurred while executing '
 SELECT `pid` FROM `sys_template`
 WHERE (root = 1
  AND deleted = 0
  AND hidden = 0
  AND starttime <= :starttime
  AND (endtime = 0 OR endtime > :endtime)
  )
  AND (
   (`sys_template`.`deleted` = 0)
   AND (`sys_template`.`hidden` = 0)
   AND (`sys_template`.`starttime` <= 1500891480)
   AND ((`sys_template`.`endtime` = 0) OR (`sys_template`.`endtime` > 1500891480))
  )
':

You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '
:starttime AND (endtime = 0 OR endtime > :endtime)) AND ((`sys_template`.`delete
' at line 1
```
