### PR TITLE
[BUGFIX] Custom controller actions in Typo3 11 with new return types

### DIFF
--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -18,7 +18,6 @@ use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
 use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
 use FluidTYPO3\Flux\ViewHelpers\FormViewHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;
@@ -446,7 +445,7 @@ abstract class AbstractFluxController extends ActionController
                     'controllerActionName' => $controllerActionName
                 ]
             );
-            if ($typo3VersionArray['version_main'] < 11) {
+            if (version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), 11, '<')) {
                 $potentialControllerInstance->processRequest($this->request, $response);
             } else {
                 $response = $potentialControllerInstance->processRequest($this->request);

--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -17,6 +17,8 @@ use FluidTYPO3\Flux\Service\WorkspacesAwareRecordService;
 use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
 use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
 use FluidTYPO3\Flux\ViewHelpers\FormViewHelper;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -427,10 +429,17 @@ abstract class AbstractFluxController extends ActionController
         $this->request->setControllerExtensionName($extensionName);
         $this->request->setControllerActionName($controllerActionName);
         $potentialControllerInstance = $this->objectManager->get($controllerClassName);
+
         if (isset($this->responseFactory)) {
             $response = $this->responseFactory->createResponse();
         } else {
             $response = $this->objectManager->get(Response::class);
+        }
+
+        if (class_exists(Typo3Version::class)) {
+            $version = GeneralUtility::makeInstance(Typo3Version::class)->getVersion();
+        } else {
+            $version = ExtensionManagementUtility::getExtensionVersion('core');
         }
 
         try {
@@ -444,7 +453,8 @@ abstract class AbstractFluxController extends ActionController
                     'controllerActionName' => $controllerActionName
                 ]
             );
-            if (version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), 11, '<')) {
+
+            if (version_compare($version, 11, '<')) {
                 $potentialControllerInstance->processRequest($this->request, $response);
             } else {
                 $response = $potentialControllerInstance->processRequest($this->request);

--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -18,6 +18,7 @@ use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
 use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
 use FluidTYPO3\Flux\ViewHelpers\FormViewHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;
@@ -426,6 +427,7 @@ abstract class AbstractFluxController extends ActionController
         $this->request->setArguments($arguments);
         $this->request->setControllerExtensionName($extensionName);
         $this->request->setControllerActionName($controllerActionName);
+        $typo3Version = VersionNumberUtility::convertVersionStringToArray(VersionNumberUtility::getCurrentTypo3Version());
         $potentialControllerInstance = $this->objectManager->get($controllerClassName);
         if (isset($this->responseFactory)) {
             $response = $this->responseFactory->createResponse();
@@ -444,7 +446,11 @@ abstract class AbstractFluxController extends ActionController
                     'controllerActionName' => $controllerActionName
                 ]
             );
-            $potentialControllerInstance->processRequest($this->request, $response);
+            if ($typo3VersionArray['version_main'] < 11) {
+                $potentialControllerInstance->processRequest($this->request, $response);
+            } else {
+                $response = $potentialControllerInstance->processRequest($this->request);
+            }
         } catch (StopActionException $error) {
             // intentionally left blank
         }

--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -426,7 +426,6 @@ abstract class AbstractFluxController extends ActionController
         $this->request->setArguments($arguments);
         $this->request->setControllerExtensionName($extensionName);
         $this->request->setControllerActionName($controllerActionName);
-        $typo3Version = VersionNumberUtility::convertVersionStringToArray(VersionNumberUtility::getCurrentTypo3Version());
         $potentialControllerInstance = $this->objectManager->get($controllerClassName);
         if (isset($this->responseFactory)) {
             $response = $this->responseFactory->createResponse();


### PR DESCRIPTION
The custom controller actions breaks in Typo3 11, because the process function for the custom functions got changed. I already got a working solution for the problem, but i want to describe it first.

In flux, the action is called here: https://github.com/FluidTYPO3/flux/blob/development/Classes/Controller/AbstractFluxController.php#L447
But with typo3 11, the parameters got changed. The response is no parameter anymore, it's the result. Extbase code: https://github.com/TYPO3/typo3/blob/main/typo3/sysext/extbase/Classes/Mvc/Controller/ActionController.php

I fixed the problem with a version check for the Typo3 version. So it is also working for older versions of Typo3.