### PR TITLE
WIP: [BUGFIX] Make "clear value" wizard work in TYPO3 v8+

### DIFF
--- a/Classes/Form/AbstractFormField.php
+++ b/Classes/Form/AbstractFormField.php
@@ -225,13 +225,9 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
         }
         $wizards = $this->buildChildren($this->wizards);
         if (true === $this->getClearable()) {
-            array_push($wizards, [
-                'type' => 'userFunc',
-                'userFunc' => UserFunctions::class . '->renderClearValueWizardField',
-                'params' => [
-                    'itemName' => $this->getName(),
-                ],
-            ]);
+            $fieldStructureArray['config']['fieldWizard']['fluxClearValue'] = [
+                'renderType' => 'fluxClearValue',
+            ];
         }
         if (!empty($wizards)) {
             $fieldStructureArray['config']['wizards'] = $wizards;

--- a/Classes/Integration/FormEngine/ClearValueWizard.php
+++ b/Classes/Integration/FormEngine/ClearValueWizard.php
@@ -1,0 +1,35 @@
+<?php
+namespace FluidTYPO3\Flux\Integration\FormEngine;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Backend\Form\AbstractNode;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+/**
+ * TCA field wizard to remove empty values
+ */
+class ClearValueWizard extends AbstractNode
+{
+    public function render(): array
+    {
+        $result = $this->initializeResultArray();
+
+        $fieldName = 'data' . $this->data['elementBaseName'];
+        $nameSegments = explode('][', $fieldName);
+        $nameSegments[count($nameSegments) - 2] .= '_clear';
+        $fieldName = implode('][', $nameSegments);
+
+        $result['html'] = '<label style="opacity: 0.65;">'
+            . '<input type="checkbox" name="' . $fieldName . '" value="1" /> '
+            . LocalizationUtility::translate('flux.clearValue', 'Flux')
+            . '</label>';
+
+        return $result;
+    }
+}

--- a/Classes/Integration/FormEngine/UserFunctions.php
+++ b/Classes/Integration/FormEngine/UserFunctions.php
@@ -19,22 +19,6 @@ use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 class UserFunctions
 {
     /**
-     * @param array $parameters
-     * @param object $pObj Not used
-     * @return string
-     */
-    public function renderClearValueWizardField(&$parameters, &$pObj)
-    {
-        unset($pObj);
-        $nameSegments = explode('][', $parameters['itemName']);
-        $nameSegments[6] .= '_clear';
-        $fieldName = implode('][', $nameSegments);
-        $html = '<label style="opacity: 0.65; padding-left: 2em"><input type="checkbox" name="' . $fieldName .
-            '_clear"  value="1" /> ' . LocalizationUtility::translate('flux.clearValue', 'Flux') . '</label>';
-        return $html;
-    }
-
-    /**
      * User function for TCA fields to hide a Flux-enabled "flex" type field if
      * there are no fields in the DS.
      *

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -61,6 +61,11 @@ $conf = isset($_EXTCONF) ? $_EXTCONF : null;
             'priority' => 40,
             'class' => \FluidTYPO3\Flux\Integration\FormEngine\HtmlOutputNode::class,
         ];
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1661337814] = [
+            'nodeName' => 'fluxClearValue',
+            'priority' => 40,
+            'class' => \FluidTYPO3\Flux\Integration\FormEngine\ClearValueWizard::class,
+        ];
 
         // Small override for record-localize controller to manipulate the record listing to provide child records in list
         if (!class_exists(\TYPO3\CMS\Backend\Controller\Event\AfterPageColumnsSelectedForLocalizationEvent::class)) {


### PR DESCRIPTION
The "clear value" field wizard that can be enabled with the "clear="1" attribute
on "<flux:field.*>" elements is broken in TYPO3 v8 and later, because
the registration of field wizards changed:
https://docs.typo3.org/c/typo3/cms-core/8.7/en-us/Changelog/8.6/Deprecation-79440-TcaChanges.html

We register a "field wizard" that renders a checkbox that allows removing
the value instead of simply writing an empty string into flexform.

WHAT DOES NOT WORK YET:
Actually removing the field from flexform, because
AbstractProvider::postProcessRecord does not get called anymore since
commit e9127768d7b64681becbf1fb7b3774cf21bb52f3
("[FEATURE] Use colPos instead of tx_flux_column")

Resolves: https://github.com/FluidTYPO3/flux/issues/1894

:warning:  I have no idea how AbstractProvider::postProcessRecord shall be merged into TceMain.php, so I'm leaving this PR as "Work in progress" open for others to continue.
