### PR TITLE
[TASK] Use PSR-14 event registration for TYPO3 v10.2+

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -5,3 +5,9 @@ services:
         identifier: 'flux-after-localization-controller-columns'
         method: 'modifyColumnsManifest'
         event: TYPO3\CMS\Backend\Controller\Event\AfterPageColumnsSelectedForLocalizationEvent
+  FluidTYPO3\Flux\Integration\HookSubscribers\EditDocumentController:
+    tags:
+      - name: event.listener
+        identifier: 'flux-requireColumnPositionJavaScript'
+        method: 'requireColumnPositionJavaScript'
+        event: TYPO3\CMS\Backend\Controller\Event\AfterFormEnginePageInitializedEvent

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -107,14 +107,16 @@ $conf = isset($_EXTCONF) ? $_EXTCONF : null;
             );
         }
 
-        /** @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher */
-        $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
-        $signalSlotDispatcher->connect(
-            \TYPO3\CMS\Backend\Controller\EditDocumentController::class,
-            'initAfter',
-            \FluidTYPO3\Flux\Integration\HookSubscribers\EditDocumentController::class,
-            'requireColumnPositionJavaScript'
-        );
+        if (version_compare(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('core'), 10.2, '<')) {
+            /** @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher */
+            $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
+            $signalSlotDispatcher->connect(
+                \TYPO3\CMS\Backend\Controller\EditDocumentController::class,
+                'initAfter',
+                \FluidTYPO3\Flux\Integration\HookSubscribers\EditDocumentController::class,
+                'requireColumnPositionJavaScript'
+            );
+        }
 
         if (true === class_exists(\FluidTYPO3\Flux\Core::class)) {
             \FluidTYPO3\Flux\Core::registerConfigurationProvider(\FluidTYPO3\Flux\Content\ContentTypeProvider::class);


### PR DESCRIPTION
Signal registration via SignalSlotDispatcher has been deprecated in TYPO3 v10.4:
https://docs.typo3.org/c/typo3/cms-core/10.4/en-us/Changelog/10.4/Deprecation-90625-ExtbaseSignalSlotDispatcher.html

The "EditDocumentController::initAfter" signal has been deprecated in TYPO3 v10.2:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.2/Deprecation-89733-SignalSlotsInCoreExtensionMigratedToPSR-14Events.html

.. and replaced with PSR-14 events:
https://docs.typo3.org/c/typo3/cms-core/10.4/en-us/Changelog/10.2/Feature-89733-NewPSR-14EventsForExistingSignalSlotsInCoreExtension.html

Flux generated a deprecation notice on TYPO3 10.4 because of that:
> The signal "initAfter" in "TYPO3\CMS\Backend\Controller\EditDocumentController"
> is deprecated and will stop working in TYPO3 11.0.
> Use the PSR-14 event: "TYPO3\CMS\Backend\Controller\Event\AfterFormEnginePageInitializedEvent"
> in typo3/sysext/extbase/Classes/SignalSlot/Dispatcher.php line 438