### PR TITLE
[BUGFIX] Error "Language -1 does not exist on site"

### DIFF
--- a/Classes/Integration/PreviewView.php
+++ b/Classes/Integration/PreviewView.php
@@ -353,7 +353,7 @@ class PreviewView extends TemplateView
                 // TYPO3 10.4+
                 $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
                 $site = $siteFinder->getSiteByPageId($pageId);
-                $language = $site->getLanguageById((int) $row['sys_language_uid']);
+                $language = $site->getLanguageById(max(0, (int) $row['sys_language_uid']));
 
                 $context = GeneralUtility::makeInstance(PageLayoutContext::class, BackendUtility::getRecord('pages', $pageId), $backendLayout);
                 $context = $context->cloneForLanguage($language);


### PR DESCRIPTION
Hello there!

In one of our projects we use a multi-lingual TYPO3 10.4 together with our custom flux elements extension. After enabling the TYPO3 feature "Fluid based page module" this error occurred on any page in the page module if the accessed page contains a container content element which got assigned to all languages:
![image](https://user-images.githubusercontent.com/86473817/161943573-fcd6f210-f298-4849-85a5-92bba17f1a98.png)

We could reproduce this error using containers from an external flux elements extension as well.
With this adjustment the page module renders as expected:
![image](https://user-images.githubusercontent.com/86473817/161940805-dfae92bf-e61f-48aa-9419-b850e7bd2ae9.png)
