### PR TITLE
[BUGFIX] First argument to is_callable() in pages.php, since php8 has…

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -59,11 +59,13 @@ defined('TYPO3_MODE') or die('Access denied.');
         ],
     ]);
 
-    if (is_callable([\FluidTYPO3\Flux\Integration\FormEngine\UserFunctions::class, 'fluxFormFieldDisplayCondition'])) {
+    $userFunctionsClass = new \FluidTYPO3\Flux\Integration\FormEngine\UserFunctions();
+    if (is_callable([$userFunctionsClass , 'fluxFormFieldDisplayCondition'])) {
+
         // Flux version is recent enough to support the custom displayCond from Flux that hides the entire "flex" field
         // if there are no fields in the DS it uses.
-        $GLOBALS['TCA']['pages']['columns']['tx_fed_page_flexform']['displayCond'] = 'USER:' . \FluidTYPO3\Flux\Integration\FormEngine\UserFunctions::class . '->fluxFormFieldDisplayCondition:pages:tx_fed_page_flexform';
-        $GLOBALS['TCA']['pages']['columns']['tx_fed_page_flexform_sub']['displayCond'] = 'USER:' . \FluidTYPO3\Flux\Integration\FormEngine\UserFunctions::class . '->fluxFormFieldDisplayCondition:pages:tx_fed_page_flexform_sub';
+        $GLOBALS['TCA']['pages']['columns']['tx_fed_page_flexform']['displayCond'] = 'USER:' . $userFunctionsClass::class . '->fluxFormFieldDisplayCondition:pages:tx_fed_page_flexform';
+        $GLOBALS['TCA']['pages']['columns']['tx_fed_page_flexform_sub']['displayCond'] = 'USER:' . $userFunctionsClass::class . '->fluxFormFieldDisplayCondition:pages:tx_fed_page_flexform_sub';
     }
 
     $doktypes = '0,1,4';

--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -37,10 +37,11 @@ defined('TYPO3_MODE') or die('Access denied.');
         '--div--;LLL:EXT:flux/Resources/Private/Language/locallang.xlf:pages.tx_fed_page_configuration,tx_fed_page_flexform,tx_fed_page_flexform_sub'
     );
 
-    if (is_callable([\FluidTYPO3\Flux\Integration\FormEngine\UserFunctions::class, 'fluxFormFieldDisplayCondition'])) {
+    $userFunctionsClass = new \FluidTYPO3\Flux\Integration\FormEngine\UserFunctions();
+    if (is_callable([$userFunctionsClass, 'fluxFormFieldDisplayCondition'])) {
         // Flux version is recent enough to support the custom displayCond from Flux that hides the entire "flex" field
         // if there are no fields in the DS it uses.
-        $GLOBALS['TCA']['pages_language_overlay']['columns']['tx_fed_page_flexform']['displayCond'] = 'USER:' . \FluidTYPO3\Flux\Integration\FormEngine\UserFunctions::class . '->fluxFormFieldDisplayCondition:pages_language_overlay:tx_fed_page_flexform';
-        $GLOBALS['TCA']['pages_language_overlay']['columns']['tx_fed_page_flexform_sub']['displayCond'] = 'USER:' . \FluidTYPO3\Flux\Integration\FormEngine\UserFunctions::class . '->fluxFormFieldDisplayCondition:pages_language_overlay:tx_fed_page_flexform_sub';
+        $GLOBALS['TCA']['pages_language_overlay']['columns']['tx_fed_page_flexform']['displayCond'] = 'USER:' . $userFunctionsClass . '->fluxFormFieldDisplayCondition:pages_language_overlay:tx_fed_page_flexform';
+        $GLOBALS['TCA']['pages_language_overlay']['columns']['tx_fed_page_flexform_sub']['displayCond'] = 'USER:' . $userFunctionsClass . '->fluxFormFieldDisplayCondition:pages_language_overlay:tx_fed_page_flexform_sub';
     }
 })();

--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -41,7 +41,7 @@ defined('TYPO3_MODE') or die('Access denied.');
     if (is_callable([$userFunctionsClass, 'fluxFormFieldDisplayCondition'])) {
         // Flux version is recent enough to support the custom displayCond from Flux that hides the entire "flex" field
         // if there are no fields in the DS it uses.
-        $GLOBALS['TCA']['pages_language_overlay']['columns']['tx_fed_page_flexform']['displayCond'] = 'USER:' . $userFunctionsClass . '->fluxFormFieldDisplayCondition:pages_language_overlay:tx_fed_page_flexform';
-        $GLOBALS['TCA']['pages_language_overlay']['columns']['tx_fed_page_flexform_sub']['displayCond'] = 'USER:' . $userFunctionsClass . '->fluxFormFieldDisplayCondition:pages_language_overlay:tx_fed_page_flexform_sub';
+        $GLOBALS['TCA']['pages_language_overlay']['columns']['tx_fed_page_flexform']['displayCond'] = 'USER:' . $userFunctionsClass::class . '->fluxFormFieldDisplayCondition:pages_language_overlay:tx_fed_page_flexform';
+        $GLOBALS['TCA']['pages_language_overlay']['columns']['tx_fed_page_flexform_sub']['displayCond'] = 'USER:' . $userFunctionsClass::class . '->fluxFormFieldDisplayCondition:pages_language_overlay:tx_fed_page_flexform_sub';
     }
 })();


### PR DESCRIPTION
… to be a class object instead of the classname

[BUGFIX] Change 1st Parameter for is_callable() in pages.php

Otherwise causes php warnings when editing page properties with php ^8.