### PR TITLE
[BUGFIX] Fix handling of drop-in templates

### DIFF
--- a/Classes/Builder/ContentTypeBuilder.php
+++ b/Classes/Builder/ContentTypeBuilder.php
@@ -234,6 +234,17 @@ class ContentTypeBuilder
             'CType',
             $providerExtensionName
         );
+
+        /** @var \Countable $fields */
+        $fields = $form->getFields();
+        if (count($fields) > 0) {
+            \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+                'tt_content',
+                'pi_flexform',
+                $provider->getContentObjectType(),
+                'after:header'
+            );
+        }
     }
 
     protected function addIcon(Form $form, string $contentType): string

--- a/Classes/Content/TypeDefinition/FluidFileBased/DropInContentTypeDefinition.php
+++ b/Classes/Content/TypeDefinition/FluidFileBased/DropInContentTypeDefinition.php
@@ -14,6 +14,7 @@ use FluidTYPO3\Flux\Provider\Provider;
 use FluidTYPO3\Flux\Utility\ExtensionConfigurationUtility;
 use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 use Symfony\Component\Finder\Finder;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -168,6 +169,9 @@ class DropInContentTypeDefinition extends FluidFileBasedContentTypeDefinition
         if (strpos($filename, '://') !== false) {
             return $filename;
         }
-        return realpath($filename) ?: $filename;
+        if (strpos($filename, '/') === 0) {
+            return $filename;
+        }
+        return Environment::getPublicPath() . '/' . $filename;
     }
 }


### PR DESCRIPTION
Fixes a combined issue where template file paths would be wrong in BE context and the pi_flexform field would not be shown in record editing, for templates placed in the plug-and-play / drop-in directory.