### PR TITLE
[BUGFIX] find child records also with "insertRecord"

### DIFF
--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -180,7 +180,8 @@ class GetViewHelper extends AbstractViewHelper implements CompilableInterface
                         'max' => $arguments['limit'],
                         'begin' => $arguments['offset'],
                         'orderBy' => $arguments['order'] . ' ' . $arguments['sortDirection'],
-                        'where' => $conditions
+                        'where' => $conditions,
+                        'pidInList' => $parent['pid']
                     ]
                 )
             ]


### PR DESCRIPTION
If a fluidcontent element containing other content elements is added as "insertRecord" into a page, then currently the child records are not found anymore, because the pid is wrong. TYPO3 used by default the pid of the currently rendered page, but if you used "insertRecord" for your container element, then the pid for the childs records will be different, they always match the pid of the container element.