### PR TITLE
[BUGFIX] Make sure the creation of content elements works

### DIFF
--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -52,7 +52,7 @@ class DataHandlerSubscriber
             GeneralUtility::makeInstance(ContentTypeManager::class)->regenerate();
         }
 
-        if ($table !== 'tt_content' || $command !== 'new' || !isset($fieldArray['t3_origuid'])) {
+        if ($table !== 'tt_content' || $command !== 'new' || !isset($fieldArray['t3_origuid']) || !$fieldArray['t3_origuid']) {
             // The action was not for tt_content, not a "create new" action, or not a "copy" or "copyToLanguage" action.
             return;
         }


### PR DESCRIPTION
When creating a new Record processDatamap_afterDatabaseOperations is
called with $fieldArray['t3_origuid'] = 0. However the handler should
exit early when this is not a newly created translation.

Fixes #1786