### PR TITLE
[BUGFIX] Add offset in RecordService->get

### DIFF
--- a/Classes/Service/RecordService.php
+++ b/Classes/Service/RecordService.php
@@ -29,9 +29,10 @@ class RecordService implements SingletonInterface
      * @param string $groupBy
      * @param string $orderBy
      * @param integer $limit
+     * @param integer $offset
      * @return array|NULL
      */
-    public function get($table, $fields, $clause = null, $groupBy = null, $orderBy = null, $limit = 0)
+    public function get($table, $fields, $clause = null, $groupBy = null, $orderBy = null, $limit = 0, $offset = 0)
     {
         $statement = $this->getQueryBuilder($table)->from($table)->select(...explode(',', $fields));
 
@@ -46,6 +47,9 @@ class RecordService implements SingletonInterface
         }
         if ($limit) {
             $statement->setMaxResults($limit);
+        }
+        if ($offset) {
+            $statement->setFirstResult($offset);
         }
 
         return $statement->execute()->fetchAll();

--- a/Classes/Service/WorkspacesAwareRecordService.php
+++ b/Classes/Service/WorkspacesAwareRecordService.php
@@ -26,11 +26,12 @@ class WorkspacesAwareRecordService extends RecordService implements SingletonInt
      * @param string $groupBy
      * @param string $orderBy
      * @param string $limit
+     * @param string $offset
      * @return array|null
      */
-    public function get($table, $fields, $clause = '1=1', $groupBy = '', $orderBy = '', $limit = '')
+    public function get($table, $fields, $clause = '1=1', $groupBy = '', $orderBy = '', $limit = '', $offset = '')
     {
-        $records = parent::get($table, $fields, $clause, $groupBy, $orderBy, $limit);
+        $records = parent::get($table, $fields, $clause, $groupBy, $orderBy, $limit, $offset);
         return null === $records ? null : $this->overlayRecords($table, $records);
     }
 

--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -153,7 +153,7 @@ class GetViewHelper extends AbstractViewHelper implements CompilableInterface
             $contentObjectRenderer->enableFields('tt_content'),
             BackendUtility::versioningPlaceholderClause('tt_content')
         );
-        $rows = static::getRecordService()->get('tt_content', '*', $conditions, '', $order, $offset . ',' . $limit);
+        $rows = static::getRecordService()->get('tt_content', '*', $conditions, '', $order, $limit, $offset);
 
         $elements = false === (boolean) $arguments['render'] ? $rows : static::getRenderedRecords($rows);
         if (true === empty($arguments['as'])) {

--- a/Tests/Unit/Service/RecordServiceTest.php
+++ b/Tests/Unit/Service/RecordServiceTest.php
@@ -45,8 +45,8 @@ class RecordServiceTest extends AbstractTestCase
         $queryBuilder->select(Argument::type('string'))->will(function ($arguments) use ($queryBuilder) { return $queryBuilder->reveal(); });
         $queryBuilder->orderBy('sorting', '');
         $queryBuilder->delete(Argument::type('string'));
-        $queryBuilder->setMaxResults(0);
         $queryBuilder->setMaxResults(60);
+        $queryBuilder->setMaxResults(99999);
         $queryBuilder->execute()->willReturn($statement->reveal());
 
         $prophecy = $this->prophesize(ConnectionPool::class);

--- a/Tests/Unit/Service/RecordServiceTest.php
+++ b/Tests/Unit/Service/RecordServiceTest.php
@@ -45,8 +45,7 @@ class RecordServiceTest extends AbstractTestCase
         $queryBuilder->select(Argument::type('string'))->will(function ($arguments) use ($queryBuilder) { return $queryBuilder->reveal(); });
         $queryBuilder->orderBy('sorting', '');
         $queryBuilder->delete(Argument::type('string'));
-        $queryBuilder->setMaxResults(60);
-        $queryBuilder->setMaxResults(99999);
+        $queryBuilder->setMaxResults(Argument::type('int'));
         $queryBuilder->execute()->willReturn($statement->reveal());
 
         $prophecy = $this->prophesize(ConnectionPool::class);


### PR DESCRIPTION
Curently elements in containers are not rendered if you use flux:content.get due to different behaviour in new QueryBuilder since TYPO3 8 due to wrong offset usage.

Just saw that there is already a pull request regarding this problem:
https://github.com/FluidTYPO3/flux/pull/1452/
This new pull request is a slightly different and IMO somewhat cleaner approach.
