### PR TITLE
[BUGFIX] Fix wrong usage of cache API in ContentIcon hook subscriber

### DIFF
--- a/Classes/Integration/HookSubscribers/ContentIcon.php
+++ b/Classes/Integration/HookSubscribers/ContentIcon.php
@@ -105,7 +105,7 @@ class ContentIcon
         // we check the cache here because at this point, the cache key is decidedly
         // unique and we have not yet consulted the (potentially costly) Provider.
         $cachedIconIdentifier = $this->cache->get($cacheIdentity);
-        if ($cachedIconIdentifier !== null) {
+        if ($cachedIconIdentifier !== false) {
             return $cachedIconIdentifier;
         } elseif ($record) {
             $field = $this->detectFirstFlexTypeFieldInTableFromPossibilities($table, array_keys($record));


### PR DESCRIPTION
cache->get returns `false` if a key cannot be found - not `null`, so the
code will always assume that a valid cache entry was found and never
return any useful information.

Broken in 3d45411368d39afa9606a0e21d3a7347623d5864