### PR TITLE
Fix BUG calculateColumnNumberForParentAndColumn float instead of int returned

### DIFF
--- a/Classes/Utility/ColumnNumberUtility.php
+++ b/Classes/Utility/ColumnNumberUtility.php
@@ -45,7 +45,7 @@ abstract class ColumnNumberUtility
 
     public static function calculateColumnNumberForParentAndColumn($parentUid, $columnNumber): int
     {
-        return ($parentUid * static::MULTIPLIER) + $columnNumber;
+        return (int) floor(($parentUid * static::MULTIPLIER) + $columnNumber);
     }
 
     public static function calculateParentUidAndColumnFromVirtualColumnNumber($virtualColumnNumber): array


### PR DESCRIPTION
Fix BUG 
Return value of FluidTYPO3\Flux\Utility\ColumnNumberUtility::calculateColumnNumberForParentAndColumn() must be of the type int, float returned