### PR TITLE
[BUGFIX] Allow ItemProcessingService as param in execute function of …

### DIFF
--- a/Classes/Integration/MultipleItemsProcFunc.php
+++ b/Classes/Integration/MultipleItemsProcFunc.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Flux\Integration;
 
 use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\DataHandling\ItemProcessingService;
 
 class MultipleItemsProcFunc
 {
@@ -32,7 +33,7 @@ class MultipleItemsProcFunc
         $GLOBALS['TCA'][$table]['columns'][$field]['config']['itemsProcFunc'] = $newFunction;
     }
 
-    public function execute(array &$parameters, FormDataProviderInterface $formDataProvider): void
+    public function execute(array &$parameters, ItemProcessingService | FormDataProviderInterface $formDataProvider): void
     {
         $table = $parameters['table'];
         $field = $parameters['field'];

--- a/Classes/Integration/MultipleItemsProcFunc.php
+++ b/Classes/Integration/MultipleItemsProcFunc.php
@@ -34,9 +34,7 @@ class MultipleItemsProcFunc
     }
 
     /**
-     * @param array $parameters
      * @param ItemProcessingService|FormDataProviderInterface $formDataProvider
-     * @return void
      */
     public function execute(array &$parameters, $formDataProvider): void
     {

--- a/Classes/Integration/MultipleItemsProcFunc.php
+++ b/Classes/Integration/MultipleItemsProcFunc.php
@@ -33,7 +33,12 @@ class MultipleItemsProcFunc
         $GLOBALS['TCA'][$table]['columns'][$field]['config']['itemsProcFunc'] = $newFunction;
     }
 
-    public function execute(array &$parameters, ItemProcessingService | FormDataProviderInterface $formDataProvider): void
+    /**
+     * @param array $parameters
+     * @param ItemProcessingService|FormDataProviderInterface $formDataProvider
+     * @return void
+     */
+    public function execute(array &$parameters, $formDataProvider): void
     {
         $table = $parameters['table'];
         $field = $parameters['field'];

--- a/Tests/Unit/Integration/MultipleItemsProcFuncTest.php
+++ b/Tests/Unit/Integration/MultipleItemsProcFuncTest.php
@@ -30,18 +30,28 @@ class MultipleItemsProcFuncTest extends AbstractTestCase
         );
     }
 
-    public function testExecutesFunction(): void
+    public function testExecutesFunctionWithFormDataProvider(): void
     {
+        static::$executed = false;
         $formDataProviderInterface = $this->getMockBuilder(FormDataProviderInterface::class)->getMockForAbstractClass();
         MultipleItemsProcFunc::register('table', 'field', static::class . '->dummyFunction');
         $parameters = ['table' => 'table', 'field' => 'field'];
         (new MultipleItemsProcFunc())->execute($parameters, $formDataProviderInterface);
 
-        if (class_exists('ItemProcessingService')) {
-            $itemProcessingServiceProvider = $this->getMockBuilder(ItemProcessingService::class)->getMockForAbstractClass();
-            (new MultipleItemsProcFunc())->execute($parameters, $itemProcessingServiceProvider);
-        }
+        self::assertTrue(static::$executed);
+    }
 
