### PR TITLE
[BUGFIX] Do not try to load page 0 from database

### DIFF
--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -409,6 +409,9 @@ class PageProvider extends AbstractProvider implements ProviderInterface
      */
     protected function loadRecordTreeFromDatabase($record)
     {
+        if (empty($record['uid'])) {
+            return array();
+        }
         $rootLineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $record['uid']);
         return array_slice($rootLineUtility->get(), 1);
     }


### PR DESCRIPTION
On TYPO3 v8.7.32, copying a page with content elements or creating a new
content element leads to an exception:

> #1343589451: Could not fetch page data for uid 0.

TYPO3 v10 fixed that in core with https://forge.typo3.org/issues/86271
and the review was at https://review.typo3.org/58289

This is a better version of https://github.com/FluidTYPO3/flux/pull/1915 with
coding style fixes.

Resolves: https://github.com/FluidTYPO3/flux/issues/1912