### PR TITLE
[BUGFIX] Do not try to copy deleted records

### DIFF
--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -15,6 +15,7 @@ use FluidTYPO3\Flux\Provider\ProviderResolver;
 use FluidTYPO3\Flux\Utility\ColumnNumberUtility;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -350,7 +351,8 @@ class DataHandlerSubscriber
         $languageField = $GLOBALS['TCA'][$table]['ctrl']['languageField'];
 
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
-        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder->getRestrictions()->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
 
         $query = $queryBuilder->select(...GeneralUtility::trimExplode(',', $fieldsToSelect))
             ->from($table)


### PR DESCRIPTION
When trying to copy child records, do not copy deleted ones.

Steps to reproduce:
1. Create an element that allows children (grid)
2. Create a child element
3. Delete child element
4. Copy and paste the main element
5. Error occurs, since deleted child element is tried to be copied.

Close: #1704