### PR TITLE
[BUGFIX] Fix content type Available content types

### DIFF
--- a/Classes/Content/ContentTypeManager.php
+++ b/Classes/Content/ContentTypeManager.php
@@ -56,7 +56,7 @@ class ContentTypeManager implements SingletonInterface
                     (array) FluidFileBasedContentTypeDefinition::fetchContentTypes(),
                     (array) RecordBasedContentTypeDefinition::fetchContentTypes()
                 );
-                $this->typeNames = array_keys($types);
+                $this->typeNames = array_merge($this->typeNames, array_keys($types));
             } catch (DBALException $error) {
                 // Suppress schema- or connection-related issues
             } catch (NoSuchCacheException $error) {


### PR DESCRIPTION
I've discovered the problem with Issue #1866 where the content types selection only worked when the Plug & Play checkbox was selected.
During my xdebug fiddling I noticed that even I had 2 flux based extensions and the Plug & Play enabled the CEs of first extension didn't get listed in the 'Available content types' list.
After a bit more of debugging I came down to this line where the `$this->typeNames` were replaced instead of added to the already existing one.
After I've changed the line it worked even without Plug & Play selection.