### PR TITLE
[BUGFIX] ensure compatibility with PHP 7.2

### DIFF
--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -203,7 +203,7 @@ class ext_update
                 $queryBuilder->expr()->eq('backend_layout', $queryBuilder->createNamedParameter('fluidpages__fluidpages', \PDO::PARAM_STR)),
                 $queryBuilder->expr()->eq('backend_layout_next_level', $queryBuilder->createNamedParameter('fluidpages__fluidpages', \PDO::PARAM_STR)),
                 $queryBuilder->expr()->eq('backend_layout', $queryBuilder->createNamedParameter('fluidpages__grid', \PDO::PARAM_STR)),
-                $queryBuilder->expr()->eq('backend_layout_next_level', $queryBuilder->createNamedParameter('fluidpages__grid', \PDO::PARAM_STR)),
+                $queryBuilder->expr()->eq('backend_layout_next_level', $queryBuilder->createNamedParameter('fluidpages__grid', \PDO::PARAM_STR))
             )
         );
         return $queryBuilder->execute()->fetchAll();


### PR DESCRIPTION
The trailing comma in function arguments syntax was added in PHP 7.3.
As this extension should be backwards compatible with TYPO3 9.5 it needs
to run on PHP 7.2.

Fixes #1784