### PR TITLE
[TASK] Do not use "cache_" prefix for caches in TYPO3v10+

### DIFF
--- a/Classes/Content/ContentTypeManager.php
+++ b/Classes/Content/ContentTypeManager.php
@@ -116,7 +116,8 @@ class ContentTypeManager implements SingletonInterface
             try {
                 $cache = $cacheManager->getCache('flux');
             } catch (NoSuchCacheException $error) {
-                $cache = $cacheManager->getCache('cache_runtime');
+                $cacheKey = version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), 10.0, '>=') ? 'runtime' : 'cache_runtime';
+                $cache = $cacheManager->getCache($cacheKey);
             }
         }
         return $cache;

--- a/Classes/Integration/ContentTypeBuilder.php
+++ b/Classes/Integration/ContentTypeBuilder.php
@@ -202,8 +202,9 @@ class ContentTypeBuilder
 
         // Flush the cache entry that was generated; make sure any TypoScript overrides will take place once
         // all TypoScript is finally loaded.
+        $cacheKey = version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), 10.0, '>=') ? 'runtime' : 'cache_runtime';
         GeneralUtility::makeInstance(CacheManager::class)
-            ->getCache('cache_runtime')
+            ->getCache($cacheKey)
             ->remove('viewpaths_' . ExtensionNamingUtility::getExtensionKey($providerExtensionName));
     }
 

--- a/Classes/Integration/HookSubscribers/DynamicFlexForm.php
+++ b/Classes/Integration/HookSubscribers/DynamicFlexForm.php
@@ -239,7 +239,8 @@ class DynamicFlexForm extends FlexFormTools
     {
         static $cache;
         if (!$cache) {
-            $cache = GeneralUtility::makeInstance(CacheManager::class)->getCache('cache_runtime');
+            $cacheKey = version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), 10.0, '>=') ? 'runtime' : 'cache_runtime';
+            $cache = GeneralUtility::makeInstance(CacheManager::class)->getCache($cacheKey);
         }
         return $cache;
     }

--- a/Classes/Service/FluxService.php
+++ b/Classes/Service/FluxService.php
@@ -434,7 +434,11 @@ class FluxService implements SingletonInterface
     protected function getRuntimeCache()
     {
         static $cache;
-        return $cache ?? ($cache = GeneralUtility::makeInstance(CacheManager::class)->getCache('cache_runtime'));
+        if (!$cache) {
+            $cacheKey = version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), 10.0, '>=') ? 'runtime' : 'cache_runtime';
+            $cache = GeneralUtility::makeInstance(CacheManager::class)->getCache($cacheKey);
+        }
+        return $cache;
     }
 
     /**
@@ -448,7 +452,7 @@ class FluxService implements SingletonInterface
             try {
                 $cache = $cacheManager->getCache('flux');
             } catch (NoSuchCacheException $error) {
-                $cache = $cacheManager->getCache('cache_runtime');
+                $cache = $this->getRuntimeCache();
             }
         }
         return $cache;

--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -246,7 +246,8 @@ class PageService implements SingletonInterface
      */
     protected function getRuntimeCache()
     {
-        return GeneralUtility::makeInstance(CacheManager::class)->getCache('cache_runtime');
+        $cacheKey = version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), 10.0, '>=') ? 'runtime' : 'cache_runtime';
+        return GeneralUtility::makeInstance(CacheManager::class)->getCache($cacheKey);
     }
 
     protected function getRootLineUtility(int $pageUid): RootlineUtility


### PR DESCRIPTION
In TYPO3 v10, the "cache_" prefix for all the cache names has been removed.
Calling CacheManager::getCache('cache_runtime') is deprecated since then:
https://docs.typo3.org/c/typo3/cms-core/10.4/en-us/Changelog/10.0/Deprecation-88366-DefaultCachingFrameworkCacheNamesChanged.html

Flux generated deprecation notices on TYPO3v10:

 TYPO3 Deprecation Notice: Accessing a cache with the "cache_" prefix as
 in "cache_runtime" is not necessary anymore, and should be called without
 the cache prefix.
 in typo3/sysext/core/Classes/Cache/CacheManager.php line 151

Resolves: https://github.com/FluidTYPO3/flux/issues/1953