### PR TITLE
[DOC] Correct flux:field.inline.fal image.uid usage in f:image

### DIFF
--- a/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
+++ b/Classes/ViewHelpers/Field/Inline/FalViewHelper.php
@@ -71,19 +71,19 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  *
  *     <f:section name="Main">
  *       <f:for each="{v:content.resources.fal(field: 'settings.slides')}" as="image" iteration="iterator">
- *         <f:image src="{image.id}" height="300" class="leb-pic" crop="{image.crop}" cropVariant="default"/>
+ *         <f:image src="{image.uid}" height="300" class="leb-pic" crop="{image.crop}" cropVariant="default"/>
  *       </f:for>
  *     </f:section>
  *
  * #### Rendering the image
  *
  *     {v:content.resources.fal(field: 'settings.image') -> v:iterator.first() -> v:variable.set(name: 'image')}
- *     <f:image treatIdAsReference="1" src="{image.id}" title="{image.title}" alt="{image.alternative}"/><br/>
+ *     <f:image treatIdAsReference="1" src="{image.uid}" title="{image.title}" alt="{image.alternative}"/><br/>
  *
  * #### Rendering multiple images
  *
  *     <f:for each="{v:content.resources.fal(field: 'settings.image')}" as="image">
- *         <f:image treatIdAsReference="1" src="{image.id}" title="{image.title}" alt="{image.alternative}"/><br/>
+ *         <f:image treatIdAsReference="1" src="{image.uid}" title="{image.title}" alt="{image.alternative}"/><br/>
  *     </f:for>
  */
 class FalViewHelper extends AbstractInlineFieldViewHelper


### PR DESCRIPTION
in phpdoc it is written that how to render image with f:image but it will not crop the image if image.id will be supplied to src attribute. with image.uid it will crop the image. updated the phpdoc