### PR TITLE
PHP 8.0.8 Typo3 11.5.16

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+include:
+  - project: devops/gitlab-ci
+    ref: release/1.1.0
+    file: /templates/composer.gitlab-ci.yaml
+

--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -24,7 +24,7 @@ use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;
 use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
-use TYPO3\CMS\Extbase\Mvc\Response;
+use TYPO3\CMS\Extbase\Mvc\response;
 use TYPO3\CMS\Fluid\View\TemplatePaths;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use function get_class;
@@ -341,6 +341,13 @@ abstract class AbstractFluxController extends ActionController
      */
     protected function performSubRendering($extensionName, $controllerName, $actionName, $pluginSignature)
     {
+    
+    	if (isset($this->responseFactory)) {
+            $response = $this->responseFactory->createResponse();
+        } else {
+            $response = $this->objectManager->get(Response::class);
+        }
+    
         $shouldRelay = $this->hasSubControllerActionOnForeignController($extensionName, $controllerName, $actionName);
         if (!$shouldRelay) {
             if ($this->provider instanceof FluidProviderInterface) {
@@ -384,7 +391,7 @@ abstract class AbstractFluxController extends ActionController
                 'view' => $this->view,
                 'content' => $content,
                 'request' => $this->request,
-                'response' => $this->response,
+                'response' => $response,
                 'extensionName' => $extensionName,
                 'controllerClassName' => $foreignControllerClass,
                 'controllerActionName' => $actionName
@@ -448,7 +455,7 @@ abstract class AbstractFluxController extends ActionController
                 HookHandler::CONTROLLER_BEFORE_REQUEST,
                 [
                     'request' => $this->request,
-                    'response' => $this->response,
+                    'response' => $response,
                     'extensionName' => $extensionName,
                     'controllerClassName' => $controllerClassName,
                     'controllerActionName' => $controllerActionName

--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -30,7 +30,7 @@ class DataHandlerSubscriber
 
     public function clearCacheCommand($command)
     {
-        if ($command['cacheCmd'] === 'all' || $command['cacheCmd'] === 'system') {
+        if (isset($command['cacheCmd']) && ($command['cacheCmd'] === 'all' || $command['cacheCmd'] === 'system')) {
             GeneralUtility::makeInstance(ContentTypeManager::class)->regenerate();
         }
     }
@@ -132,11 +132,16 @@ class DataHandlerSubscriber
 
                 if ($primaryConfigurationProvider && is_array($fieldArray[$fieldName]) && array_key_exists('data', $fieldArray[$fieldName])) {
                     foreach ($fieldArray[$fieldName]['data'] as $sheet) {
-                        foreach ($sheet['lDEF'] as $key => $value) {
-                            list ($possibleTableName, $columnName) = explode('.', $key, 2);
-                            if ($possibleTableName === $table && isset($GLOBALS['TCA'][$table]['columns'][$columnName])) {
-                                $fieldArray[$columnName] = $value['vDEF'];
-                            }
+                        foreach ($sheet['lDEF'] as $key => $value) 
+                        {
+                        	$expArr = explode('.', $key, 2);
+                        	if ( count( $expArr ) > 1 )
+                        	{
+                        		list ($possibleTableName, $columnName) = explode('.', $key, 2);
+								if ($possibleTableName === $table && isset($GLOBALS['TCA'][$table]['columns'][$columnName])) {
+									$fieldArray[$columnName] = $value['vDEF'];
+								}
+                        	}                          
                         }
                     }
                 }

--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -124,7 +124,7 @@ class DataHandlerSubscriber
         // field. Updated value will still be subject to permission checks.
         $resolver = GeneralUtility::makeInstance(ObjectManager::class)->get(ProviderResolver::class);
         foreach ($fieldArray as $fieldName => $fieldValue) {
-            if ($GLOBALS["TCA"][$table]["columns"][$fieldName]["config"]["type"] === 'flex') {
+            if (isset($GLOBALS["TCA"][$table]["columns"][$fieldName]["config"]["type"]) && $GLOBALS["TCA"][$table]["columns"][$fieldName]["config"]["type"] === 'flex') {
                 $primaryConfigurationProvider = $resolver->resolvePrimaryConfigurationProvider(
                     $table,
                     $fieldName

--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -364,6 +364,7 @@ class DataHandlerSubscriber
     protected function getSingleRecordWithRestrictions(string $table, int $uid, string $fieldsToSelect): ?array
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+	$queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
         $queryBuilder->select(...GeneralUtility::trimExplode(',', $fieldsToSelect))
             ->from($table)
             ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, \PDO::PARAM_INT)));

--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -137,8 +137,9 @@ class DataHandlerSubscriber
                         	$expArr = explode('.', $key, 2);
                         	if ( count( $expArr ) > 1 )
                         	{
-                        		list ($possibleTableName, $columnName) = explode('.', $key, 2);
-								if ($possibleTableName === $table && isset($GLOBALS['TCA'][$table]['columns'][$columnName])) {
+                        		list ($possibleTableName, $columnName) = $expArr;
+								if ($possibleTableName === $table && isset($GLOBALS['TCA'][$table]['columns'][$columnName]))
+                                {
 									$fieldArray[$columnName] = $value['vDEF'];
 								}
                         	}                          

--- a/Classes/Integration/PreviewView.php
+++ b/Classes/Integration/PreviewView.php
@@ -353,14 +353,25 @@ class PreviewView extends TemplateView
                 // TYPO3 10.4+
                 $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
                 $site = $siteFinder->getSiteByPageId($pageId);
-                $language = $site->getLanguageById((int) $row['sys_language_uid']);
-
+                $language = null;
+                if ($row['sys_language_uid'] >= 0 )
+                {
+                	$language = $site->getLanguageById((int) $row['sys_language_uid']);
+                }
+                
                 $context = GeneralUtility::makeInstance(PageLayoutContext::class, BackendUtility::getRecord('pages', $pageId), $backendLayout);
-                $context = $context->cloneForLanguage($language);
+                if (isset($language))
+                {
+                	 $context = $context->cloneForLanguage($language);
+                }
 
                 $configuration = $context->getDrawingConfiguration();
                 $configuration->setActiveColumns($backendLayout->getColumnPositionNumbers());
-                $configuration->setSelectedLanguageId($language->getLanguageId());
+                
+                if (isset($language))
+                {
+                	$configuration->setSelectedLanguageId($language->getLanguageId());
+                }
 
                 return GeneralUtility::makeInstance(BackendLayoutRenderer::class, $context);
             } else {

--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -16,6 +16,7 @@ use FluidTYPO3\Flux\Service\WorkspacesAwareRecordService;
 use FluidTYPO3\Flux\Utility\ColumnNumberUtility;
 use FluidTYPO3\Flux\ViewHelpers\FormViewHelper;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -99,6 +100,7 @@ class GetViewHelper extends AbstractViewHelper
         );
         $this->registerArgument('loadRegister', 'array', 'List of LOAD_REGISTER variable');
         $this->registerArgument('render', 'boolean', 'Optional returning variable as original table rows', false, true);
+        $this->registerArgument('hideUntranslated', 'boolean', 'Exclude untranslated records', false, false);
     }
 
     /**
@@ -127,7 +129,7 @@ class GetViewHelper extends AbstractViewHelper
         }
         $templateVariableContainer = $renderingContext->getVariableProvider();
         $record = (array) $renderingContext->getViewHelperVariableContainer()->get(FormViewHelper::class, 'record');
-
+        
         if ($GLOBALS['BE_USER']->workspace) {
             $placeholder = BackendUtility::getMovePlaceholder('tt_content', $record['uid']);
             if ($placeholder) {

--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -130,8 +130,9 @@ class GetViewHelper extends AbstractViewHelper
         $templateVariableContainer = $renderingContext->getVariableProvider();
         $record = (array) $renderingContext->getViewHelperVariableContainer()->get(FormViewHelper::class, 'record');
         
-        if ($GLOBALS['BE_USER']->workspace) {
-            $placeholder = BackendUtility::getMovePlaceholder('tt_content', $record['uid']);
+        $workspaceId = GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('workspace', 'id');
+        if ($workspaceId) {
+            $placeholder = BackendUtility::getWorkspaceVersionOfRecord($workspaceId,'tt_content', $record['uid']);
             if ($placeholder) {
                 // Use the move placeholder if one exists, ensuring that "pid" and "tx_flux_parent" values are taken
                 // from the workspace-only placeholder.


### PR DESCRIPTION
Hi,
here are some enhancements for using PHP 8 and Typo3 11.5 to prevent output fatal errors in frontend and backend. i hope it's helps to make the extension "flux" more stablity.

Best regards
DavidK