### PR TITLE
[FEATURE] Add extension config to produce unique file field names

### DIFF
--- a/Classes/Enum/ExtensionOption.php
+++ b/Classes/Enum/ExtensionOption.php
@@ -13,4 +13,5 @@ class ExtensionOption
     public const OPTION_PAGE_INTEGRATION = 'pageIntegration';
     public const OPTION_FLEXFORM_TO_IRRE = 'flexFormToIrre';
     public const OPTION_INHERITANCE_MODE = 'inheritanceMode';
+    public const OPTION_UNIQUE_FILE_FIELD_NAMES = 'uniqueFileFieldNames';
 }

--- a/Classes/Form/Transformation/Transformer/FileTransformer.php
+++ b/Classes/Form/Transformation/Transformer/FileTransformer.php
@@ -10,10 +10,12 @@ namespace FluidTYPO3\Flux\Form\Transformation\Transformer;
  */
 
 use FluidTYPO3\Flux\Attribute\DataTransformer;
+use FluidTYPO3\Flux\Enum\ExtensionOption;
 use FluidTYPO3\Flux\Enum\FormOption;
 use FluidTYPO3\Flux\Form\FormInterface;
 use FluidTYPO3\Flux\Form\OptionCarryingInterface;
 use FluidTYPO3\Flux\Form\Transformation\DataTransformerInterface;
+use FluidTYPO3\Flux\Utility\ExtensionConfigurationUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Resource\Exception\ResourceDoesNotExistException;
 use TYPO3\CMS\Core\Resource\File;
@@ -59,7 +61,12 @@ class FileTransformer implements DataTransformerInterface
         /** @var array $record */
         $record = $form->getOption(FormOption::RECORD);
 
-        $references = $this->fetchFileReferences($table, (string) $component->getName(), (integer) $record['uid']);
+        $fieldName = (string) $component->getName();
+        if (ExtensionConfigurationUtility::getOption(ExtensionOption::OPTION_UNIQUE_FILE_FIELD_NAMES)) {
+            $fieldName = $form->getOption(FormOption::RECORD_FIELD) . '.' . $fieldName;
+        }
+
+        $references = $this->fetchFileReferences($table, $fieldName, (integer) $record['uid']);
 
         switch ($type) {
             case 'file':

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -582,6 +582,12 @@ class AbstractProvider implements ProviderInterface
     {
         $form = $this->getForm($row, $conf['fieldName'] ?? null);
         if ($dataStructure !== null && $form !== null) {
+            // Last minute set the field name. Ensures the field name matches the one given with the DS identifier,
+            // even if the Form instance was resolved from another field (e.g. inherited Form in page template).
+            $form->setOption(
+                FormOption::RECORD_FIELD,
+                $conf['fieldName'] ?? $form->getOption(FormOption::RECORD_FIELD)
+            );
             $dataStructure = array_replace_recursive($dataStructure, $form->build());
         }
     }

--- a/Classes/Utility/ExtensionConfigurationUtility.php
+++ b/Classes/Utility/ExtensionConfigurationUtility.php
@@ -21,6 +21,7 @@ class ExtensionConfigurationUtility
         ExtensionOption::OPTION_PAGE_INTEGRATION => true,
         ExtensionOption::OPTION_FLEXFORM_TO_IRRE => false,
         ExtensionOption::OPTION_INHERITANCE_MODE => 'restricted',
+        ExtensionOption::OPTION_UNIQUE_FILE_FIELD_NAMES => false,
     ];
 
     public static function initialize(?string $extensionConfiguration): void

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -39,6 +39,9 @@
 			<trans-unit id="extension_configuration.inheritanceMode">
 				<source>Default mode of Form value inheritance: The default mode is "restricted" which means inheritance follows the Flux pre 10.1.x rules that page variable inheritance only happens if the parent page uses the same page layout as the child page. This can be set to "unrestrited" to remove that constraint and allow inheritance when parent and child pages do not use the same page layout. This option changes the global default - individual templates can also set the mode which that specific template uses, with the flux:form.option.inheritanceMode ViewHelper.</source>
 			</trans-unit>
