### PR TITLE
[FEATURE] Allow arbitrary TCA "config" array on fields

### DIFF
--- a/Classes/Form/AbstractFormField.php
+++ b/Classes/Form/AbstractFormField.php
@@ -73,6 +73,11 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
     protected $wizards;
 
     /**
+     * @var array
+     */
+    protected $config = [];
+
+    /**
      * CONSTRUCTOR
      */
     public function __construct()
@@ -200,7 +205,10 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
         if (false === $this->getEnabled()) {
             return [];
         }
-        $configuration = $this->buildConfiguration();
+
+        // The "config" section consists of whichever configuration arry the component built, but with
+        // priority to any options set directly as raw TCA field config options in $this->config.
+        $configuration = array_replace($this->buildConfiguration(), $this->getConfig());
         $filterClosure = function($value) {
             return $value !== null && $value !== '' && $value !== [];
         };
@@ -343,6 +351,24 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
     public function setValidate($validate)
     {
         $this->validate = $validate;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
+     * @param array $config
+     * @return FieldInterface
+     */
+    public function setConfig(array $config)
+    {
+        $this->config = $config;
         return $this;
     }
 

--- a/Classes/Form/FieldInterface.php
+++ b/Classes/Form/FieldInterface.php
@@ -108,6 +108,17 @@ interface FieldInterface extends FormInterface
     public function getValidate();
 
     /**
+     * @return array
+     */
+    public function getConfig();
+
+    /**
+     * @param array $config
+     * @return FieldInterface
+     */
+    public function setConfig(array $config);
+
+    /**
      * @param WizardInterface $wizard
      * @return FormInterface
      */

--- a/Classes/ViewHelpers/Field/AbstractFieldViewHelper.php
+++ b/Classes/ViewHelpers/Field/AbstractFieldViewHelper.php
@@ -106,6 +106,15 @@ abstract class AbstractFieldViewHelper extends AbstractFormViewHelper
             'If provided, enables overriding the extension context for this and all child nodes. The extension name ' .
             'is otherwise automatically detected from rendering context.'
         );
+        $this->registerArgument(
+            'config',
+            'array',
+            'Raw TCA options - passed directly to "config" section of created field and overrides anything generated ' .
+            'by the component itself. Can be used to provide options that Flux itself does not support, and can be ' .
+            'used to pass root-level arguments for a "userFunc"',
+            false,
+            []
+        );
     }
 
     /**
@@ -118,6 +127,7 @@ abstract class AbstractFieldViewHelper extends AbstractFormViewHelper
     {
         $component = static::getContainerFromRenderingContext($renderingContext)
             ->createField($type, $arguments['name'], $arguments['label']);
+        $component->setConfig((array)$arguments['config']);
         $component->setExtensionName(
             static::getExtensionNameFromRenderingContextOrArguments($renderingContext, $arguments)
         );


### PR DESCRIPTION
Allows users to pass "config" to Flux form fields and
provide any TCA option, including those that are not
supported as ViewHelper attributes. Values specified
in this array will have priority over other properties.