### PR TITLE
[BUGFIX] Fixed language handling for nesting

### DIFF
--- a/Classes/Integration/PreviewView.php
+++ b/Classes/Integration/PreviewView.php
@@ -338,7 +338,11 @@ class PreviewView extends TemplateView
         $dblist->tt_contentConfig['showInfo'] = 1;
         $dblist->tt_contentConfig['single'] = 0;
         $dblist->nextThree = 1;
-        $dblist->tt_contentConfig['sys_language_uid'] = $row['sys_language_uid'];
+
+        if ($GLOBALS['SOBE']) {
+            $dblist->tt_contentConfig['sys_language_uid'] = $GLOBALS['SOBE']->current_sys_language;
+        }
+
         $dblist->tt_contentConfig['showHidden'] = $showHiddenRecords;
         $dblist->tt_contentConfig['activeCols'] = $columnsAsCSV;
         $dblist->tt_contentConfig['cols'] = $columnsAsCSV;

--- a/Classes/Integration/PreviewView.php
+++ b/Classes/Integration/PreviewView.php
@@ -338,11 +338,7 @@ class PreviewView extends TemplateView
         $dblist->tt_contentConfig['showInfo'] = 1;
         $dblist->tt_contentConfig['single'] = 0;
         $dblist->nextThree = 1;
-
-        if ($GLOBALS['SOBE']) {
-            $dblist->tt_contentConfig['sys_language_uid'] = $GLOBALS['SOBE']->current_sys_language;
-        }
-
+        $dblist->tt_contentConfig['sys_language_uid'] = (int) $moduleData['language'];
         $dblist->tt_contentConfig['showHidden'] = $showHiddenRecords;
         $dblist->tt_contentConfig['activeCols'] = $columnsAsCSV;
         $dblist->tt_contentConfig['cols'] = $columnsAsCSV;


### PR DESCRIPTION
Used TYPO3 Version: 8.7.27
Used Flux Version: dev-development

Having a parent record with sys_language_uid -1 and a child
record with sys_language_uid 0 will result in the child record
not being shown. This happens because till now the respected
sys_language_uid of the child record will be set to the parent
record, which would be -1. This results in a query looking for
the record with sys_language_uid = -1, which dosn't exist.

The normal behaviour should respect the currently selected
language in the Backend as in the Backend/PageLayoutController
shown in Line 926 (TYPO3 8).