### PR TITLE
[BUGFIX] Set input field range independent of validators

### DIFF
--- a/Classes/Form/Field/Input.php
+++ b/Classes/Form/Field/Input.php
@@ -62,7 +62,7 @@ class Input extends AbstractFormField implements FieldInterface
         $configuration['size'] = $this->getSize();
         $configuration['max'] = $this->getMaxCharacters();
         $configuration['eval'] = $validate;
-        if (null !== $minimum && null !== $maximum && in_array('int', GeneralUtility::trimExplode(',', $validate))) {
+        if (null !== $minimum && null !== $maximum) {
             $configuration['range'] = [
                 'lower' => $minimum,
                 'upper' => $maximum


### PR DESCRIPTION
Checking for 'int' in the validator list is needlessly
limiting. range works just as well e.g. with double2 fields.