### PR TITLE
[FEATURE] Add inheritance mode control

### DIFF
--- a/Classes/Enum/ExtensionOption.php
+++ b/Classes/Enum/ExtensionOption.php
@@ -12,4 +12,5 @@ class ExtensionOption
     public const OPTION_PLUG_AND_PLAY_DIRECTORY = 'plugAndPlayDirectory';
     public const OPTION_PAGE_INTEGRATION = 'pageIntegration';
     public const OPTION_FLEXFORM_TO_IRRE = 'flexFormToIrre';
+    public const OPTION_INHERITANCE_MODE = 'inheritanceMode';
 }

--- a/Classes/Enum/FormOption.php
+++ b/Classes/Enum/FormOption.php
@@ -15,4 +15,5 @@ class FormOption
     public const RECORD_TABLE = 'recordTable';
     public const TRANSFORM = 'transform';
     public const HIDE_NATIVE_FIELDS = 'hideNativeFields';
+    public const INHERITANCE_MODE = 'inheritanceMode';
 }

--- a/Classes/Integration/NormalizedData/DataAccessTrait.php
+++ b/Classes/Integration/NormalizedData/DataAccessTrait.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 namespace FluidTYPO3\Flux\Integration\NormalizedData;
 
+use FluidTYPO3\Flux\Enum\ExtensionOption;
 use FluidTYPO3\Flux\Form\Transformation\FormDataTransformer;
 use FluidTYPO3\Flux\Provider\Interfaces\FormProviderInterface;
 use FluidTYPO3\Flux\Provider\ProviderResolver;
@@ -27,7 +28,7 @@ trait DataAccessTrait
         $this->settings = $this->configurationManager->getConfiguration(
             ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS
         );
