### PR TITLE
[BUGFIX] Fix RecordService->getSingle return type

### DIFF
--- a/Classes/Service/RecordService.php
+++ b/Classes/Service/RecordService.php
@@ -71,7 +71,7 @@ class RecordService implements SingletonInterface
             ->where(sprintf('uid = %d', $uid))
             ->execute()
             ->fetchAll() ?: [];
-        return reset($results);
+        return reset($results) ?: null;
     }
 
     /**


### PR DESCRIPTION
This fixes the case where `reset([])` returned `FALSE`, but should return `NULL` to match the method signature doc comments.

> [**reset()**](http://php.net/manual/en/function.reset.php) rewinds array's internal pointer to the first element and returns the value of the first array element. – Returns the value of the first array element, or **FALSE** if the array is empty.

As a side effect this fixes an endless loop in fluidpages described in https://github.com/FluidTYPO3/fluidpages/issues/390, because the [`FluidTYPO3\Fluidpages\Service\PageService->getPageTemplateConfiguration()`](https://github.com/FluidTYPO3/fluidpages/blob/development/Classes/Service/PageService.php#L145) depends on the documented return type of `RecordService->getSingle()` to abort the loop.