### PR TITLE
[BUGFIX] Load entire record in BackendLayoutDataProvider->getBackendlayout

### DIFF
--- a/Classes/Backend/BackendLayoutDataProvider.php
+++ b/Classes/Backend/BackendLayoutDataProvider.php
@@ -113,7 +113,7 @@ class BackendLayoutDataProvider extends DefaultDataProvider implements DataProvi
     public function getBackendLayout($identifier, $pageUid)
     {
         $emptyLayout = $this->createBackendLayoutInstance($identifier, 'Empty', '');
-        $record = $this->recordService->getSingle('pages', 'uid', $pageUid);
+        $record = $this->recordService->getSingle('pages', '*', $pageUid);
         if (null === $record) {
             return $emptyLayout;
         }


### PR DESCRIPTION
only the uid of the page is read. But here all fields must be read, because later in PageProvider->getControllerActionReferenceFromRecord is checked whether the main template of the page is set. And this is then never set! Then the layout from the settings of the parent page is used by mistake.