### PR TITLE
[BUGFIX] Increase integer size of colPos SQL column

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -2,6 +2,6 @@
 # Table structure for table 'tt_content'
 #
 CREATE TABLE tt_content (
-  tx_flux_migrated_version varchar(11) DEFAULT NULL
-  colPos BIGINT NOT NULL DEFAULT '0'
+  tx_flux_migrated_version varchar(11) DEFAULT NULL,
+  colPos bigint(20) DEFAULT '0' NOT NULL
 );

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -3,4 +3,5 @@
 #
 CREATE TABLE tt_content (
   tx_flux_migrated_version varchar(11) DEFAULT NULL
+  colPos BIGINT NOT NULL DEFAULT '0'
 );


### PR DESCRIPTION
If you have a few more sites, the originally used SMALLINT column does not fit the longer colPos values