### PR TITLE
[DOC] Add example on how to use cropVariants

### DIFF
--- a/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
+++ b/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
@@ -67,6 +67,14 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  *       }
  *     }"/>
  *
+ * The crop configuration can now be passed to the image viewhelper:
+ *
+ *     <f:section name="Main">
+ *       <f:for each="{v:content.resources.fal(field: 'settings.slides')}" as="image" iteration="iterator">
+ *         <f:image src="{image.id}" height="300" class="leb-pic" crop="{image.crop}" cropVariant="default"/>
+ *       </f:for>
+ *     </f:section>
+ *
  * #### Rendering the image
  *
  *     {v:content.resources.fal(field: 'settings.image') -> v:iterator.first() -> v:variable.set(name: 'image')}


### PR DESCRIPTION
There was an example on how to use the new cropVariants property to define the flux form already, added an example on how to use the crop data in the frontend.

Added this because I got a request on how to actually use the feature in the original PR: https://github.com/FluidTYPO3/flux/pull/1660#issuecomment-458134267 