### PR TITLE
BUGFIX: In PageService getTemplateConfiguration.

### DIFF
--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -129,7 +129,7 @@ class PageService implements SingletonInterface
                 : $page['tx_fed_page_controller_action_sub'] ?? null;
             $containsSubDefinition = (false !== strpos($page['tx_fed_page_controller_action_sub'] ?? '', '->'));
             $isCandidate = ((integer) ($page['uid'] ?? 0) !== $pageUid);
-            if (true === $containsSubDefinition && true === $isCandidate) {
+            if (true === $containsSubDefinition || true === $isCandidate) {
                 $resolvedSubTemplateIdentity = $page['tx_fed_page_controller_action_sub'] ?? null;
                 if (true === empty($resolvedMainTemplateIdentity)) {
                     // Conditions met: current page is not $pageUid, original page did not


### PR DESCRIPTION
Although the PageLayout setting of the page is set, it is ignored. Instead, the layout of the parent page is used. This is not correct. I think the OR operator must be used here.
Tested it and it works.