### PR TITLE
[BUGFIX] readd child elements toggler to flux containers

### DIFF
--- a/Classes/Integration/HookSubscribers/ContentIcon.php
+++ b/Classes/Integration/HookSubscribers/ContentIcon.php
@@ -12,6 +12,7 @@ use FluidTYPO3\Flux\Hooks\HookHandler;
 use FluidTYPO3\Flux\Provider\Interfaces\GridProviderInterface;
 use FluidTYPO3\Flux\Service\FluxService;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Backend\View\BackendLayout\Grid\GridColumnItem;
 use TYPO3\CMS\Backend\View\PageLayoutView;
 use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
@@ -87,7 +88,7 @@ class ContentIcon
      */
     public function addSubIcon(array $parameters, $caller = null)
     {
-        if (!$caller instanceof PageLayoutView) {
+        if (!($caller instanceof PageLayoutView || $caller instanceof GridColumnItem)) {
             return '';
         }
         list ($table, $uid, $record) = $parameters;


### PR DESCRIPTION
With flux 9.2.0 and TYPO3 8 there was a toggler icon in the backend page module to hide the child elements of a flux (fluidcontent) container. In TYPO3 with the current flux version it is not shown anymore. The proposed patch readds that toggler.
![flux-container-toggler](https://user-images.githubusercontent.com/11320147/116720281-47f3ee80-a9dc-11eb-9acb-23723f4d30cf.png)
