### PR TITLE
[BUGFIX] Allow deleting hidden content elements

### DIFF
--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -358,6 +358,7 @@ class DataHandlerSubscriber
     protected function getSingleRecordWithRestrictions(string $table, int $uid, string $fieldsToSelect): ?array
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+        $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
         $queryBuilder->select(...GeneralUtility::trimExplode(',', $fieldsToSelect))
             ->from($table)
             ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, \PDO::PARAM_INT)));


### PR DESCRIPTION
Deleting content elements that are restricted in some way
(hidden, starttime, endtime, fe_group) is broken since commit
> [BUGFIX] Prevent error when moving/pasting content with deleted child

That commit was meant to fix a problem with deleted content elements.
This commit here actually only filters deleted elements instead of all.

Resolves: https://github.com/FluidTYPO3/flux/issues/1939