### PR TITLE
[BUGFIX] Use controller FQCN on TYPO3 10.4+

### DIFF
--- a/Classes/Integration/ContentTypeBuilder.php
+++ b/Classes/Integration/ContentTypeBuilder.php
@@ -119,7 +119,11 @@ class ContentTypeBuilder
      */
     protected function configureContentTypeForController($providerExtensionName, $controllerClassName, $controllerAction)
     {
-        $controllerName = substr($controllerClassName, strrpos($controllerClassName, '\\') + 1, -10);
+        if (version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), 10.4, '>=')) {
+            $controllerName = $controllerClassName;
+        } else {
+            $controllerName = substr($controllerClassName, strrpos($controllerClassName, '\\') + 1, -10);
+        }
         $emulatedPluginName = ucfirst(strtolower($controllerAction));
 
         // Sanity check: if controller does not implement a custom method matching the template name, default to "render"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -132,11 +132,19 @@ if (!defined('TYPO3_MODE')) {
         }
 
         if (!\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('fluidpages')) {
+            if (version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), 10.4, '>=')) {
+                $pageControllerName = \FluidTYPO3\Flux\Controller\PageController::class;
+                $pageControllerExtensionName = 'Flux';
+            } else {
+                $pageControllerName = 'Page';
+                $pageControllerExtensionName = 'FluidTYPO3.Flux';
+            }
+
             \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-                'FluidTYPO3.Flux',
+                $pageControllerExtensionName,
                 'Page',
                 [
-                    'Page' => 'render,error',
+                    $pageControllerName => 'render,error',
                 ],
                 [],
                 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::PLUGIN_TYPE_PLUGIN


### PR DESCRIPTION
Use full class name instead of short handle on TYPO3
versions that support using FQCN.