### PR TITLE
[BUGFIX] Skip migration of deleted content records

### DIFF
--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -5,6 +5,12 @@ use FluidTYPO3\Flux\Provider\Interfaces\FluidProviderInterface;
 use FluidTYPO3\Flux\Provider\Interfaces\GridProviderInterface;
 use FluidTYPO3\Flux\Utility\ColumnNumberUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\BackendWorkspaceRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\FrontendGroupRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\FrontendWorkspaceRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use FluidTYPO3\Flux\Service\FluxService;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -261,7 +267,12 @@ class ext_update
     protected function loadContentRecords(): \Doctrine\DBAL\Driver\Statement
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
-        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
+        $queryBuilder->getRestrictions()->removeByType(StartTimeRestriction::class);
+        $queryBuilder->getRestrictions()->removeByType(EndTimeRestriction::class);
+        $queryBuilder->getRestrictions()->removeByType(BackendWorkspaceRestriction::class);
+        $queryBuilder->getRestrictions()->removeByType(FrontendGroupRestriction::class);
+        $queryBuilder->getRestrictions()->removeByType(FrontendWorkspaceRestriction::class);
         $queryBuilder->select('*')->from('tt_content');
         return $queryBuilder->execute();
     }


### PR DESCRIPTION
Do not remove the soft-delete restriction, but still remove all other restrictions for selecting content records to be migrated. This reduces the need to clean up the database before running the migration to avoid problems with old content that cannot resolve parent/child relations correctly for whichever reasons.

References: #1645