### PR TITLE
[BUGFIX] Avoid error when copying on list

### DIFF
--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -205,7 +205,9 @@ class DataHandlerSubscriber
                             $this->cascadeCommandToChildRecords($table, (int)$id, $command, $value, $dataHandler);
                             break;
                         case 'copy':
-                            unset($value['update']['colPos']);
+                            if (is_array($value)) {
+                                unset($value['update']['colPos']);
+                            }
                             $this->cascadeCommandToChildRecords($table, (int)$id, $command, $value, $dataHandler);
                             break;
                         default:


### PR DESCRIPTION
When copying on list view, `$value` comes as a negative integer indicating the id of the content after which is going to be pasted. A simple `is_array` conditions seems to work.

Resolves: #1816