### PR TITLE
[BUGFIX] Brings back Inline and Relation fields expected behaviour

### DIFF
--- a/Classes/Form/Field/Inline.php
+++ b/Classes/Form/Field/Inline.php
@@ -17,6 +17,11 @@ class Inline extends AbstractInlineFormField
 {
 
     /**
+     * @var string|null
+     */
+    protected $renderType = null;
+
+    /**
      * @return array
      */
     public function buildConfiguration()

--- a/Classes/Form/Field/Relation.php
+++ b/Classes/Form/Field/Relation.php
@@ -17,6 +17,11 @@ class Relation extends AbstractRelationFormField
 {
 
     /**
+     * @var string|null
+     */
+    protected $renderType = null;
+
+    /**
      * @return array
      */
     public function buildConfiguration()


### PR DESCRIPTION
After https://github.com/FluidTYPO3/flux/commit/0bd5466f85b0ad9962803a396d7a9ac624c65cc4
field.inline and field.relation are not working as expected