### PR TITLE
[BUGFIX] Handle possible DBALException

### DIFF
--- a/Classes/Integration/Configuration/SpooledConfigurationApplicator.php
+++ b/Classes/Integration/Configuration/SpooledConfigurationApplicator.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Flux\Integration\Configuration;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use Doctrine\DBAL\DBALException;
 use FluidTYPO3\Flux\Builder\ContentTypeBuilder;
 use FluidTYPO3\Flux\Builder\RequestBuilder;
 use FluidTYPO3\Flux\Content\ContentTypeManager;
@@ -178,7 +179,7 @@ class SpooledConfigurationApplicator
 
             try {
                 $this->contentTypeBuilder->registerContentType($providerExtensionName, $contentType, $provider);
-            } catch (PageNotFoundException $error) {
+            } catch (PageNotFoundException|DBALException $error) {
                 // Suppressed: Flux bootstrap does not care if a page can be resolved or not.
             } catch (Exception $error) {
                 if (!$applicationContext->isProduction()) {

--- a/Classes/Integration/Configuration/SpooledConfigurationApplicator.php
+++ b/Classes/Integration/Configuration/SpooledConfigurationApplicator.php
@@ -8,7 +8,7 @@ namespace FluidTYPO3\Flux\Integration\Configuration;
  * LICENSE.md file that was distributed with this source code.
  */
 
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use FluidTYPO3\Flux\Builder\ContentTypeBuilder;
 use FluidTYPO3\Flux\Builder\RequestBuilder;
 use FluidTYPO3\Flux\Content\ContentTypeManager;
@@ -179,7 +179,7 @@ class SpooledConfigurationApplicator
 
             try {
                 $this->contentTypeBuilder->registerContentType($providerExtensionName, $contentType, $provider);
-            } catch (PageNotFoundException|DBALException $error) {
+            } catch (PageNotFoundException|TableNotFoundException $error) {
                 // Suppressed: Flux bootstrap does not care if a page can be resolved or not.
             } catch (Exception $error) {
                 if (!$applicationContext->isProduction()) {


### PR DESCRIPTION
We can ignore a missing database connection at this point. We cant do anything about a missing database connection. This Scenario is possible during first install.

In a Scenario, where flux is installed before first install, this happens:
1. Upon the last setup step, when finishing by sending the admin user credentials and some metadata, the BootCompletedEvent is fired which brings up the FluidTYPO3\Flux\Integration\Event\BootCompletedEventListener.
2. The `SpooledConfigurationApplicator` then in its `processData` calls `$this->spoolQueuedContentTypeRegistrations` in Line 71.
3. Then `$this->contentTypeBuilder->registerContentType` in Line 181 **requires a Database Connection** for registering the content types.
4. Because the **Database is not fully setup** yet, DBAL returns a TableNotFoundException, which is a subclass of the more generic DBALException.
5. This is nowhere caught and therefore we cant successfully end the first install process.

Tested in Typo3 11.5.36 with flux 10.0.9