### PR TITLE
[BUGFIX] Ensure correct extension configuration is returned in PHP8+

### DIFF
--- a/Classes/Utility/ExtensionConfigurationUtility.php
+++ b/Classes/Utility/ExtensionConfigurationUtility.php
@@ -52,6 +52,7 @@ class ExtensionConfigurationUtility
 
     public static function getOption(string $optionName)
     {
-        return ($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'] ?? $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'])['flux']['setup'][$optionName] ?? static::$defaults[$optionName] ?? null;
+        return $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'][$optionName] ??
+            $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['flux'][$optionName] ?? static::$defaults[$optionName] ?? null;
     }
 }

--- a/Classes/Utility/ExtensionConfigurationUtility.php
+++ b/Classes/Utility/ExtensionConfigurationUtility.php
@@ -52,7 +52,9 @@ class ExtensionConfigurationUtility
 
     public static function getOption(string $optionName)
     {
-        return $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'][$optionName] ??
-            $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['flux'][$optionName] ?? static::$defaults[$optionName] ?? null;
+        return $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'][$optionName]
+            ?? $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['flux'][$optionName]
+            ?? static::$defaults[$optionName]
+            ?? null;
     }
 }


### PR DESCRIPTION
When using ext:flux with PHP 8+, always the default extension configuration is returned. Also, the `['flux']['setup']`
extension configuration array key is not available when extension settings are processed in $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['flux']

Refs #1977