-        if (!ExtensionConfigurationUtility::getOption(ExtensionConfigurationUtility::OPTION_FLEXFORM_TO_IRRE)) {
+        if (!ExtensionConfigurationUtility::getOption(ExtensionOption::OPTION_FLEXFORM_TO_IRRE)) {
             return;
         }
 

--- a/Classes/Utility/ExtensionConfigurationUtility.php
+++ b/Classes/Utility/ExtensionConfigurationUtility.php
@@ -9,13 +9,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ExtensionConfigurationUtility
 {
-    public const OPTION_DEBUG_MODE = 'debugMode';
-    public const OPTION_DOKTYPES = 'doktypes';
-    public const OPTION_HANDLE_ERRORS = 'handleErrors';
-    public const OPTION_AUTOLOAD = 'autoload';
-    public const OPTION_PLUG_AND_PLAY = 'plugAndPlay';
-    public const OPTION_PLUG_AND_PLAY_DIRECTORY = 'plugAndPlayDirectory';
-    public const OPTION_PAGE_INTEGRATION = 'pageIntegration';
     public const OPTION_FLEXFORM_TO_IRRE = 'flexFormToIrre';
 
     protected static array $defaults = [
@@ -27,6 +20,7 @@ class ExtensionConfigurationUtility
         ExtensionOption::OPTION_PLUG_AND_PLAY_DIRECTORY => DropInContentTypeDefinition::DESIGN_DIRECTORY,
         ExtensionOption::OPTION_PAGE_INTEGRATION => true,
         ExtensionOption::OPTION_FLEXFORM_TO_IRRE => false,
+        ExtensionOption::OPTION_INHERITANCE_MODE => 'restricted',
     ];
 
     public static function initialize(?string $extensionConfiguration): void

--- a/Classes/ViewHelpers/Form/Option/InheritanceModeViewHelper.php
+++ b/Classes/ViewHelpers/Form/Option/InheritanceModeViewHelper.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+namespace FluidTYPO3\Flux\ViewHelpers\Form\Option;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Flux\Enum\FormOption;
+use FluidTYPO3\Flux\ViewHelpers\Form\OptionViewHelper;
+
+/**
+ * ### Inheritance mode option
+ *
+ * Control how this Form will handle inheritance (page context only).
+ * There are two possible values of this option:
+ *
+ * - restricted
+ * - unrestricted
+ *
+ * Note that the default (the mode which is used if you do NOT specify
+ * the mode with this ViewHelper/option) is defined by the Flux extension
+ * configuration. If you do not change the extension configuration then
+ * the default behavior is "restricted". Any template that wants to use
+ * a mode other than the default *MUST* specify the mode with this option.
+ *
+ * When the option is set to "restricted" either by this ViewHelper or
+ * by extension configuration, the inheritance behavior matches the
+ * Flux behavior pre version 10.1.x, meaning that inheritance will only
+ * happen if the parent (page) has selected the same Form (layout) as
+ * the current page. As soon as a different Form is encountered in a
+ * parent, the inheritance stops. In short: inheritance only works for
+ * identical Forms.
+ *
+ * Alternatively, when the option is set to "unrestricted", the above
+ * constraint is removed and inheritance can happen for Forms which are
+ * NOT the same.
+ *
+ * This makes sense to use if you have different page templates which
+ * use the same values (for example a shared set of fields) and you want
+ * child pages to be able to inherit these values from parents even if
+ * the child page has selected a different page layout.
+ *
+ * #### Example
+ *
+ *     <flux:form.option.inheritanceMode value="unrestricted" />
+ *     (which is the same as:)
+ *     <flux:form.option.inheritanceMode>unrestricted</flux:form.option.inheritanceMode>
+ *
+ * Or:
+ *
+ *     <flux:form.option.inheritanceMode value="restricted" />
+ *     (which is the same as:)
+ *     <flux:form.option.inheritanceMode>restricted</flux:form.option.inheritanceMode>
+ */
+class InheritanceModeViewHelper extends OptionViewHelper
+{
+    public static string $option = FormOption::INHERITANCE_MODE;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('value', 'string', 'Mode of inheritance, either "restricted" or "unrestricted".');
+    }
+}

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -36,6 +36,9 @@
 			<trans-unit id="extension_configuration.flexFormToIrre">
 				<source>EXPERIMENTAL - FlexForm-to-IRRE: FlexForm XML to IRRE storage. WARNING - destroys existing FlexForm data in DB when saving records! Enabling this option makes Flux capable of storing FlexForm XML data structures as normalized IRRE records. By using the DataAccessTrait, classes such as controllers can read out the data in an array structure compatible with vanilla FlexForm data.</source>
 			</trans-unit>
+			<trans-unit id="extension_configuration.inheritanceMode">
+				<source>Default mode of Form value inheritance: The default mode is "restricted" which means inheritance follows the Flux pre 10.1.x rules that page variable inheritance only happens if the parent page uses the same page layout as the child page. This can be set to "unrestrited" to remove that constraint and allow inheritance when parent and child pages do not use the same page layout. This option changes the global default - individual templates can also set the mode which that specific template uses, with the flux:form.option.inheritanceMode ViewHelper.</source>
+			</trans-unit>
 			<trans-unit id="content_types">
 				<source>Flux-based Content Type</source>
 			</trans-unit>

--- a/Tests/Unit/Provider/PageProviderTest.php
+++ b/Tests/Unit/Provider/PageProviderTest.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Flux\Tests\Unit\Provider;
  */
 
 use FluidTYPO3\Flux\Builder\ViewBuilder;
+use FluidTYPO3\Flux\Enum\FormOption;
 use FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\Form\Transformation\FormDataTransformer;
 use FluidTYPO3\Flux\Provider\PageProvider;
@@ -21,6 +22,8 @@ use FluidTYPO3\Flux\Tests\Fixtures\Data\Xml;
 use FluidTYPO3\Flux\Tests\Unit\AbstractTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Resource\FileRepository;
+use TYPO3\CMS\Core\Service\FlexFormService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Fluid\View\TemplatePaths;
@@ -203,25 +206,26 @@ class PageProviderTest extends AbstractTestCase
     /**
      * @dataProvider getInheritanceTreeTestValues
      */
-    public function testGetInheritanceTree(array $input, array $expected): void
+    public function testGetInheritanceTree(array $input, array $forms, ?array $expected = null): void
     {
         $record = ['uid' => 1];
         $instance = $this->getMockBuilder($this->createInstanceClassName())
             ->setConstructorArgs($this->getConstructorArguments())
-            ->onlyMethods(['loadRecordTreeFromDatabase'])
+            ->onlyMethods(['loadRecordTreeFromDatabase', 'getForm'])
             ->getMock();
+        $instance->method('getForm')->willReturnOnConsecutiveCalls(...$forms);
         $instance->method('loadRecordTreeFromDatabase')->with($record)->willReturn($input);
         $result = $this->callInaccessibleMethod($instance, 'getInheritanceTree', $record);
-        $this->assertEquals($expected, $result);
+        $this->assertEquals($expected ?? $input, $result);
     }
 
     public function getInheritanceTreeTestValues(): array
     {
         return [
-            'empty tree returns empty' => [[], []],
+            'empty tree returns empty' => [[], [], []],
             'no sub action returns full tree' => [
                 [[PageProvider::FIELD_ACTION_MAIN => 'testmain']],
-                [[PageProvider::FIELD_ACTION_MAIN => 'testmain']]
+                [Form::create()],
             ],
             'defined sub action halts reading' => [
                 [
@@ -229,7 +233,20 @@ class PageProviderTest extends AbstractTestCase
                     [PageProvider::FIELD_ACTION_SUB => 'testsub'],
                     [PageProvider::FIELD_ACTION_SUB => 'notincluded']
                 ],
+                [Form::create(), Form::create(), Form::create()],
                 [[PageProvider::FIELD_ACTION_MAIN => ''], [PageProvider::FIELD_ACTION_SUB => 'testsub']],
+            ],
+            'inheritanceMode=unrestricted continues even if sub-template differs' => [
+                [
+                    [PageProvider::FIELD_ACTION_MAIN => ''],
+                    [PageProvider::FIELD_ACTION_SUB => 'testsub'],
+                    [PageProvider::FIELD_ACTION_SUB => 'beyondDifferent']
+                ],
+                [
+                    Form::create(),
+                    Form::create(),
+                    Form::create(['options' => [FormOption::INHERITANCE_MODE => 'unrestricted']])
+                ],
             ],
         ];
     }
@@ -361,29 +378,6 @@ class PageProviderTest extends AbstractTestCase
     }
 
     /**
-     * @test
-     */
-    public function getParentFieldValueLoadsRecordFromDatabaseIfRecordLacksParentFieldValue(): void
-    {
-        $row = Records::$contentRecordWithoutParentAndWithoutChildren;
-        $row['uid'] = 2;
-        $rowWithPid = $row;
-        $rowWithPid['pid'] = 1;
-        $className = str_replace('Tests\\Unit\\', '', substr(get_class($this), 0, -4));
-
-        $this->recordService->expects($this->exactly(1))->method('getSingle')->will($this->returnValue($rowWithPid));
-
-        $instance = $this->getMockBuilder($className)
-            ->setConstructorArgs($this->getConstructorArguments())
-            ->onlyMethods(['getParentFieldName', 'getTableName'])
-            ->getMock();
-        $instance->expects($this->once())->method('getParentFieldName')->with($row)->will($this->returnValue('pid'));
-
-        $result = $this->callInaccessibleMethod($instance, 'getParentFieldValue', $row);
-        $this->assertEquals($rowWithPid['pid'], $result);
-    }
-
-    /**
      * @dataProvider getInheritedPropertyValueByDottedPathTestValues
      * @param mixed $expected
      */
