### PR TITLE
Re-added version check for Typo3

### DIFF
--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -472,7 +472,12 @@ abstract class AbstractFluxController extends ActionController
             );
 
             /** @var Response $response */
-            $response = $potentialControllerInstance->processRequest($this->request, $response);
+            if (version_compare($version, 11, '<')) {
+                $potentialControllerInstance->processRequest($this->request, $response);
+            } else {
+                /** @var Response $response */
+                $response = $potentialControllerInstance->processRequest($this->request, $response);
+            }
         } catch (StopActionException $error) {
             // intentionally left blank
         }


### PR DESCRIPTION
On Typo3 v10 an error (Call to a member function getBody()) occurs on sub action controllers. 
Also reported here: https://github.com/FluidTYPO3/flux/issues/2034