### PR TITLE
[BUGFIX] Respect new extension configuration API

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -5,7 +5,11 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('fluidpages')) 
     return;
 }
 
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['flux']);
+if (class_exists(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)) {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('flux');
+} else {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] ?? unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['flux']);
+}
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', [
     'tx_fed_page_controller_action' => [

--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -5,7 +5,11 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('fluidpages')) 
     return;
 }
 
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['flux']);
+if (class_exists(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)) {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('flux');
+} else {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] ?? unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['flux']);
+}
 
 if (TRUE === isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup']['pagesLanguageConfigurationOverlay'])
     && TRUE === (boolean) $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup']['pagesLanguageConfigurationOverlay']) {

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -5,7 +5,11 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('fluidpages')) 
     return;
 }
 
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['flux']);
+if (class_exists(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)) {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('flux');
+} else {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'] ?? unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['flux']);
+}
 
 if (!($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup']['autoload'] ?? true)) {
 	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('flux', 'Configuration/TypoScript', 'Flux PAGE rendering');


### PR DESCRIPTION
As of TYPO3 CMS v9 the extension configuration stored in $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'] has been replaced by a plain array in $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'].

Resolves: #1781