### PR TITLE
[BUGFIX] make sure to have correct pid

### DIFF
--- a/Classes/Builder/FlexFormBuilder.php
+++ b/Classes/Builder/FlexFormBuilder.php
@@ -70,6 +70,10 @@ class FlexFormBuilder
                 // template selection values as part of our DS identifier.
                 // This is NOT necessary if the input record contains an explicitly selected page layout, hence the
                 // added check above before entering this condition block.
+                if ((int)$record['pid'] < 0) {
+                    // we have uid of sibling, need parent
+                    $record['pid'] = BackendUtility::getRecord('pages',abs($record['pid']),'uid')['uid'];
+                }
                 $record = array_merge(
                     $record,
                     $this->pageService->getPageTemplateConfiguration($record['pid'], true) ?? []

--- a/Classes/Builder/FlexFormBuilder.php
+++ b/Classes/Builder/FlexFormBuilder.php
@@ -72,7 +72,11 @@ class FlexFormBuilder
                 // added check above before entering this condition block.
                 if ((integer) $record['pid'] < 0) {
                     // we have uid of sibling, need parent
-                    $record['pid'] = BackendUtility::getRecord('pages', (integer) abs($record['pid']), 'uid')['uid'] ?? 0;
+                    $record['pid'] = BackendUtility::getRecord(
+                        'pages',
+                        (integer) abs($record['pid']),
+                        'uid'
+                    )['uid'] ?? 0;
                 }
                 $record = array_merge(
                     $record,

--- a/Classes/Builder/FlexFormBuilder.php
+++ b/Classes/Builder/FlexFormBuilder.php
@@ -70,9 +70,9 @@ class FlexFormBuilder
                 // template selection values as part of our DS identifier.
                 // This is NOT necessary if the input record contains an explicitly selected page layout, hence the
                 // added check above before entering this condition block.
-                if ((int)$record['pid'] < 0) {
+                if ((integer) $record['pid'] < 0) {
                     // we have uid of sibling, need parent
-                    $record['pid'] = BackendUtility::getRecord('pages', (int)abs($record['pid']), 'uid')['uid'] ?? 0;
+                    $record['pid'] = BackendUtility::getRecord('pages', (integer) abs($record['pid']), 'uid')['uid'] ?? 0;
                 }
                 $record = array_merge(
                     $record,

--- a/Classes/Builder/FlexFormBuilder.php
+++ b/Classes/Builder/FlexFormBuilder.php
@@ -72,7 +72,7 @@ class FlexFormBuilder
                 // added check above before entering this condition block.
                 if ((int)$record['pid'] < 0) {
                     // we have uid of sibling, need parent
-                    $record['pid'] = BackendUtility::getRecord('pages',abs($record['pid']),'uid')['uid'];
+                    $record['pid'] = BackendUtility::getRecord('pages', (int)abs($record['pid']), 'uid')['uid'] ?? 0;
                 }
                 $record = array_merge(
                     $record,


### PR DESCRIPTION
When you add a new page from list view via page (select position) then BeforeFlexFormDataStructureIdentifierInitializedEvent gives us the negative value of the page uid of the sibling to the choosen position. We need the real parent id though (as the documentation implies is always given).