### PR TITLE
[DOC] update annotation for allowedContentTypes in ColumnViewHelper 

### DIFF
--- a/Classes/ViewHelpers/Grid/ColumnViewHelper.php
+++ b/Classes/ViewHelpers/Grid/ColumnViewHelper.php
@@ -38,9 +38,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  * It is also possible to limit the allowed fluid content elements:
  *
  *     <flux:grid.column name="elements" colPos="0">
- *         <flux:form.variable name="allowedContentTypes" value="fluidcontent_content"/>
- *         <flux:form.variable name="Fluidcontent"
- *             value="{allowedContentTypes: 'Vendor.Extension:ContentElement.html'}"/>
+ *         <flux:form.variable name="allowedContentTypes" value="extkey_vehicledetailssectionusedcarseal"/>
  *     </flux:grid.column>
  */
 class ColumnViewHelper extends AbstractFormViewHelper


### PR DESCRIPTION
Viewhelper annotation was not up-to-date with current implementation of "allowedContentTypes" in  ColumnViewHelper