### PR TITLE
[TASK] Add renderType to Form\Field\Tree.

### DIFF
--- a/Classes/Form/Field/Tree.php
+++ b/Classes/Form/Field/Tree.php
@@ -65,6 +65,7 @@ class Tree extends AbstractRelationFormField
     {
         $configuration = $this->prepareConfiguration('select');
         $configuration['renderMode'] = 'tree';
+        $configuration['renderType'] = 'selectTree';
         $configuration['treeConfig'] = [
             'parentField' => $this->getParentField(),
             'appearance' => [


### PR DESCRIPTION
Form/Field/Tree has not set the renderType and there are no getters or setters to add it.

The renderType is mandatory.