### PR TITLE
[FEATURE] Allow cropVariants definition for FAL fields

### DIFF
--- a/Classes/Form/Field/Inline/Fal.php
+++ b/Classes/Form/Field/Inline/Fal.php
@@ -154,7 +154,7 @@ class Fal extends AbstractInlineFormField
      *
      * @var array
      */
-    protected $cropVariants = null;
+    protected $cropVariants = [];
 
     /**
      * @var null|string
@@ -168,12 +168,12 @@ class Fal extends AbstractInlineFormField
     {
         $configuration = $this->prepareConfiguration('inline');
         $configuration['appearance']['createNewRelationLinkTitle'] = $this->getCreateNewRelationLinkTitle();
-        if ($this->getCropVariants()) {
+        if (!empty($this->cropVariants)) {
             $configuration['overrideChildTca'] = [
                 'columns' => [
                     'crop' => [
                         'config' => [
-                            'cropVariants' => $this->getCropVariants()
+                            'cropVariants' => $this->cropVariants
                         ]
                     ]
                 ]

--- a/Classes/Form/Field/Inline/Fal.php
+++ b/Classes/Form/Field/Inline/Fal.php
@@ -150,6 +150,13 @@ class Fal extends AbstractInlineFormField
     protected $createNewRelationLinkTitle = self::DEFAULT_CREATE_NEW_RELATION_LINK_TITLE;
 
     /**
+     * Crop variants for uploaded images
+     *
+     * @var array
+     */
+    protected $cropVariants = null;
+
+    /**
      * @var null|string
      */
     protected $renderType = null;
@@ -161,6 +168,17 @@ class Fal extends AbstractInlineFormField
     {
         $configuration = $this->prepareConfiguration('inline');
         $configuration['appearance']['createNewRelationLinkTitle'] = $this->getCreateNewRelationLinkTitle();
+        if ($this->getCropVariants()) {
+            $configuration['overrideChildTca'] = [
+                'columns' => [
+                    'crop' => [
+                        'config' => [
+                            'cropVariants' => $this->getCropVariants()
+                        ]
+                    ]
+                ]
+            ];
+        }
         return $configuration;
     }
 
@@ -179,6 +197,24 @@ class Fal extends AbstractInlineFormField
     public function setCreateNewRelationLinkTitle($createNewRelationLinkTitle)
     {
         $this->createNewRelationLinkTitle = $createNewRelationLinkTitle;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCropVariants()
+    {
+        return $this->cropVariants;
+    }
+
+    /**
+     * @param array $cropVariants
+     * @return Fal
+     */
+    public function setCropVariants(array $cropVariants)
+    {
+        $this->cropVariants = $cropVariants;
         return $this;
     }
 }

--- a/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
+++ b/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
@@ -53,6 +53,20 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  *
  *     <flux:field.inline.fal name="settings.image" required="1" maxItems="1" minItems="1"/>
  *
+ * #### Define crop variants
+ *
+ *     <flux:field.inline.fal name="settings.slides" required="1" maxItems="10" minItems="1" cropVariants="{
+ *       default: {
+ *         title: 'Default',
+ *         allowedAspectRatios: {
+ *           default: {
+ *             title: '1200:450',
+ *             value: '2.6666666666'
+ *           }
+ *         }
+ *       }
+ *     }"/>
+ *
  * #### Rendering the image
  *
  *     {v:content.resources.fal(field: 'settings.image') -> v:iterator.first() -> v:variable.set(name: 'image')}
@@ -176,6 +190,12 @@ class FalViewHelper extends AbstractInlineFieldViewHelper
             false,
             Fal::DEFAULT_CREATE_NEW_RELATION_LINK_TITLE
         );
+        $this->registerArgument(
+            'cropVariants',
+            'array',
+            'Add one or multiple crop variants for uploaded images',
+            false
+        );
     }
 
     /**
@@ -188,6 +208,7 @@ class FalViewHelper extends AbstractInlineFieldViewHelper
         $allowedExtensions = $arguments['allowedExtensions'];
         $disallowedExtensions = $arguments['disallowedExtensions'];
         $createNewRelationLinkTitle = $arguments['createNewRelationLinkTitle'];
+        $cropVariants = $arguments['cropVariants'];
 
         /** @var Fal $component */
         $component = static::getPreparedComponent('Inline/Fal', $renderingContext, $arguments);
@@ -226,6 +247,9 @@ class FalViewHelper extends AbstractInlineFieldViewHelper
         }
 
         $component->setCreateNewRelationLinkTitle($createNewRelationLinkTitle);
+        if(is_array($cropVariants)) {
+            $component->setCropVariants($cropVariants);
+        }
 
         return $component;
     }

--- a/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
+++ b/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
@@ -193,8 +193,7 @@ class FalViewHelper extends AbstractInlineFieldViewHelper
         $this->registerArgument(
             'cropVariants',
             'array',
-            'Add one or multiple crop variants for uploaded images',
-            false
+            'Add one or multiple crop variants for uploaded images'
         );
     }
 
@@ -245,11 +244,12 @@ class FalViewHelper extends AbstractInlineFieldViewHelper
                 ],
             ]);
         }
-
-        $component->setCreateNewRelationLinkTitle($createNewRelationLinkTitle);
-        if(is_array($cropVariants)) {
+        
+        if (!empty($cropVariants)) {
             $component->setCropVariants($cropVariants);
         }
+
+        $component->setCreateNewRelationLinkTitle($createNewRelationLinkTitle);
 
         return $component;
     }


### PR DESCRIPTION
Fixes #1433 
Pretty straightforward, I added a `cropVariant` attribute to `flux:field.inline.fal`.
The example I added creates this crop wizzard:
![image](https://user-images.githubusercontent.com/143341/50740298-d715e080-11ec-11e9-9d02-943fcb0ecb2d.png)
