### PR TITLE
[FEATURE] Add support for field description properties.

### DIFF
--- a/Classes/Form/AbstractFormComponent.php
+++ b/Classes/Form/AbstractFormComponent.php
@@ -266,6 +266,16 @@ abstract class AbstractFormComponent implements FormInterface
     }
 
     /**
+     * @param string $description
+     * @return FormInterface
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    /**
      * @return string
      */
     public function getPath()
@@ -299,6 +309,14 @@ abstract class AbstractFormComponent implements FormInterface
     public function getLabel()
     {
         return $this->resolveLocalLanguageValueOfLabel($this->label);
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
     }
 
     /**

--- a/Classes/Form/Field.php
+++ b/Classes/Form/Field.php
@@ -1,6 +1,8 @@
 <?php
 namespace FluidTYPO3\Flux\Form;
 
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 /**
  * Generic TCA field
  */
@@ -67,6 +69,10 @@ class Field extends AbstractFormField
             'displayCond' => $this->getDisplayCondition(),
             'onChange' => $this->getOnChange(),
         ];
+
+        if (version_compare(ExtensionManagementUtility::getExtensionVersion('core'), '9.4', '>=')) {
+            $fieldStructureArray['description'] = $this->getDescription();
+        }
 
         $fieldStructureArray = array_filter($fieldStructureArray, $filterClosure);
         return $fieldStructureArray;

--- a/Classes/Form/FormInterface.php
+++ b/Classes/Form/FormInterface.php
@@ -62,6 +62,16 @@ interface FormInterface
     public function getLabel();
 
     /**
+     * @param string $description
+     */
+    public function setDescription($description);
+
+    /**
+     * @return string
+     */
+    public function getDescription();
+
+    /**
      * @param string $localLanguageFileRelativePath
      * @return FormInterface
      */

--- a/Classes/ViewHelpers/FieldViewHelper.php
+++ b/Classes/ViewHelpers/FieldViewHelper.php
@@ -26,6 +26,7 @@ class FieldViewHelper extends AbstractFieldViewHelper
         $this->registerArgument('type', 'string', 'TCA field type', true);
         $this->registerArgument('name', 'string', 'Name of the attribute, FlexForm XML-valid tag name string', true);
         $this->registerArgument('label', 'string', 'Label for field', true);
+        $this->registerArgument('description', 'string', 'Field description', false);
         $this->registerArgument('exclude', 'bool', 'Set to FALSE if field is not an "exclude" field', false, false);
         $this->registerArgument('config', 'array', 'TCA "config" array', false, []);
         $this->registerArgument(


### PR DESCRIPTION
In addition to labels, TYPO3 9.4 add a description TCA field property that can be used as help text.

This patch makes the property available for flux fields.

The property is only added to fields in TYPO3 version 9.4+.

See https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Feature-85410-AllowTCADescriptionProperty.html