### PR TITLE
[BUGFIX] Avoid FileRepository for reading FAL relations

### DIFF
--- a/Tests/Mock/ExpressionBuilder.php
+++ b/Tests/Mock/ExpressionBuilder.php
@@ -1,0 +1,164 @@
+<?php
+declare(strict_types=1);
+namespace FluidTYPO3\Flux\Tests\Mock;
+
+use Doctrine\DBAL\Platforms\TrimMode;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\Query\Expression\CompositeExpression;
+
+class ExpressionBuilder extends \TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder
+{
+    public function __construct()
+    {
+    }
+
+    public function andX(...$expressions): CompositeExpression
+    {
+        return __FUNCTION__;
+    }
+
+    public function orX(...$expressions): CompositeExpression
+    {
+        return __FUNCTION__;
+    }
+
+    public function and(...$expressions): CompositeExpression
+    {
+        return __FUNCTION__;
+    }
+
+    public function or(...$expressions): CompositeExpression
+    {
+        return __FUNCTION__;
+    }
+
+    public function comparison($leftExpression, string $operator, $rightExpression): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function eq(string $fieldName, $value): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function neq(string $fieldName, $value): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function lt($fieldName, $value): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function lte(string $fieldName, $value): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function gt(string $fieldName, $value): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function gte(string $fieldName, $value): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function isNull(string $fieldName): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function isNotNull(string $fieldName): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function like(string $fieldName, $value): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function notLike(string $fieldName, $value): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function in(string $fieldName, $value): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function notIn(string $fieldName, $value): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function inSet(string $fieldName, string $value, bool $isColumn = false): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function notInSet(string $fieldName, string $value, bool $isColumn = false): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function bitAnd(string $fieldName, int $value): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function min(string $fieldName, string $alias = null): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function max(string $fieldName, string $alias = null): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function avg(string $fieldName, string $alias = null): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function sum(string $fieldName, string $alias = null): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function count(string $fieldName, string $alias = null): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function length(string $fieldName, string $alias = null): string
+    {
+        return __FUNCTION__;
+    }
+
+    protected function calculation(string $aggregateName, string $fieldName, string $alias = null): string
+    {
+        return __FUNCTION__;
+    }
+
+    public function trim(string $fieldName, int $position = TrimMode::UNSPECIFIED, string $char = null)
+    {
+        return __FUNCTION__;
+    }
+
+    public function literal($input, $type = Connection::PARAM_STR)
+    {
+        return __FUNCTION__;
+    }
+
+    protected function unquoteLiteral(string $value): string
+    {
+        return __FUNCTION__;
+    }
+}

--- a/Tests/Mock/QueryBuilder.php
+++ b/Tests/Mock/QueryBuilder.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+namespace FluidTYPO3\Flux\Tests\Mock;
+
+use TYPO3\CMS\Core\Database\Connection;
+
+class QueryBuilder extends \TYPO3\CMS\Core\Database\Query\QueryBuilder
+{
+    private Result $result;
+    private ExpressionBuilder $expressionBuilder;
+
+    public function __construct(array ...$returns)
+    {
+        $this->result = new Result(...$returns);
+        $this->expressionBuilder = new ExpressionBuilder();
+    }
+
+    public function execute(): Result
+    {
+        return $this->result;
+    }
+
+    public function expr(): ExpressionBuilder
+    {
+        return $this->expressionBuilder;
+    }
+
+    public function createNamedParameter($value, int $type = Connection::PARAM_STR, string $placeHolder = null): string
+    {
+        return 'p';
+    }
+
+    public function setMaxResults(int $maxResults): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+
+    public function select(string ...$selects): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+
+    public function addSelect(string ...$selects): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+
+    public function selectLiteral(string ...$selects): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+
+    public function addSelectLiteral(string ...$selects): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+
+    public function from(string $from, string $alias = null): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+
+    public function join(
+        string $fromAlias,
+        string $join,
+        string $alias,
+        string $condition = null
+    ): \TYPO3\CMS\Core\Database\Query\QueryBuilder {
+        return $this;
+    }
+
+    public function where(...$predicates): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+
+    public function andWhere(...$where): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+
+    public function orWhere(...$where): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+
+    public function groupBy(...$groupBy): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+
+    public function orderBy(string $fieldName, string $order = null): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+
+    public function addOrderBy(string $fieldName, string $order = null): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    {
+        return $this;
+    }
+}

--- a/Tests/Mock/Result.php
+++ b/Tests/Mock/Result.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+namespace FluidTYPO3\Flux\Tests\Mock;
+
+// @codingStandardsIgnoreStart
+if (class_exists(\Doctrine\DBAL\ForwardCompatibility\Result::class)) {
+    class Result extends \Doctrine\DBAL\ForwardCompatibility\Result
+    {
+        use ResultTrait;
+    }
+} else {
+    class Result extends \Doctrine\DBAL\Result
+    {
+        use ResultTrait;
+    }
+}
+
+trait ResultTrait
+{
+    private array $returns;
+
+    public function __construct(array $returns)
+    {
+        $this->returns = $returns;
+    }
+
+    public function fetchAssociative()
+    {
+        return array_shift($this->returns);
+    }
+
+    public function fetchOne()
+    {
+        return array_shift($this->returns);
+    }
+
+    public function fetchAllAssociative(): array
+    {
+        return $this->returns;
+    }
+}


### PR DESCRIPTION
FileRepository is broken in BE context for FlexForm-based relations.

Refs: #2139
Refs: https://forge.typo3.org/issues/104331