### PR TITLE
[BUGFIX] Use TYPO3v9 API for colPos upgrade wizard

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -19,7 +19,7 @@ $conf = isset($_EXTCONF) ? $_EXTCONF : null;
 
     \FluidTYPO3\Flux\Utility\ExtensionConfigurationUtility::initialize($conf);
 
-    if (TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_INSTALL) {
+    if (version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), 9.0, '>=') && TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_INSTALL) {
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\FluidTYPO3\Flux\Updates\MigrateColPosWizard::class]
             = \FluidTYPO3\Flux\Updates\MigrateColPosWizard::class;
     }


### PR DESCRIPTION
The v8 API is not available on TYPO3v10 and v11, so to support them
we have to use the new upgrade wizard API.

We drop support for TYPO3v8 for that feature.

See
https://docs.typo3.org/c/typo3/cms-core/9.5/en-us/Changelog/9.4/Feature-86076-NewAPIForUpgradeWizards.html

Resolves: https://github.com/FluidTYPO3/flux/issues/1934
Related: https://github.com/FluidTYPO3/flux/pull/1929