### PR TITLE
Fix/2053 : fix error when trying to process item field

### DIFF
--- a/Classes/Backend/PageLayoutDataProvider.php
+++ b/Classes/Backend/PageLayoutDataProvider.php
@@ -204,6 +204,7 @@ class PageLayoutDataProvider
             $groupTitle = ucfirst($extensionKey);
         } else {
             $emConfigFile = ExtensionManagementUtility::extPath($extensionKey, 'ext_emconf.php');
+            $_EXTKEY = $extensionKey;
             require $emConfigFile;
             $groupTitle = reset($EM_CONF)['title'];
         }

--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -399,6 +399,7 @@ class PageProvider extends AbstractProvider implements ProviderInterface
         $name = $field->getName();
         $inherit = (boolean) $field->getInherit();
         $inheritEmpty = (boolean) $field->getInheritEmpty();
+        $values[$name] = ($values[$name] ?? 0);
         $empty = (true === empty($values[$name]) && $values[$name] !== '0' && $values[$name] !== 0);
         if (false === $inherit || (true === $inheritEmpty && true === $empty)) {
             unset($values[$name]);


### PR DESCRIPTION
With TYPO3 V11, the variable `$_EXTKEY` is not always set, have to set it manually before including **ext_emconf.php** file.