### PR TITLE
[BUGFIX] Make sure inline fal works with TYPO3 10

### DIFF
--- a/Classes/Form/AbstractInlineFormField.php
+++ b/Classes/Form/AbstractInlineFormField.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace FluidTYPO3\Flux\Form;
 
 /*
@@ -128,7 +129,7 @@ abstract class AbstractInlineFormField extends AbstractRelationFormField impleme
     protected $levelLinksPosition = null;
 
     /**
-     * @var string
+     * @var array
      */
     protected $overrideChildTca;
 
@@ -423,9 +424,32 @@ abstract class AbstractInlineFormField extends AbstractRelationFormField impleme
     }
 
     /**
-     * @param string $overrideChildTca
+     * @param array $foreignSelectorFieldTcaOverride
      * @return RelationFieldInterface
-     * @deprecated
+     * @deprecated Please switch to overrideChildTca
+     */
+    public function setForeignSelectorFieldTcaOverride($foreignSelectorFieldTcaOverride)
+    {
+        $this->overrideChildTca = [
+            'columns' => [
+                'uid_local' => $foreignSelectorFieldTcaOverride
+            ]
+        ];
+        return $this;
+    }
+
+    /** 
+     * @return array
+     * @deprecated Please switch to overrideChildTca
+     */
+    public function getForeignSelectorFieldTcaOverride()
+    {
+        return isset($this->overrideChildTca['columns']['uid_local']) ? $this->overrideChildTca['columns']['uid_local'] : null;
+    }
+
+    /**
+     * @param array $overrideChildTca
+     * @return RelationFieldInterface
      */
     public function setOverrideChildTca($overrideChildTca)
     {

--- a/Classes/Form/AbstractInlineFormField.php
+++ b/Classes/Form/AbstractInlineFormField.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace FluidTYPO3\Flux\Form;
 
 /*

--- a/Classes/Form/AbstractInlineFormField.php
+++ b/Classes/Form/AbstractInlineFormField.php
@@ -130,7 +130,7 @@ abstract class AbstractInlineFormField extends AbstractRelationFormField impleme
     /**
      * @var string
      */
-    protected $foreignSelectorFieldTcaOverride;
+    protected $overrideChildTca;
 
     /**
      * @var array
@@ -145,7 +145,7 @@ abstract class AbstractInlineFormField extends AbstractRelationFormField impleme
     {
         $configuration = parent::prepareConfiguration($type);
         $configuration['foreign_match_fields'] = $this->getForeignMatchFields();
-        $configuration['foreign_selector_fieldTcaOverride'] = $this->getForeignSelectorFieldTcaOverride();
+        $configuration['overrideChildTca'] = $this->getOverrideChildTca();
         $configuration['foreign_types'] = $this->getForeignTypes();
         $configuration['appearance'] = [
             'collapseAll' => $this->getCollapseAll(),
@@ -423,21 +423,22 @@ abstract class AbstractInlineFormField extends AbstractRelationFormField impleme
     }
 
     /**
-     * @param string $foreignSelectorFieldTcaOverride
+     * @param string $overrideChildTca
      * @return RelationFieldInterface
+     * @deprecated
      */
-    public function setForeignSelectorFieldTcaOverride($foreignSelectorFieldTcaOverride)
+    public function setOverrideChildTca($overrideChildTca)
     {
-        $this->foreignSelectorFieldTcaOverride = $foreignSelectorFieldTcaOverride;
+        $this->overrideChildTca = $overrideChildTca;
         return $this;
     }
 
     /**
      * @return string
      */
-    public function getForeignSelectorFieldTcaOverride()
+    public function getOverrideChildTca()
     {
-        return $this->foreignSelectorFieldTcaOverride;
+        return $this->overrideChildTca;
     }
 
     /**

--- a/Classes/Form/Field/Inline/Fal.php
+++ b/Classes/Form/Field/Inline/Fal.php
@@ -169,15 +169,17 @@ class Fal extends AbstractInlineFormField
         $configuration = $this->prepareConfiguration('inline');
         $configuration['appearance']['createNewRelationLinkTitle'] = $this->getCreateNewRelationLinkTitle();
         if (!empty($this->cropVariants)) {
-            $configuration['overrideChildTca'] = [
-                'columns' => [
-                    'crop' => [
-                        'config' => [
-                            'cropVariants' => $this->cropVariants
+            array_merge_recursive($configuration, [
+                'overrideChildTca' => [
+                    'columns' => [
+                        'crop' => [
+                            'config' => [
+                                'cropVariants' => $this->cropVariants
+                            ]
                         ]
                     ]
                 ]
-            ];
+            ]);
         }
         return $configuration;
     }

--- a/Classes/Form/Field/Inline/Fal.php
+++ b/Classes/Form/Field/Inline/Fal.php
@@ -169,17 +169,18 @@ class Fal extends AbstractInlineFormField
         $configuration = $this->prepareConfiguration('inline');
         $configuration['appearance']['createNewRelationLinkTitle'] = $this->getCreateNewRelationLinkTitle();
         if (!empty($this->cropVariants)) {
-            array_merge_recursive($configuration, [
-                'overrideChildTca' => [
-                    'columns' => [
-                        'crop' => [
-                            'config' => [
-                                'cropVariants' => $this->cropVariants
-                            ]
-                        ]
+            if (!isset($configuration['overrideChildTca'])) {
+                $configuration['overrideChildTca'] = ['columns' => []];
+            }
+            if (!isset($configuration['overrideChildTca']['columns'])) {
+                $configuration['overrideChildTca']['columns'] = [];
+            }
+            $configuration['overrideChildTca']['columns']['crop'] =
+                [
+                    'config' => [
+                        'cropVariants' => $this->cropVariants
                     ]
-                ]
-            ]);
+                ];
         }
         return $configuration;
     }

--- a/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
+++ b/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
@@ -227,11 +227,15 @@ class FalViewHelper extends AbstractInlineFieldViewHelper
                 'fieldname' => $arguments['name']
             ]);
         }
-        $component->setForeignSelectorFieldTcaOverride([
-            'config' => [
-                'appearance' => [
-                    'elementBrowserType' => 'file',
-                    'elementBrowserAllowed' => $allowedExtensions
+        $component->setOverrideChildTca([
+            'columns' => [
+                'uid_local' => [
+                    'config' => [
+                        'appearance' => [
+                            'elementBrowserType' => 'file',
+                            'elementBrowserAllowed' => $allowedExtensions
+                        ]
+                    ]
                 ]
             ]
         ]);


### PR DESCRIPTION
This migrates the inline fal configuration from using the now removed
foreign_selector_fieldTcaOverride to overrideChildTca.

Fixes #1774