@@ -405,6 +399,53 @@ class PageProviderTest extends AbstractTestCase
             [['foo' => 'bar'], 'bar', null],
             [['foo' => ['bar' => 'baz']], 'foo.bar', 'baz'],
             [['foo' => ['bar' => 'baz']], 'foo.foo', null],
+        ];
+    }
+
+    /**
+     * @dataProvider getInheritedConfigurationTestValues
+     */
+    public function testGetInheritedConfiguration(string $expected, array $inheritedValues): void
+    {
+        $provider = $this->getMockBuilder(PageProvider::class)
+            ->onlyMethods(['getInheritanceTree', 'getFlexFormValuesSingle'])
+            ->setConstructorArgs($this->getConstructorArguments())
+            ->getMock();
+        $provider->method('getFlexFormValuesSingle')->willReturnOnConsecutiveCalls(...$inheritedValues);
+        $inheritanceTree = [];
+        foreach ($inheritedValues as $inheritedValue) {
+            $inheritanceTree[] = [PageProvider::FIELD_NAME_SUB => $inheritedValue];
+        }
+        $provider->method('getInheritanceTree')->willReturn($inheritanceTree);
+
+        $output = $this->callInaccessibleMethod($provider, 'getInheritedConfiguration', ['uid' => rand(10000, 99999)]);
+        self::assertSame($expected, $output['test']);
+    }
+
+    public function getInheritedConfigurationTestValues(): array
+    {
+        return [
+            'first parent has value' => [
+                'first-parent',
+                [
+                    ['test' => 'second-parent'],
+                    ['test' => 'first-parent'],
+                ],
+            ],
+            'first parent is empty, second parent has value' => [
+                'second-parent',
+                [
+                    ['test' => 'second-parent'],
+                    [],
+                ],
+            ],
+            'first-parent has value, second parent does not have value' => [
+                'first-parent',
+                [
+                    [],
+                    ['test' => 'first-parent'],
+                ],
+            ],
         ];
     }
 

--- a/Tests/Unit/ViewHelpers/Form/Option/InheritanceModeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Form/Option/InheritanceModeViewHelperTest.php
@@ -1,0 +1,15 @@
+<?php
+namespace FluidTYPO3\Flux\Tests\Unit\ViewHelpers\Form\Option;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Flux\Tests\Unit\ViewHelpers\AbstractFormViewHelperTestCase;
+
+class InheritanceModeViewHelperTest extends AbstractFormViewHelperTestCase
+{
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -21,3 +21,6 @@ pageIntegration = 1
 
 # cat=basic/enable; type=boolean; label=LLL:EXT:flux/Resources/Private/Language/locallang.xlf:extension_configuration.flexFormToIrre
 flexFormToIrre = 0
+
+# cat=basic/enable; type=options[restricted, unrestricted]; label=LLL:EXT:flux/Resources/Private/Language/locallang.xlf:extension_configuration.inheritanceMode
+inheritanceMode = restricted


### PR DESCRIPTION
Adds an extension configuration option and corresponding Form option and option ViewHelper which allows a site to control how Flux handles inheritance of FlexForm values (specific to pages).

Normally, Flux will only allow FlexForm values to be inherited from a parent page to children if the child uses the same page layout (template) as the parent page(s). This new option allows changing this inheritance mode from the default "restricted" to an "unrestricted" mode which allows FlexForm values to be inherited even if the child and parent uses different page layouts.

This is useful when you have different page templates which use the same FlexForm fields (for example, a shared set of fields) and you wish to inherit such fields from parents even if you use different page layouts on the child/parent(s).

There is a similar Form option which allows setting this inheritance mode on a per-template basis. Use the new ViewHelper flux:form.option.inheritanceMode for this, with either "restricted" or "unrestricted" as value. If no mode is specified on a template then the inheritance mode defined in extension configuration will be used.