### PR TITLE
[BUGFIX] Set flux colPos for moved records only if correct

### DIFF
--- a/Classes/Service/ContentService.php
+++ b/Classes/Service/ContentService.php
@@ -153,12 +153,14 @@ class ContentService implements SingletonInterface
      */
     public function moveRecord(array &$row, &$relativeTo, $parameters, DataHandler $tceMain)
     {
+        // This condition matches colPos values which are above the constant which is a virtual, assumed limit. When
+        // the $relativeTo value is above this constant value it is likely a virtual value - but it may also be the
+        // case for very large page trees where UID values naturally exceed this.
         if (MiscellaneousUtility::UNIQUE_INTEGER_OVERHEAD < $relativeTo) {
             // Fake relative to value - we can get the target from a session variable
             list ($parent, $column) = $this->getTargetAreaStoredInSession($relativeTo);
             $row['tx_flux_parent'] = $parent;
             $row['tx_flux_column'] = $column;
-            $row['colPos'] = static::COLPOS_FLUXCONTENT;
             $row['sorting'] = 0;
         } elseif (0 <= (integer) $relativeTo && false === empty($parameters[1])) {
             // Special case for clipboard commands only. This special case also requires a new
@@ -172,7 +174,6 @@ class ContentService implements SingletonInterface
             }
             $row['tx_flux_parent'] = $parentUid;
             $row['tx_flux_column'] = $area;
-            $row['colPos'] = static::COLPOS_FLUXCONTENT;
         } elseif (0 > (integer) $relativeTo) {
             // inserting a new element after another element. Check column position of that element.
             // Get the desired sorting value after the relative record.


### PR DESCRIPTION
It seems that \FluidTYPO3\Flux\Service\ContentService::moveRecord is surprisingly called with target pid in parameter $relativeTo if editor is cutting and inserting a content record via clipboard. Only on big pagetrees this leads to lost content elements, because colPos is set to 18181 then even for regular content elements.
Since the flux colPos only makes sense, if we have a tx_flux_parent, this pull request fixes that issue.

I am fully aware that this fix is likely not targeting the root cause of the problem (getting the pid for the parameter $relativeTo) but i was not able to fully grasp what should be going on here.
Thus i hope this helps at least as hotfix for people affected by this problem.