### PR TITLE
[BUGFIX] Adjust colPos of workspace overlay records of copied content…

### DIFF
--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -193,6 +193,11 @@ class DataHandlerSubscriber
                         );
 
                         $reference->updateDB('tt_content', $copiedRecordUidNested, $overrideArray);
+
+                        if (isset($reference->autoVersionIdMap['tt_content'][$copiedRecordUidNested])) {
+                            //also adjust workspace-overlaid version
+                            $reference->updateDB('tt_content', $reference->autoVersionIdMap['tt_content'][$copiedRecordUidNested], $overrideArray);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
… elements

When copying a page, the colPos of nested tt_content elements is adjusted
automatically.
Inside a workspace, TYPO3's DataHandler automatically creates shadow records
for this workspace. Their colPos needs to be adjusted, too.

Steps to reproduce:
1. Create a page, a container element and a child element
2. Switch into a workspace and copy&paste the page
3. In the pasted page, the child element is not visible