+    public function testExecutesFunctionWithItemProcessingService(): void
+    {
+        static::$executed = false;
+        if (!class_exists(ItemProcessingService::class)) {
+            $this->markTestSkipped('Skippped, class ' . ItemProcessingService::class . ' does not exist');
+        }
+        MultipleItemsProcFunc::register('table', 'field', static::class . '->dummyFunction');
+        $parameters = ['table' => 'table', 'field' => 'field'];
+        $itemProcessingServiceProvider = $this->getMockBuilder(ItemProcessingService::class)->getMockForAbstractClass();
+        (new MultipleItemsProcFunc())->execute($parameters, $itemProcessingServiceProvider
+                                               
         self::assertTrue(static::$executed);
     }
 

--- a/Tests/Unit/Integration/MultipleItemsProcFuncTest.php
+++ b/Tests/Unit/Integration/MultipleItemsProcFuncTest.php
@@ -33,11 +33,15 @@ class MultipleItemsProcFuncTest extends AbstractTestCase
     public function testExecutesFunction(): void
     {
         $formDataProviderInterface = $this->getMockBuilder(FormDataProviderInterface::class)->getMockForAbstractClass();
-        $itemProcessingServiceProvider = $this->getMockBuilder(ItemProcessingService::class)->getMockForAbstractClass();
         MultipleItemsProcFunc::register('table', 'field', static::class . '->dummyFunction');
         $parameters = ['table' => 'table', 'field' => 'field'];
         (new MultipleItemsProcFunc())->execute($parameters, $formDataProviderInterface);
-        (new MultipleItemsProcFunc())->execute($parameters, $itemProcessingServiceProvider);
+
+        if (class_exists('ItemProcessingService')) {
+            $itemProcessingServiceProvider = $this->getMockBuilder(ItemProcessingService::class)->getMockForAbstractClass();
+            (new MultipleItemsProcFunc())->execute($parameters, $itemProcessingServiceProvider);
+        }
+
         self::assertTrue(static::$executed);
     }
 

--- a/Tests/Unit/Integration/MultipleItemsProcFuncTest.php
+++ b/Tests/Unit/Integration/MultipleItemsProcFuncTest.php
@@ -50,7 +50,7 @@ class MultipleItemsProcFuncTest extends AbstractTestCase
         MultipleItemsProcFunc::register('table', 'field', static::class . '->dummyFunction');
         $parameters = ['table' => 'table', 'field' => 'field'];
         $itemProcessingServiceProvider = $this->getMockBuilder(ItemProcessingService::class)->getMockForAbstractClass();
-        (new MultipleItemsProcFunc())->execute($parameters, $itemProcessingServiceProvider
+        (new MultipleItemsProcFunc())->execute($parameters, $itemProcessingServiceProvider);
                                                
         self::assertTrue(static::$executed);
     }

--- a/Tests/Unit/Integration/MultipleItemsProcFuncTest.php
+++ b/Tests/Unit/Integration/MultipleItemsProcFuncTest.php
@@ -11,6 +11,7 @@ namespace FluidTYPO3\Flux\Tests\Unit\Integration;
 use FluidTYPO3\Flux\Integration\MultipleItemsProcFunc;
 use FluidTYPO3\Flux\Tests\Unit\AbstractTestCase;
 use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
+use TYPO3\CMS\Core\DataHandling\ItemProcessingService;
 
 class MultipleItemsProcFuncTest extends AbstractTestCase
 {
@@ -31,10 +32,12 @@ class MultipleItemsProcFuncTest extends AbstractTestCase
 
     public function testExecutesFunction(): void
     {
-        $provider = $this->getMockBuilder(FormDataProviderInterface::class)->getMockForAbstractClass();
+        $formDataProviderInterface = $this->getMockBuilder(FormDataProviderInterface::class)->getMockForAbstractClass();
+        $itemProcessingServiceProvider = $this->getMockBuilder(ItemProcessingService::class)->getMockForAbstractClass();
         MultipleItemsProcFunc::register('table', 'field', static::class . '->dummyFunction');
         $parameters = ['table' => 'table', 'field' => 'field'];
-        (new MultipleItemsProcFunc())->execute($parameters, $provider);
+        (new MultipleItemsProcFunc())->execute($parameters, $formDataProviderInterface);
+        (new MultipleItemsProcFunc())->execute($parameters, $itemProcessingServiceProvider);
         self::assertTrue(static::$executed);
     }
 


### PR DESCRIPTION
Resolves https://github.com/FluidTYPO3/flux/issues/2143 also see https://github.com/FluidTYPO3/flux/issues/2143#issuecomment-1855795050