### PR TITLE
[FEATURE] Revive Outlet feature

### DIFF
--- a/Classes/Integration/ContentTypeBuilder.php
+++ b/Classes/Integration/ContentTypeBuilder.php
@@ -134,7 +134,7 @@ class ContentTypeBuilder
             $providerExtensionName,
             $emulatedPluginName,
             [$controllerName => $controllerAction . ',outlet,error'],
-            [],
+            [$controllerName => 'outlet'],
             ExtensionUtility::PLUGIN_TYPE_CONTENT_ELEMENT
         );
     }

--- a/Classes/Outlet/Pipe/AbstractPipe.php
+++ b/Classes/Outlet/Pipe/AbstractPipe.php
@@ -8,12 +8,6 @@ namespace FluidTYPO3\Flux\Outlet\Pipe;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use FluidTYPO3\Flux\Form\Field\Input;
-use FluidTYPO3\Flux\Form\Field\Select;
-use FluidTYPO3\Flux\Form\FieldInterface;
-use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
-
 /**
  * Abstract Pipe
  *
@@ -21,20 +15,6 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
  */
 abstract class AbstractPipe implements PipeInterface
 {
-
-    /**
-     * @param array $settings
-     * @return void
-     */
-    public function loadSettings(array $settings)
-    {
-        foreach ($settings as $name => $value) {
-            if (true === property_exists($this, $name)) {
-                ObjectAccess::setProperty($this, $name, $value);
-            }
-        }
-    }
-
     /**
      * @param mixed $data
      * @return mixed
@@ -42,43 +22,5 @@ abstract class AbstractPipe implements PipeInterface
     public function conduct($data)
     {
         return $data;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return substr(lcfirst(array_pop(explode('\\', get_class($this)))), 0, -4);
-    }
-
-    /**
-     * @return string
-     */
-    public function getLabel()
-    {
-        $type = $this->getType();
-        $translated = LocalizationUtility::translate('pipes.' . $type . '.label', 'flux');
-        return (null === $translated ? $type : $translated);
-    }
-
-    /**
-     * @return FieldInterface[]
-     */
-    public function getFormFields()
-    {
-        $class = get_class($this);
-        /** @var Input $labelField */
-        $labelField = Input::create(['type' => 'Input']);
-        $labelField->setName('label');
-        $labelField->setDefault($this->getLabel());
-        /** @var Select $classField */
-        $classField = Select::create(['type' => 'Select']);
-        $classField->setName('class');
-        $classField->setItems([$class => $class]);
-        return [
-            'label' => $labelField,
-            'class' => $classField
-        ];
     }
 }

--- a/Classes/Outlet/Pipe/FlashMessagePipe.php
+++ b/Classes/Outlet/Pipe/FlashMessagePipe.php
@@ -63,29 +63,6 @@ class FlashMessagePipe extends AbstractPipe implements PipeInterface
     }
 
     /**
-     * @return FieldInterface[]
-     */
-    public function getFormFields()
-    {
-        $severities = [
-            FlashMessage::OK => 'OK',
-            FlashMessage::ERROR => 'ERROR',
-            FlashMessage::NOTICE => 'NOTICE',
-            FlashMessage::WARNING => 'WARNING'
-        ];
-        $fields = parent::getFormFields();
-        $fields['message'] = Text::create(['type' => 'Text'])->setName('message');
-        $fields['title'] = Input::create(['type' => 'Input'])->setName('title');
-        /** @var Select $severity */
-        $severity = Select::create(['type' => 'Select']);
-        $severity->setName('severity');
-        $severity->setItems($severities);
-        $severity->setDefault(FlashMessage::OK);
-        $fields['severity'] = $severity;
-        return $fields;
-    }
-
-    /**
      * @param integer $severity
      * @return FlashMessagePipe
      */

--- a/Classes/Outlet/Pipe/PipeInterface.php
+++ b/Classes/Outlet/Pipe/PipeInterface.php
@@ -8,8 +8,6 @@ namespace FluidTYPO3\Flux\Outlet\Pipe;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use FluidTYPO3\Flux\Form\FieldInterface;
-
 /**
  * Pipe Interface
  *
@@ -17,13 +15,6 @@ use FluidTYPO3\Flux\Form\FieldInterface;
  */
 interface PipeInterface
 {
-
-    /**
-     * @param array $settings
-     * @return void
-     */
-    public function loadSettings(array $settings);
-
     /**
      * Accept $data and do whatever the Pipe should do before
      * returning the same or a modified version of $data for
@@ -33,19 +24,4 @@ interface PipeInterface
      * @return mixed
      */
     public function conduct($data);
-
-    /**
-     * Get a human-readable name of this Pipe.
-     *
-     * @return string
-     */
-    public function getLabel();
-
-    /**
-     * Return the FormComponent "Field" instances which represent
-     * options this Pipe supports.
-     *
-     * @return FieldInterface[]
-     */
-    public function getFormFields();
 }

