### PR TITLE
[BUGFIX] Cast "id" Form attribute to string

### DIFF
--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -84,8 +84,10 @@ class FormViewHelper extends AbstractFormViewHelper
         $extensionName = static::getExtensionNameFromRenderingContextOrArguments($renderingContext, $arguments);
         $form = static::getComponent($renderingContext, $arguments);
         // configure Form instance
+        /** @var string|int $formId */
+        $formId = $arguments['id'] ?? 'form';
         /** @var string $formId */
-        $formId = (string) ($arguments['id'] ?? 'form');
+        $formId = (string) $formId;
         /** @var string|null $formLabel */
         $formLabel = $arguments['label'];
         /** @var string|null $formDescription */

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -85,7 +85,7 @@ class FormViewHelper extends AbstractFormViewHelper
         $form = static::getComponent($renderingContext, $arguments);
         // configure Form instance
         /** @var string $formId */
-        $formId = (string)$arguments['id'] ?? 'form';
+        $formId = (string) ($arguments['id'] ?? 'form');
         /** @var string|null $formLabel */
         $formLabel = $arguments['label'];
         /** @var string|null $formDescription */

--- a/Classes/ViewHelpers/FormViewHelper.php
+++ b/Classes/ViewHelpers/FormViewHelper.php
@@ -85,7 +85,7 @@ class FormViewHelper extends AbstractFormViewHelper
         $form = static::getComponent($renderingContext, $arguments);
         // configure Form instance
         /** @var string $formId */
-        $formId = $arguments['id'] ?? 'form';
+        $formId = (string)$arguments['id'] ?? 'form';
         /** @var string|null $formLabel */
         $formLabel = $arguments['label'];
         /** @var string|null $formDescription */


### PR DESCRIPTION
If $arguments['id'] is an integer an error gets thrown. This way the integer gets casted to a string and doesn't break the processing.