+			<trans-unit id="extension_configuration.uniqueFileFieldNames">
+				<source>Unique file field names: When this is enabled, FAL reference fields within a Flux context will be prefixed with the parent field name. This is done in order to ensure that references written to sys_file_reference will contain a unique value in "fieldname". Without this option enabled, any record which renders the same Flux form in two fields (e.g. pages when "this page" and "subpages" templates are identical) will show the same references in both fields because the "fieldname" saved in sys_file_reference is the same for both contexts. So, in order to avoid this duplication symptom, you can prefix the "fieldname" value stored in DB. Note: although this is handled transparently when you use transform="file" (and other file transformations) the prefix must manually be added to the field name when using e.g. v:resources.record.fal. CHANGING THIS OPTION WILL ORPHAN ALL EXISTING RELATIONS - TOGGLE IT ON FOR NEW SITES BUT LEAVE OLD SITES USING THE OPTION VALUE THEY WERE BORN WITH, OR YOU WILL NEED TO MIGRATE YOUR FILE REFERENCES!</source>
+			</trans-unit>
 			<trans-unit id="content_types">
 				<source>Flux-based Content Type</source>
 			</trans-unit>

--- a/Tests/Unit/Form/Transformation/Transformer/FileTransformerTest.php
+++ b/Tests/Unit/Form/Transformation/Transformer/FileTransformerTest.php
@@ -8,12 +8,14 @@ namespace FluidTYPO3\Flux\Tests\Unit\Form\Transformation\Transformer;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Flux\Enum\ExtensionOption;
 use FluidTYPO3\Flux\Enum\FormOption;
 use FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\Form\Transformation\Transformer\FileTransformer;
 use FluidTYPO3\Flux\Tests\Mock\QueryBuilder;
 use FluidTYPO3\Flux\Tests\Unit\AbstractTestCase;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Resource\Exception\ResourceDoesNotExistException;
 use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
@@ -43,21 +45,60 @@ class FileTransformerTest extends AbstractTestCase
         parent::setUp();
     }
 
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'][ExtensionOption::OPTION_UNIQUE_FILE_FIELD_NAMES]);
+        parent::tearDown();
+    }
+
     public function testGetPriority(): void
     {
         self::assertSame(0, $this->subject->getPriority());
     }
 
     /**
+     * @dataProvider getCanTransformToTypeTestValues
+     */
+    public function testCanTransformToType(bool $expected, string $type): void
+    {
+        self::assertSame($expected, $this->subject->canTransformToType($type));
+    }
+
+    public function getCanTransformToTypeTestValues(): array
+    {
+        return [
+            'supports file' => [true, 'file'],
+            'supports files' => [true, 'files'],
+            'supports filereference' => [true, 'filereference'],
+            'supports filereferences' => [true, 'filereferences'],
+            'does not support integer' => [false, 'integer'],
+            'does not support string' => [false, 'string'],
+        ];
+    }
+
+    /**
      * @dataProvider getTransformWithFileTargetTypesTestValues
      * @param mixed $expected
      */