--- a/Classes/Outlet/Pipe/TypeConverterPipe.php
+++ b/Classes/Outlet/Pipe/TypeConverterPipe.php
@@ -8,9 +8,6 @@ namespace FluidTYPO3\Flux\Outlet\Pipe;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use FluidTYPO3\Flux\Form\Field\Input;
-use FluidTYPO3\Flux\Form\Field\Select;
-use FluidTYPO3\Flux\Form\FieldInterface;
 use TYPO3\CMS\Extbase\Error\Error;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Extbase\Property\TypeConverterInterface;
@@ -40,6 +37,11 @@ class TypeConverterPipe extends AbstractPipe implements PipeInterface
     protected $targetType;
 
     /**
+     * @var string|null
+     */
+    protected $propertyName = '';
+
+    /**
      * @param ObjectManagerInterface $objectManager
      * @return void
      */
@@ -47,24 +49,6 @@ class TypeConverterPipe extends AbstractPipe implements PipeInterface
     {
         $this->objectManager = $objectManager;
     }
-
-    /**
-     * @return FieldInterface[]
-     */
-    public function getFormFields()
-    {
-        $fields = parent::getFormFields();
-        $converters = array_values((array) $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['extbase']['typeConverters']);
-        $converters = array_combine($converters, $converters);
-        /** @var Select $typeConverter */
-        $typeConverter = Select::create(['type' => 'Select']);
-        $typeConverter->setName('typeConverter');
-        $typeConverter->setItems($converters);
-        $fields['typeConverter'] = $typeConverter;
-        $fields['targetType'] = Input::create(['type' => 'Input'])->setName('targetType');
-        return $fields;
-    }
-
 
     /**
      * @param TypeConverterInterface|string $typeConverter
@@ -105,6 +89,16 @@ class TypeConverterPipe extends AbstractPipe implements PipeInterface
         return $this->targetType;
     }
 
+    public function getPropertyName(): string
+    {
+        return $this->propertyName;
+    }
+
+    public function setPropertyName(?string $propertyName): void
+    {
+        $this->propertyName = $propertyName;
+    }
+
     /**
      * @param mixed $data
      * @return mixed
@@ -112,20 +106,27 @@ class TypeConverterPipe extends AbstractPipe implements PipeInterface
      */
     public function conduct($data)
     {
+        $output = &$data;
+        $subject = &$data;
+        if (!empty($this->propertyName)) {
+            foreach (explode('.', $this->propertyName) as $segment) {
+                $subject = &$subject[$segment];
+            }
+        }
         $targetType = $this->getTargetType();
         $typeConverter = $this->getTypeConverter();
-        if (false === $typeConverter->canConvertFrom($data, $targetType)) {
+        if (false === $typeConverter->canConvertFrom($subject, $targetType)) {
             throw new Exception(
                 sprintf(
                     'TypeConverter %s cannot convert %s to %s',
                     get_class($typeConverter),
-                    gettype($data),
+                    gettype($subject),
                     $targetType
                 ),
                 1386292424
             );
         }
-        $output = $this->typeConverter->convertFrom($data, $targetType);
+        $subject= $this->typeConverter->convertFrom($subject, $targetType);
         if (true === $output instanceof Error) {
             throw new Exception(
                 sprintf(

--- a/Classes/ViewHelpers/Outlet/FormViewHelper.php
+++ b/Classes/ViewHelpers/Outlet/FormViewHelper.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Flux\ViewHelpers\Outlet;
  */
 
 use FluidTYPO3\Flux\Provider\AbstractProvider;
+use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
 
 /**
  * Outlet Form Renderer
@@ -43,31 +44,30 @@ class FormViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\FormViewHelper
     protected $record;
 
     /**
-     * NB: We use this method because 7.6 LTS FormViewHelper uses render() method
-     * arguments which cannot be overridden by other means while preserving
-     * compatibility between 7.6 and 8.x branches. Once 8.x LTS is the only
-     * supported TYPO3 version we can move these.
-     *
      * @return void
      */
-    public function initialize()
+    public function render()
     {
-        $this->provider = $this->viewHelperVariableContainer->get(static::class, 'provider');
-        $this->record = $this->viewHelperVariableContainer->get(static::class, 'record');
+        $this->provider = $this->viewHelperVariableContainer->get(\FluidTYPO3\Flux\ViewHelpers\FormViewHelper::class, 'provider');
+        $this->record = $this->viewHelperVariableContainer->get(\FluidTYPO3\Flux\ViewHelpers\FormViewHelper::class, 'record');
 
         if (!$this->hasArgument('extensionName')) {
-            $this->arguments['extensionName'] = $this->viewHelperVariableContainer->get(static::class, 'extensionName');
+            $this->arguments['extensionName'] = ExtensionNamingUtility::getExtensionName($this->provider->getControllerExtensionKeyFromRecord($this->record));
+        }
+
+        if (!$this->hasArgument('controller')) {
+            $this->arguments['controller'] = $this->provider->getControllerNameFromRecord($this->record);
         }
 
         if (!$this->hasArgument('pluginName')) {
-            $this->arguments['pluginName'] = $this->viewHelperVariableContainer->get(static::class, 'pluginName');
+            $this->arguments['pluginName'] = $this->viewHelperVariableContainer->get(\FluidTYPO3\Flux\ViewHelpers\FormViewHelper::class, 'pluginName');
         }
 
         if (!$this->hasArgument('action')) {
             $this->arguments['action'] = 'outlet';
         }
 
-        parent::initialize();
+        return parent::render();
     }
 
     /**

--- a/Classes/ViewHelpers/Pipe/AbstractPipeViewHelper.php
+++ b/Classes/ViewHelpers/Pipe/AbstractPipeViewHelper.php
@@ -40,15 +40,15 @@ abstract class AbstractPipeViewHelper extends AbstractFormViewHelper
         );
     }
 
-    protected function callRenderMethod()
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        $form = static::getFormFromRenderingContext($this->renderingContext);
-        $sheet = true === $form->has('pipes') ? $form->get('pipes') : $form->createContainer('Sheet', 'pipes');
-        $pipe = static::preparePipeInstance($this->renderingContext, $this->arguments);
-        foreach ($pipe->getFormFields() as $formField) {
-            $sheet->add($formField);
+        $form = static::getFormFromRenderingContext($renderingContext);
+        $pipe = static::preparePipeInstance($renderingContext, $arguments);
+        if ($arguments['direction'] === static::DIRECTION_IN) {
+            $form->getOutlet()->addPipeIn($pipe);
+        } else {
+            $form->getOutlet()->addPipeOut($pipe);
         }
-        $form->getOutlet()->addPipeOut($pipe);
     }
 
     /**

--- a/Classes/ViewHelpers/Pipe/TypeConverterViewHelper.php
+++ b/Classes/ViewHelpers/Pipe/TypeConverterViewHelper.php
@@ -37,6 +37,7 @@ class TypeConverterViewHelper extends AbstractPipeViewHelper
             '"Converter" suffix, e.g. PersistentObject, Array etc.',
             true
         );
+        $this->registerArgument('property', 'string', 'Optional property which needs to be converted in data. If empty, uses entire form data array as input.');
     }
 
     /**
@@ -55,11 +56,14 @@ class TypeConverterViewHelper extends AbstractPipeViewHelper
         $pipe = $objectManager->get(TypeConverterPipe::class);
         $converter = $arguments['typeConverter'];
         if (false === $converter instanceof TypeConverterInterface) {
-            if (false === class_exists($converter)) {
-                $converter = 'TYPO3\\CMS\\Extbase\\Property\\TypeConverter\\' . $converter . 'Converter';
+            $coreConverterFqn = 'TYPO3\\CMS\\Extbase\\Property\\TypeConverter\\' . $converter . 'Converter';
+            if (class_exists($coreConverterFqn)) {
+                $converter = $coreConverterFqn;
             }
             $converter = $objectManager->get($converter);
         }
+
+        $pipe->setPropertyName($arguments['property']);
         $pipe->setTypeConverter($converter);
         $pipe->setTargetType($arguments['targetType']);
         return $pipe;

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -193,21 +193,6 @@
 			<trans-unit id="flux.clearValue">
 				<source>Clear value</source>
 			</trans-unit>
-			<trans-unit id="pipes.standard.label">
-				<source>Standard pipe (no action)</source>
-			</trans-unit>
-			<trans-unit id="pipes.controller.label">
-				<source>Controller action pipe</source>
-			</trans-unit>
-			<trans-unit id="pipes.email.label">
-				<source>Email sending pipe</source>
-			</trans-unit>
-			<trans-unit id="pipes.flashMessage.label">
-				<source>FlashMessage dispatch pipe</source>
-			</trans-unit>
-			<trans-unit id="pipes.typeConverter.label">
-				<source>Extbase TypeConverter pipe</source>
-			</trans-unit>
 			<trans-unit id="reference">
 				<source>Reference to content on page '%s' - click to jump to original</source>
 			</trans-unit>

--- a/Tests/Unit/Outlet/Pipe/AbstractPipeTestCase.php
+++ b/Tests/Unit/Outlet/Pipe/AbstractPipeTestCase.php
@@ -31,38 +31,4 @@ abstract class AbstractPipeTestCase extends AbstractTestCase
         $output = $instance->conduct($this->defaultData);
         $this->assertNotEmpty($output);
     }
-
-    /**
-     * @test
-     */
-    public function canGetLabel()
-    {
-        $instance = $this->createInstance();
-        $label = $instance->getLabel();
-        $this->assertNotEmpty($label);
-    }
-
-    /**
-     * @test
-     */
-    public function canGetFormFields()
-    {
-        $fields = $this->createInstance()->getFormFields();
-        $this->assertIsArray($fields);
-        $this->assertInstanceOf('FluidTYPO3\Flux\Form\FieldInterface', $fields['class']);
-        $this->assertInstanceOf('FluidTYPO3\Flux\Form\FieldInterface', $fields['label']);
-    }
-
-    /**
-     * @test
-     */
-    public function canLoadSettings()
-    {
-        $instance = $this->createInstance();
-        $instance->loadSettings($this->defaultData);
-        foreach ($this->defaultData as $propertyName => $propertyValue) {
-            $result = ObjectAccess::getProperty($instance, $propertyName, true);
-            $this->assertEquals($propertyValue, $result);
-        }
-    }
 }

--- a/Tests/Unit/Outlet/Pipe/EmailPipeTest.php
+++ b/Tests/Unit/Outlet/Pipe/EmailPipeTest.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Flux\Tests\Unit\Outlet\Pipe;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Flux\Outlet\Pipe\EmailPipe;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 
 /**
@@ -29,28 +30,6 @@ class EmailPipeTest extends AbstractPipeTestCase
         $pipe = $this->getMockBuilder('FluidTYPO3\Flux\Outlet\Pipe\EmailPipe')->setMethods(array('sendEmail'))->getMock();
         ObjectAccess::setProperty($pipe, 'label', 'Mock EmailPipe', true);
         return $pipe;
-    }
-
-    /**
-     * @test
-     */
-    public function supportsSenderArray()
-    {
-        $instance = $this->createInstance();
-        $instance->setSender(array('test@test.com', 'test'));
-        $output = $instance->conduct($this->defaultData);
-        $this->assertNotEmpty($output);
-    }
-
-    /**
-     * @test
-     */
-    public function supportsRecipientArray()
-    {
-        $instance = $this->createInstance();
-        $instance->setRecipient(array('test@test.com', 'test'));
-        $output = $instance->conduct($this->defaultData);
-        $this->assertNotEmpty($output);
     }
 
     /**

--- a/Tests/Unit/Outlet/Pipe/StandardPipeTest.php
+++ b/Tests/Unit/Outlet/Pipe/StandardPipeTest.php
@@ -15,21 +15,8 @@ class StandardPipeTest extends AbstractPipeTestCase
 {
 
     /**
-     * @test
+     * @var array
      */
-    public function canConductData()
-    {
-        $instance = $this->createInstance();
-        $output = $instance->conduct($this->defaultData);
-        $this->assertEmpty($output);
-    }
+    protected $defaultData = array('foo' => 'bar');
 
-    /**
-     * @test
-     */
-    public function canLoadSettings()
-    {
-        $result = $this->createInstance()->loadSettings(array());
-        $this->assertEmpty($result);
-    }
 }


### PR DESCRIPTION
Revives the Outlet feature by cleaning up the implementation
and removing the form fields integration so that Outlet/Pipe
is now exclusively configured at Form level. Adds TYPO3 10.4
support to the EmailPipe, and adds a "property" argument for
the TypeConverterPipe to allow converting only a single
property in the posted form data array.