### PR TITLE
[FEATURE] Add ability to protect values from changing when inherited

### DIFF
--- a/Classes/Form/AbstractFormField.php
+++ b/Classes/Form/AbstractFormField.php
@@ -33,6 +33,7 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
     protected bool $inherit = true;
     protected bool $inheritEmpty = false;
     protected bool $clearable = false;
+    protected bool $protectable = false;
     protected bool $exclude = false;
     protected ?string $validate = null;
     protected ?string $position = null;
@@ -107,6 +108,12 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
         if ($this->getClearable()) {
             $fieldStructureArray['config']['fieldWizard']['fluxClearValue'] = [
                 'renderType' => 'fluxClearValue',
+            ];
+        }
+
+        if ($this->getProtectable() && $this->getInherit()) {
+            $fieldStructureArray['config']['fieldWizard']['fluxProtectValue'] = [
+                'renderType' => 'fluxProtectValue',
             ];
         }
 
@@ -256,5 +263,16 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
     public function getClearable(): bool
     {
         return $this->clearable;
+    }
+
+    public function getProtectable(): bool
+    {
+        return $this->protectable;
+    }
+
+    public function setProtectable(bool $protectable): self
+    {
+        $this->protectable = $protectable;
+        return $this;
     }
 }

--- a/Classes/Form/FieldInterface.php
+++ b/Classes/Form/FieldInterface.php
@@ -13,6 +13,8 @@ interface FieldInterface extends FormInterface
     public function buildConfiguration(): array;
     public function setClearable(bool $clearable): self;
     public function getClearable(): bool;
+    public function getProtectable(): bool;
+    public function setProtectable(bool $protectable): self;
     public function setNative(bool $native): self;
     public function isNative(): bool;
     public function setRequired(bool $required): self;

--- a/Classes/Integration/FormEngine/ProtectValueWizard.php
+++ b/Classes/Integration/FormEngine/ProtectValueWizard.php
@@ -12,9 +12,9 @@ use TYPO3\CMS\Backend\Form\AbstractNode;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
- * TCA field wizard to remove empty values
+ * TCA field wizard to protect the value from changing when inherited value changes.
  */