-    public function testTransformationWithFileTargetTypes(string $type, array $files, $expected): void
-    {
+    public function testTransformationWithFileTargetTypes(
+        string $type,
+        array $files,
+        bool $exception,
+        bool $uniqueFilenamesExtensionSetting,
+        $expected
+    ): void {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['flux']['setup'][ExtensionOption::OPTION_UNIQUE_FILE_FIELD_NAMES]
+            = $uniqueFilenamesExtensionSetting;
+
         $this->connectionPool->method('getQueryBuilderForTable')->willReturn(
             new QueryBuilder(array_fill(0, count($files), ['uid' => 1]))
         );
-        $this->resourceFactory->method('getFileReferenceObject')->willReturnOnConsecutiveCalls(...$files);
+        if ($exception) {
+            $this->resourceFactory->method('getFileReferenceObject')
+                ->willThrowException(new ResourceDoesNotExistException());
+        } else {
+            $this->resourceFactory->method('getFileReferenceObject')->willReturnOnConsecutiveCalls(...$files);
+        }
 
         $form = $this->getMockBuilder(Form::class)->addMethods(['dummy'])->getMock();
         $form->setOption(FormOption::RECORD_TABLE, 'tt_content');
@@ -85,19 +126,32 @@ class FileTransformerTest extends AbstractTestCase
             ->getMock();
         $fileReference2->method('getOriginalFile')->willReturn($file2);
 
-        return [
-            'file, non-empty' => ['file', [$fileReference1], $file1],
-            'files, non-empty' => ['files', [$fileReference1, $fileReference2], [$file1, $file2]],
-            'filereference, non-empty' => ['filereference', [$fileReference1], $fileReference1],
+        $set = [
+            'file, non-empty' => ['file', [$fileReference1], false, false, $file1],
+            'file, non-empty, but not found' => ['file', [$fileReference1], true, false, null],
+            'files, non-empty' => ['files', [$fileReference1, $fileReference2], false, false, [$file1, $file2]],
+            'filereference, non-empty' => ['filereference', [$fileReference1], false, false, $fileReference1],
             'filereferences, non-empty' => [
                 'filereferences',
                 [$fileReference1, $fileReference2],
+                false,
+                false,
                 [$fileReference1, $fileReference2]
             ],
-            'file, empty' => ['file', [], null],
-            'files, empty' => ['files', [], []],
-            'filereference, empty' => ['filereference', [], null],
-            'filereferences, empty' => ['filereferences', [], []],
+            'file, empty' => ['file', [], false, false, null],
+            'files, empty' => ['files', [], false, false, []],
+            'filereference, empty' => ['filereference', [], false, false, null],
+            'filereferences, empty' => ['filereferences', [], false, false, []],
+            'incompatible type' => ['incompatible', [], false, false, null],
         ];
+        $copy = $set;
+
+        foreach ($copy as $name => $values) {
+            // Duplicate all test values but flip the "unique filenames" extension setting.
+            $values[3] = true;
+            $set[$name . ', unique field name'] = $values;
+        }
+
+        return $set;
     }
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -24,3 +24,6 @@ flexFormToIrre = 0
 
 # cat=basic/enable; type=options[restricted, unrestricted]; label=LLL:EXT:flux/Resources/Private/Language/locallang.xlf:extension_configuration.inheritanceMode
 inheritanceMode = restricted
+
+# cat=basic/enable; type=boolean; label=LLL:EXT:flux/Resources/Private/Language/locallang.xlf:extension_configuration.uniqueFileFieldNames
+uniqueFileFieldNames = 0


### PR DESCRIPTION
TYPO3 has a limitation (one among many) when dealing with with FAL references within FlexForms. The field name saved to sys_file_reference is unique to the DS but not unique to the parent field name context.

Usually we would solve this by extending foreign_match_fields but someone in their infinite wisdom decided that as part of the automatic TCA migration wizard that rewrites type=inline with FAL to type=file, the foreign_match_fields setting should be destroyed and type=file should not have any support whatsoever for this kind of advanced relation criteria.

We are therefore left with only one option: changing the field name of the FAL field to include the parent field name as prefix. This new extension feature enables that behavior.

Unfortunately this means that file references are stored in a completely different way which is not compatible. Changing this extension setting will effectively orphan all existing file relations. You should therefore never change this unless you are setting up a new site, or you plan to migrate all your existing file relations (updating sys_file_reference to set a new fieldname value for every relation matching your set of FAL field names throughout all templates).

Note: the prefix is automatically handled when using transform="file" and other file transform types. But if you use other means of resolving the FAL reference you'll need to manually specify the prefixed version of the fieldname when fetching file relation records.