### PR TITLE
#1964 Fix deprecation messages in PHP8.1

### DIFF
--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -417,6 +417,9 @@ abstract class AbstractFluxController extends ActionController
                 $extensionName,
                 $controllerName
             );
+        if ($potentialControllerClassName === null) {
+            return false;
+        }
         $isForeign = $extensionName !== $this->extensionName;
         $isValidController = class_exists($potentialControllerClassName);
         return (true === $isForeign && true === $isValidController && method_exists($potentialControllerClassName, $actionName . 'Action'));


### PR DESCRIPTION
Fix deprecation messages by checking for null values before passing p…arameter as non-nullable internal function parameters which is deprecated in >= PHP8.1.

Fixes issue #1964 