### PR TITLE
bugfix: type cast (int) in AbstractMultiValueFieldViewHelper.php

### DIFF
--- a/Classes/ViewHelpers/Field/AbstractMultiValueFieldViewHelper.php
+++ b/Classes/ViewHelpers/Field/AbstractMultiValueFieldViewHelper.php
@@ -88,10 +88,10 @@ abstract class AbstractMultiValueFieldViewHelper extends AbstractFieldViewHelper
         $component->setEmptyOption($arguments['emptyOption']);
         $component->setTranslateCsvItems((boolean) $arguments['translateCsvItems']);
         $component->setValidate($arguments['validate']);
-        $component->setMinItems((int)$arguments['minItems']);
-        $component->setMaxItems((int)$arguments['maxItems']);
-        $component->setSize((int)$arguments['size']);
-        $component->setMultiple($arguments['multiple']);
+        $component->setMinItems((integer) $arguments['minItems']);
+        $component->setMaxItems((integer) $arguments['maxItems']);
+        $component->setSize((integer) $arguments['size']);
+        $component->setMultiple((boolean) $arguments['multiple']);
         $component->setItemListStyle($arguments['itemListStyle']);
         $component->setSelectedListStyle($arguments['selectedListStyle']);
         return $component;

--- a/Classes/ViewHelpers/Field/AbstractMultiValueFieldViewHelper.php
+++ b/Classes/ViewHelpers/Field/AbstractMultiValueFieldViewHelper.php
@@ -88,9 +88,9 @@ abstract class AbstractMultiValueFieldViewHelper extends AbstractFieldViewHelper
         $component->setEmptyOption($arguments['emptyOption']);
         $component->setTranslateCsvItems((boolean) $arguments['translateCsvItems']);
         $component->setValidate($arguments['validate']);
-        $component->setMinItems($arguments['minItems']);
-        $component->setMaxItems($arguments['maxItems']);
-        $component->setSize($arguments['size']);
+        $component->setMinItems((int)$arguments['minItems']);
+        $component->setMaxItems((int)$arguments['maxItems']);
+        $component->setSize((int)$arguments['size']);
         $component->setMultiple($arguments['multiple']);
         $component->setItemListStyle($arguments['itemListStyle']);
         $component->setSelectedListStyle($arguments['selectedListStyle']);


### PR DESCRIPTION
Because of the error message:
Uncaught TYPO3 Exception FluidTYPO3\Flux\Form\AbstractMultiValueFormField::setMinItems(): Argument #1 ($minItems) must be of type int, string given, called in /var/www/html/vendor/fluidtypo3/flux/Classes/ViewHelpers/Field/AbstractMultiValueFieldViewHelper.php on line 91 thrown in file /var/www/html/vendor/fluidtypo3/flux/Classes/Form/AbstractMultiValueFormField.php in line 118