### PR TITLE
[BUGFIX] Handle memory leaks on large mirgation data sets

### DIFF
--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -125,6 +125,7 @@ class ext_update
                                 );
                             }
                         }
+                        unset($grid);
                     } catch (\TYPO3Fluid\Fluid\Core\Parser\Exception $exception) {
                         if (strpos($exception->getMessage(), 'Required argument "colPos" was not supplied.') !== false) {
                             $templateFilesRequiringMigration[$templatePathAndFilename] = $exception->getMessage();
@@ -148,6 +149,7 @@ class ext_update
                         'tx_flux_parent' => $row['tx_flux_parent']
                     ];
                 }
+                unset($row);
             }
 
             foreach ($childContentRequiringMigration as $childContent) {


### PR DESCRIPTION
Migrating a large data set of content elements can/will cause memory exhausted
exceptions. Using `unset` on `$row` and `$grid` variables deals with this. Migration of an installation with over 25000 entries runs fine after this changes.