### PR TITLE
[BUGFIX] Add missing parenthesis when checking for GLOB_BRACE.

### DIFF
--- a/Classes/Utility/MiscellaneousUtility.php
+++ b/Classes/Utility/MiscellaneousUtility.php
@@ -57,7 +57,7 @@ class MiscellaneousUtility
             $iconPathAndName = $iconFolder . $templateName;
             $filesInFolder = array();
             if (true === is_dir($iconFolder)) {
-                if (true === defined(GLOB_BRACE)) {
+                if (true === defined('GLOB_BRACE')) {
                     $allowedExtensions = implode(',', static::$allowedIconTypes);
                     $iconMatchPattern = $iconPathAndName . '.{' . $allowedExtensions . '}';
                     $filesInFolder = glob($iconMatchPattern, GLOB_BRACE);


### PR DESCRIPTION
When using TYPO3 10.4.13 and PHP 7.4 and running debug mode I get the following error for the TYPO3 backend as well as the frontend:

```
PHP Warning: Use of undefined constant GLOB_BRACE - assumed 'GLOB_BRACE' (this will throw an Error in a future version of PHP) in /www/public/typo3conf/ext/flux/Classes/Utility/MiscellaneousUtility.php line 60
```