### PR TITLE
[BUGFIX] Fix FluxService->getTypoScriptByPath not working 

### DIFF
--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -165,7 +165,7 @@ class FluxService implements SingletonInterface
         );
         $value = &$all;
         foreach (explode('.', $path) as $segment) {
-            $value = ($value[$path . '.'] ?? $value[$path] ?? null);
+            $value = ($value[$segment . '.'] ?? $value[$segment] ?? null);
             if ($value === null) {
                 break;
             }

--- a/Tests/Unit/Service/FluxServiceTest.php
+++ b/Tests/Unit/Service/FluxServiceTest.php
@@ -13,6 +13,8 @@ use FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\Service\FluxService;
 use FluidTYPO3\Flux\Tests\Fixtures\Data\Xml;
 use FluidTYPO3\Flux\Tests\Unit\AbstractTestCase;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
 /**
  * FluxServiceTest
@@ -88,6 +90,21 @@ class FluxServiceTest extends AbstractTestCase
         $service->injectProviderResolver($this->objectManager->get('FluidTYPO3\\Flux\\Provider\\ProviderResolver'));
         $result = $service->resolvePrimaryConfigurationProvider('tt_content', null);
         $this->assertNull($result);
+    }
+
+    /**
+     * @test
+     */
+    public function testGetTypoScriptByPath()
+    {
+        $service = new FluxService();;
+        $configurationManager = $this->getMockBuilder(ConfigurationManager::class)->setMethods(array('getConfiguration'))->getMock();
+        $configurationManager->expects($this->once())->method('getConfiguration')
+            ->with(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT)
+            ->willReturn(array('plugin.' => array('tx_test.' => array('settings.' => array('test_var' => 'test_val')))));
+        $service->injectConfigurationManager($configurationManager);
+        $result = $service->getTypoScriptByPath('plugin.tx_test.settings');
+        $this->assertEquals(array('test_var' => 'test_val'), $result);
     }
 
     /**


### PR DESCRIPTION
Problem should be obvious, basically `getTypoScriptByPath` will not work at all at the moment.