-class ClearValueWizard extends AbstractNode
+class ProtectValueWizard extends AbstractNode
 {
     public function render(): array
     {
@@ -22,16 +22,21 @@ class ClearValueWizard extends AbstractNode
 
         $fieldName = 'data' . $this->data['elementBaseName'];
         $nameSegments = explode('][', $fieldName);
-        $nameSegments[count($nameSegments) - 2] .= '_clear';
+        $wizardFieldName = $nameSegments[count($nameSegments) - 2] .= '_protect';
+        $wizardFieldValue = $this->data['flexFormRowData'][$wizardFieldName]['vDEF'] ?? false;
         $fieldName = implode('][', $nameSegments);
+        $checked = (bool) $wizardFieldValue ? ' checked="checked"' : '';
 
-        $result['html'] = '<label style="opacity: 0.65; margin-top: 1em; margin-right: 1em;" title="'
-            . $this->translate('flux.clearValue.help')
+        $result['html'] = '<input type="hidden" name="' . $fieldName . '" value="0" />';
+        $result['html'] .= '<label style="opacity: 0.65; margin-top: 1em; margin-right: 1em;" title="'
+            . $this->translate('flux.protectValue.help')
             . '">'
             . '<input type="checkbox" class="form-check-input" name="'
             . $fieldName
-            . '" value="1" /> '
-            . $this->translate('flux.clearValue')
+            . '" value="1"'
+            . $checked
+            . '/> '
+            . $this->translate('flux.protectValue')
             . '</label>';
 
         return $result;

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -543,23 +543,35 @@ class AbstractProvider implements ProviderInterface
 
     protected function extractFieldNamesToClear(array $record, string $fieldName): array
     {
-        $removals = [];
+        return $this->extractWizardTaggedFieldNames($record, $fieldName, 'clear');
+    }
+
+    protected function extractFieldNamesToProtect(array $record, string $fieldName): array
+    {
+        return $this->extractWizardTaggedFieldNames($record, $fieldName, 'protect');
+    }
+
+    protected function extractWizardTaggedFieldNames(array $record, string $fieldName, string $wizardName): array
+    {
+        $wizardTagName = '_' . $wizardName;
+        $tagLength = strlen($wizardTagName);
+        $fieldNames = [];
         $data = $record[$fieldName]['data'] ?? [];
         foreach ($data as $sheetName => $sheetFields) {
             foreach ($sheetFields['lDEF'] as $sheetFieldName => $fieldDefinition) {
-                if ('_clear' === substr($sheetFieldName, -6)) {
-                    $removals[] = $sheetFieldName;
+                if ($wizardTagName === substr($sheetFieldName, -$tagLength)) {
+                    $fieldNames[] = $sheetFieldName;
                 } else {
-                    $clearFieldName = $sheetFieldName . '_clear';
-                    if (isset($data[$sheetName]['lDEF'][$clearFieldName]['vDEF'])) {
-                        if ((boolean) $data[$sheetName]['lDEF'][$clearFieldName]['vDEF']) {
-                            $removals[] = $sheetFieldName;
+                    $wizardFieldName = $sheetFieldName . $wizardTagName;
+                    if (isset($data[$sheetName]['lDEF'][$wizardFieldName]['vDEF'])) {
+                        if ((boolean) $data[$sheetName]['lDEF'][$wizardFieldName]['vDEF']) {
+                            $fieldNames[] = $sheetFieldName;
                         }
                     }
                 }
             }
         }
-        return array_unique($removals);
+        return array_unique($fieldNames);
     }
 
     /**

--- a/Classes/ViewHelpers/Field/AbstractFieldViewHelper.php
+++ b/Classes/ViewHelpers/Field/AbstractFieldViewHelper.php
@@ -110,6 +110,15 @@ abstract class AbstractFieldViewHelper extends AbstractFormViewHelper
             false
         );
         $this->registerArgument(
+            'protect',
+            'boolean',
+            'If TRUE, a "protect value" checkbox is displayed next to the field which when checked, protects the ' .
+            'value from being changed if the (normally inherited) field value is changed in a parent record. Has no ' .
+            'effect if "inherit" is disabled on the field.',
+            false,
+            false
+        );
+        $this->registerArgument(
             'variables',
             'array',
             'Freestyle variables which become assigned to the resulting Component - can then be read from that ' .
@@ -161,6 +170,7 @@ abstract class AbstractFieldViewHelper extends AbstractFormViewHelper
         $component->setInheritEmpty($arguments['inheritEmpty']);
         $component->setTransform($arguments['transform']);
         $component->setClearable($arguments['clear']);
+        $component->setProtectable($arguments['protect']);
         $component->setVariables($arguments['variables']);
         $component->setNative($arguments['native']);
         $component->setPosition($arguments['position']);

--- a/Classes/ViewHelpers/FieldViewHelper.php
+++ b/Classes/ViewHelpers/FieldViewHelper.php
@@ -74,6 +74,15 @@ class FieldViewHelper extends AbstractFieldViewHelper
             false
         );
         $this->registerArgument(
+            'protect',
+            'boolean',
+            'If TRUE, a "protect value" checkbox is displayed next to the field which when checked, protects the ' .
+            'value from being changed if the (normally inherited) field value is changed in a parent record. Has no ' .
+            'effect if "inherit" is disabled on the field.',
+            false,
+            false
+        );
+        $this->registerArgument(
             'extensionName',
             'string',
             'If provided, enables overriding the extension context for this and all child nodes. The extension name ' .
@@ -88,9 +97,8 @@ class FieldViewHelper extends AbstractFieldViewHelper
         /** @var array $arguments */
         $parent = static::getContainerFromRenderingContext($renderingContext);
         $field = Field::create($arguments instanceof ArgumentCollection ? $arguments->getArrayCopy() : $arguments);
-        if ($arguments['clear'] ?? false) {
-            $field->setClearable(true);
-        }
+        $field->setClearable($arguments['clear']);
+        $field->setProtectable($arguments['protect']);
 
         if (!$parent instanceof FieldContainerInterface) {
             return $field;

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -199,6 +199,15 @@
 			<trans-unit id="flux.clearValue">
 				<source>Clear value</source>
 			</trans-unit>
+			<trans-unit id="flux.clearValue.help">
+				<source>Destroy the value that is saved in the database, allowing the value to either be inherited again from a parent or reset to the default value if there is no inherited value.</source>
+			</trans-unit>
+			<trans-unit id="flux.protectValue">
+				<source>Protect value</source>
+			</trans-unit>
+			<trans-unit id="flux.protectValue.help">
+				<source>Protected values will remain the same even if the (inherited) value changes in a parent record.</source>
+			</trans-unit>
 			<trans-unit id="reference">
 				<source>Reference to content on page '%s' - click to jump to original</source>
 			</trans-unit>

--- a/Tests/Unit/Integration/FormEngine/ProtectValueWizardTest.php
+++ b/Tests/Unit/Integration/FormEngine/ProtectValueWizardTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace FluidTYPO3\Flux\Tests\Unit\Integration\FormEngine;
+
+/*
+ * This file is part of the FluidTYPO3/Flux project under GPLv2 or later.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.md file that was distributed with this source code.
+ */
+
+use FluidTYPO3\Flux\Integration\FormEngine\ClearValueWizard;
+use FluidTYPO3\Flux\Integration\FormEngine\ProtectValueWizard;
+use FluidTYPO3\Flux\Tests\Unit\AbstractTestCase;
+use TYPO3\CMS\Backend\Form\NodeFactory;
+
+class ProtectValueWizardTest extends AbstractTestCase
+{
+    public function test(): void
+    {
+        $data = [
+            'elementBaseName' => '[foo][bar][baz]',
+        ];
+        $nodeFactory = $this->getMockBuilder(NodeFactory::class)->disableOriginalConstructor()->getMock();
+        $subject = $this->getMockBuilder(ProtectValueWizard::class)
+            ->onlyMethods(['translate'])
+            ->setConstructorArgs([$nodeFactory, $data])
+            ->getMock();
+
+        $result = $subject->render();
+
+        self::assertStringContainsString('data[foo][bar_protect][baz]', $result['html']);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -91,6 +91,11 @@ $conf = isset($_EXTCONF) ? $_EXTCONF : null;
         'priority' => 40,
         'class' => \FluidTYPO3\Flux\Integration\FormEngine\ClearValueWizard::class,
     ];
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1720866860] = [
+        'nodeName' => 'fluxProtectValue',
+        'priority' => 40,
+        'class' => \FluidTYPO3\Flux\Integration\FormEngine\ProtectValueWizard::class,
+    ];
 
     // Small override for record-localize controller to manipulate the record listing to provide child records in list
     if (!class_exists(\TYPO3\CMS\Backend\Controller\Event\AfterPageColumnsSelectedForLocalizationEvent::class)) {


### PR DESCRIPTION
Use `protect="1"` on fields to render a wizard check box which when toggled on, protects the current value of the field from being changed when the value changes in a parent record.