### PR TITLE
[BUGFIX] Tolerate record without pid

### DIFF
--- a/Classes/Form/Field/Text.php
+++ b/Classes/Form/Field/Text.php
@@ -131,7 +131,9 @@ class Text extends Input implements FieldInterface
             /** @var array|null $record */
             $record = $root->getOption('record');
             if ($record !== null) {
-                $pageUid = (integer) $record['pid'];
+                if (isset($record['pid'])) {
+                    $pageUid = (integer) $record['pid'] ?? 0;
+                }
             }
         }
 

--- a/Classes/Form/Field/Text.php
+++ b/Classes/Form/Field/Text.php
@@ -131,9 +131,7 @@ class Text extends Input implements FieldInterface
             /** @var array|null $record */
             $record = $root->getOption('record');
             if ($record !== null) {
-                if (isset($record['pid'])) {
-                    $pageUid = (integer) $record['pid'] ?? 0;
-                }
+                $pageUid = (integer) ($record['pid'] ?? 0);
             }
         }
 


### PR DESCRIPTION
This fix the bug which leads to an BE error for newly placed content elements with a flud:field.text and enabled rte. New placed content elements which are not saved doesn't have a pid in the record.

Related to issue [2078](https://github.com/FluidTYPO3/flux/issues/2078)