### PR TITLE
[BUGFIX] Add softref parsing on Text field

### DIFF
--- a/Classes/Form/Field/Text.php
+++ b/Classes/Form/Field/Text.php
@@ -69,6 +69,7 @@ class Text extends Input implements FieldInterface
         $configuration['placeholder'] = $this->getPlaceholder();
         if (true === $this->getEnableRichText()) {
             $configuration['enableRichtext'] = true;
+            $configuration['softref'] = 'typolink_tag,images,email[subst],url';
             $configuration['richtextConfiguration'] = $this->getRichtextConfiguration();
         }
         $renderType = $this->getRenderType();


### PR DESCRIPTION
Like for Input with link wizard, the Text field must have the softref TCA set to allow correct detection of soft reference.
This helps when exporting Flux contents as T3D.