### PR TITLE
[TASK] Remove "showRecordFieldList" TCA option in TYPO3 v10.3+

### DIFF
--- a/Configuration/TCA/content_types.php
+++ b/Configuration/TCA/content_types.php
@@ -1,7 +1,7 @@
 <?php
 defined('TYPO3_MODE') or die();
 
-return [
+$data = [
     'ctrl' => [
         'title' => 'LLL:EXT:flux/Resources/Private/Language/locallang.xlf:content_types',
         'descriptionColumn' => 'description',
@@ -179,3 +179,9 @@ return [
     ],
     'palettes' => []
 ];
+
+if (!defined('TYPO3_version') || version_compare(TYPO3_version, 10.3, '>=')) {
+    unset($data['interface']['showRecordFieldList']);
+}
+
+return $data;


### PR DESCRIPTION
It generates a deprecation notice in 10.3+:

> The 'content_types' TCA configuration 'showRecordFieldList' inside the section
> 'interface' is not evaluated anymore and should therefore be removed.
> in typo3/sysext/core/Classes/Utility/ExtensionManagementUtility.php line 1721

https://docs.typo3.org/c/typo3/cms-core/10.4/en-us/Changelog/10.3/Feature-88901-RenderAllFieldsInElementInformationController.html