### PR TITLE
[BUGFIX] Show column label instead of colPos (page translation view) 

### DIFF
--- a/Classes/Integration/PreviewView.php
+++ b/Classes/Integration/PreviewView.php
@@ -389,6 +389,11 @@ class PreviewView extends TemplateView
             $itemLabels[$name] = ($val['label'] ?? false) ? $this->getLanguageService()->sL($val['label']) : '';
         }
 
+        array_push(
+            $GLOBALS['TCA']['tt_content']['columns']['colPos']['config']['items'],
+            ...$layoutConfiguration['__items']
+        );
+
         $columnsAsCSV = implode(',', $layoutConfiguration['__colPosList'] ?? []);
 
         $view->script = 'db_layout.php';


### PR DESCRIPTION
Copy 5fde1b6d2cd448e6ad64c7a3f70a7de4ad79190f which once fixed #1620 to solve #1850 