### PR TITLE
[BUGFIX] Use page layout specific column labels

### DIFF
--- a/Classes/Form/Container/Grid.php
+++ b/Classes/Form/Container/Grid.php
@@ -142,7 +142,7 @@ class Grid extends AbstractFormContainer implements ContainerInterface
      * @param int $parentRecordUid
      * @return BackendLayout
      */
-    public function buildBackendLayout(int $parentRecordUid): BackendLayout
+    public function buildBackendLayout(int $parentRecordUid): ?BackendLayout
     {
         $configuration = $this->buildBackendLayoutArray($parentRecordUid);
         $configuration = $this->ensureDottedKeys($configuration);
@@ -153,9 +153,12 @@ class Grid extends AbstractFormContainer implements ContainerInterface
         foreach ($this->flattenSetup($configuration, 'backend_layout.') as $name => $value) {
             $typoScriptString .= $name . ' = ' . $value . LF;
         }
+        if ($root->getName() === null) {
+            return null;
+        }
         return new BackendLayout(
             $this->getRoot()->getName(),
-            LocalizationUtility::translate($label)
+            LocalizationUtility::translate($label, $root->getExtensionName())
                 ? $label
                 : 'LLL:EXT:flux/Resources/Private/Language/locallang.xlf:flux.grid.grids.grid',
             $typoScriptString

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -342,11 +342,15 @@ class AbstractProvider implements ProviderInterface
                         $gridColumn->setColSpan($object['colspan'] ?? 1);
                     }
                 }
+                $grid->setParent($form);
                 return $grid;
             }
         }
         $grid = $this->grid ?? $this->extractConfiguration($row, 'grids')['grid'] ?? Grid::create();
         $grid->setExtensionName($grid->getExtensionName() ?: $this->getControllerExtensionKeyFromRecord($row));
+        if ($form) {
+            $grid->setParent($form);
+        }
         return $grid;
     }
 


### PR DESCRIPTION
Labels of columns in page layouts were only translatable with the generic
non-specific key "flux.grid.columns.$columnName".

This patch sets the page layout's grid parent object to be the page layout's form,
so that the resolved parent ID is that of the form.

A column named "one" within a page layout with id "twocol" will thus get
the label key "flux.twocol.columns.one", just as it was for flux 8.

Resolves: https://github.com/FluidTYPO3/flux/issues/1468

----

:warning: I only found the code that fixes #1468. Because of the complexity of flux and my limited experience, I have no idea if that change breaks something else.