### PR TITLE
Feature/1444/locallang config

### DIFF
--- a/Classes/Form.php
+++ b/Classes/Form.php
@@ -53,7 +53,6 @@ class Form extends Form\AbstractFormContainer implements Form\FieldContainerInte
     const CONTROL_HIDE = 'hide';
     const CONTROL_DELETE = 'delete';
     const CONTROL_LOCALISE = 'localize';
-    const DEFAULT_LANGUAGEFILE = '/Resources/Private/Language/locallang.xlf';
 
     /**
      * Machine-readable, lowerCamelCase ID of this form. DOM compatible.

--- a/Classes/Form/AbstractFormComponent.php
+++ b/Classes/Form/AbstractFormComponent.php
@@ -23,6 +23,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+use TYPO3\CMS\Extensionmanager\Utility\ConfigurationUtility;
 
 /**
  * AbstractFormComponent
@@ -63,7 +64,7 @@ abstract class AbstractFormComponent implements FormInterface
      *
      * @var string
      */
-    protected $localLanguageFileRelativePath = Form::DEFAULT_LANGUAGEFILE;
+    protected $localLanguageFileRelativePath = '';
 
     /**
      * @var string
@@ -355,6 +356,15 @@ abstract class AbstractFormComponent implements FormInterface
      */
     public function getLocalLanguageFileRelativePath()
     {
+        if (!$this->localLanguageFileRelativePath) {
+            /** @var ConfigurationUtility $configurationUtility */
+            $configurationUtility = $this->getObjectManager()->get(ConfigurationUtility::class);
+            $extensionConfiguration = $configurationUtility->getCurrentConfiguration('flux');
+            return $extensionConfiguration['defaultLocallangFile']['value']
+                ? $extensionConfiguration['defaultLocallangFile']['value']
+                : $extensionConfiguration['defaultLocallangFile']['default_value'];
+        }
+
         return $this->localLanguageFileRelativePath;
     }
 

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -72,8 +72,7 @@ class FormViewHelper extends AbstractFormViewHelper
             'localLanguageFileRelativePath',
             'string',
             'Relative (from extension) path to locallang file containing labels for the LLL values used in this form.',
-            false,
-            Form::DEFAULT_LANGUAGEFILE
+            false
         );
         $this->registerArgument(
             'extensionName',

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -9,3 +9,6 @@ listNestedContent = 0
 
   # cat=basic/enable; type=boolean; label=Error handling: If enabled, all Flux controllers are permitted to handle their own errors in ways that are far more flexible than traditional error catching. Enable with care - if your plugin, content or page template collection does not contain an Error.html template, your site may risk breaking with an extremely basic and not very informative error á la "Template not found for action foobar" but when enabled and combined with proper error templates you can customise pretty much any error which might happen anywhere when a Flux controller subclass is in play. Best turned off on development sites unless you are developing exactly error templates as it greatly limits debug output!
 handleErrors = 0
+
+  # cat=basic; type=string; label=Default locallang file: Relative (from extension Flux) path to locallang file containing labels for the LLL values built by FluidTYPO3\Flux\Form\AbstractFormComponent class.
+defaultLocallangFile = /Resources/Private/Language/locallang_db.xlf


### PR DESCRIPTION
[FEATURE] - #1444 Default locallang configured by extension configuration

Path to flux:form locallang file is no more fixed as `DEFAULT_LANGUAGEFILE` constant but configured in extension configuration