### PR TITLE
[BUGFIX] Respect absolute file paths on Windows systems

### DIFF
--- a/Classes/Core.php
+++ b/Classes/Core.php
@@ -16,6 +16,7 @@ use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
 use Symfony\Component\Finder\Finder;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
@@ -319,7 +320,7 @@ class Core
         $providerClassName = Provider::class,
         $pluginName = null
     ) {
-        if ($templateFilename[0] !== DIRECTORY_SEPARATOR) {
+        if (!PathUtility::isAbsolutePath($templateFilename)) {
             $templateFilename = GeneralUtility::getFileAbsFileName($templateFilename);
         }
 

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -22,6 +22,7 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
 use TYPO3\CMS\Extbase\Mvc\Request as WebRequest;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
@@ -480,7 +481,7 @@ class AbstractProvider implements ProviderInterface
     public function getTemplatePathAndFilename(array $row)
     {
         $templatePathAndFilename = $this->templatePathAndFilename;
-        if (0 === strpos($templatePathAndFilename, 'EXT:') || 0 !== strpos($templatePathAndFilename, '/')) {
+        if (!PathUtility::isAbsolutePath($templatePathAndFilename)) {
             $templatePathAndFilename = GeneralUtility::getFileAbsFileName($templatePathAndFilename);
             if (true === empty($templatePathAndFilename)) {
                 $templatePathAndFilename = null;


### PR DESCRIPTION
The current checks for absolute file paths currently disregards Windows file paths.
This patch introduces PathUtility::isAbsolutePath to respect both, Unix and Windows paths.

Resolves: #1752