### PR TITLE
[BUGFIX] Add several sanity checks to avoid php warnings

### DIFF
--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -202,7 +202,10 @@ class PageProvider extends AbstractProvider implements ProviderInterface
         if (!empty($row[self::FIELD_ACTION_MAIN])) {
             return is_array($row[self::FIELD_ACTION_MAIN]) ? $row[self::FIELD_ACTION_MAIN][0] : $row[self::FIELD_ACTION_MAIN];
         }
-        return ($this->pageService->getPageTemplateConfiguration($row['uid'])[self::FIELD_ACTION_SUB] ?? 'flux->default') ?: 'flux->default';
+        if (isset($row['uid'])) {
+            return ($this->pageService->getPageTemplateConfiguration($row['uid'])[self::FIELD_ACTION_SUB] ?? 'flux->default') ?: 'flux->default';
+        }
+        return 'flux->default';
     }
 
     /**
@@ -329,7 +332,8 @@ class PageProvider extends AbstractProvider implements ProviderInterface
     {
         $tableName = $this->getTableName($row);
         $tableFieldName = $this->getFieldName($row);
-        $cacheKey = $tableName . $tableFieldName . $row['uid'];
+        $uid = $row['uid'] ?? '';
+        $cacheKey = $tableName . $tableFieldName . $uid;
         if (false === isset(self::$cache[$cacheKey])) {
             $tree = $this->getInheritanceTree($row);
             $data = [];
@@ -414,7 +418,7 @@ class PageProvider extends AbstractProvider implements ProviderInterface
             return [];
         }
         /** @var RootlineUtility $rootLineUtility */
-        $rootLineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $record['uid']);
+        $rootLineUtility = GeneralUtility::makeInstance(RootlineUtility::class, $record['uid'] ?? null);
         return array_slice($rootLineUtility->get(), 1);
     }
 }

--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -223,7 +223,7 @@ class GetViewHelper extends AbstractViewHelper
                 'orderBy' => $arguments['order'] . ' ' . $arguments['sortDirection'],
                 'where' => $conditions,
                 'pidInList' => $parent['pid'],
-                'includeRecordsWithoutDefaultTranslation' => !$arguments['hideUntranslated']
+                'includeRecordsWithoutDefaultTranslation' => !($arguments['hideUntranslated'] ?? false)
             ]
         );
 

--- a/Tests/Unit/Provider/SubPageProviderTest.php
+++ b/Tests/Unit/Provider/SubPageProviderTest.php
@@ -43,8 +43,8 @@ class SubPageProviderTest extends AbstractTestCase
     public function getControllerActionFromRecordTestValues()
     {
         return array(
-            array(array('tx_fed_page_controller_action_sub' => ''), 'tx_fed_page_flexform_sub', 'default'),
-            array(array('tx_fed_page_controller_action_sub' => 'flux->action'), 'tx_fed_page_flexform_sub', 'action'),
+            array(array('uid' => 123, 'tx_fed_page_controller_action_sub' => ''), 'tx_fed_page_flexform_sub', 'default'),
+            array(array('uid' => 123, 'tx_fed_page_controller_action_sub' => 'flux->action'), 'tx_fed_page_flexform_sub', 'action'),
         );
     }
 
@@ -59,6 +59,7 @@ class SubPageProviderTest extends AbstractTestCase
         $instance->setTemplatePaths(array('templateRootPaths' => array('EXT:flux/Tests/Fixtures/Templates/')));
         $instance->injectPageService($service);
         $record = array(
+            'uid' => 123,
             $fieldName => 'Flux->dummy',
         );
         $service->expects($this->any())->method('getPageTemplateConfiguration')->willReturn($record);


### PR DESCRIPTION
Massive php warning spam,  suppressed by simple sanity checks.