### PR TITLE
[BUGFIX] Do not crash referenceindex:update with deleted pages

### DIFF
--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -119,6 +119,9 @@ class PageProvider extends AbstractProvider implements ProviderInterface
      */
     public function getForm(array $row)
     {
+        if ($row['deleted']) {
+            return null;
+        }
         $form = parent::getForm($row);
         if ($form) {
             $form->setOption(PreviewView::OPTION_PREVIEW, [PreviewView::OPTION_MODE => 'none']);


### PR DESCRIPTION
The TYPO3 reference index updater runs on deleted pages.

When such a page is checked, the following exception occurs:

> Could not fetch page data for uid 2043.
> at typo3/sysext/core/Classes/Utility/RootlineUtility.php:258

This patch prevents loading the form when the page has been deleted,
thus preventing to load the rootline of a non-existing page.

(TYPO3 v10.4.28, flux 9.6.1 + a bunch of applied pull requests)

----

The exception may happen on two code paths:

Exception trace 1:

 TYPO3\CMS\Core\Utility\RootlineUtility->getRecordArray()
 TYPO3\CMS\Core\Utility\RootlineUtility->generateRootlineCache()
 TYPO3\CMS\Core\Utility\RootlineUtility->get()
 FluidTYPO3\Flux\Service\PageService->getPageTemplateConfiguration()
 FluidTYPO3\Flux\Provider\PageProvider->getControllerActionReferenceFromRecord()
 FluidTYPO3\Flux\Provider\PageProvider->getControllerExtensionKeyFromRecord()
 FluidTYPO3\Flux\Provider\AbstractProvider->getControllerPackageNameFromRecord()
 FluidTYPO3\Flux\Provider\AbstractProvider->resolveFormClassName()
 FluidTYPO3\Flux\Provider\AbstractProvider->createCustomFormInstance()
 FluidTYPO3\Flux\Provider\AbstractProvider->getForm()
 FluidTYPO3\Flux\Provider\PageProvider->getForm()
 FluidTYPO3\Flux\Integration\HookSubscribers\DynamicFlexForm->parseDataStructureByIdentifierPreProcess()
 TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools->parseDataStructureByIdentifier()
 TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools->traverseFlexFormXMLData()
 TYPO3\CMS\Core\Database\ReferenceIndex->getRelations()

Exception trace 2:
 TYPO3\CMS\Core\Utility\RootlineUtility->getRecordArray()
 TYPO3\CMS\Core\Utility\RootlineUtility->generateRootlineCache()
 TYPO3\CMS\Core\Utility\RootlineUtility->get()
 FluidTYPO3\Flux\Provider\PageProvider->loadRecordTreeFromDatabase()
 FluidTYPO3\Flux\Provider\PageProvider->getInheritanceTree()
 FluidTYPO3\Flux\Provider\PageProvider->getInheritedConfiguration()
 FluidTYPO3\Flux\Provider\PageProvider->setDefaultValuesInFieldsWithInheritedValues()
 FluidTYPO3\Flux\Provider\PageProvider->getForm()
 FluidTYPO3\Flux\Integration\HookSubscribers\DynamicFlexForm->parseDataStructureByIdentifierPreProcess()
 TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools->parseDataStructureByIdentifier()
 TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools->traverseFlexFormXMLData()
 TYPO3\CMS\Core\Database\ReferenceIndex->getRelations()