### PR TITLE
[BUGFIX] Prevent TYPO3v11 controllerContext deprecation notice

### DIFF
--- a/Classes/Builder/RenderingContextBuilder.php
+++ b/Classes/Builder/RenderingContextBuilder.php
@@ -48,6 +48,10 @@ class RenderingContextBuilder implements SingletonInterface
             $pluginName
         );
 
+        if (method_exists($renderingContext, 'setRequest')) {
+            $renderingContext->setRequest($request);
+        }
+
         if (method_exists($renderingContext, 'getControllerContext')) {
             /** @var ControllerContext $controllerContext */
             $controllerContext = $this->buildControllerContext($request);
@@ -58,10 +62,6 @@ class RenderingContextBuilder implements SingletonInterface
                     'Controller class ' . $request->getControllerObjectName() . ' caused error: ' . $error->getMessage()
                 );
             }
-        }
-
-        if (method_exists($renderingContext, 'setRequest')) {
-            $renderingContext->setRequest($request);
         }
 
         if (method_exists($renderingContext, 'setControllerAction')) {


### PR DESCRIPTION
When using flux 10.0.10 on TYPO3v11, the deprecation log is full of
> TYPO3 Deprecation Notice:
> Setting request from controllerContext in class
> TYPO3\CMS\Fluid\Core\Rendering\RenderingContext is deprecated.
> Use setRequest() directly.
> in typo3/sysext/fluid/Classes/Core/Rendering/RenderingContext.php line 205

The deprecation notice is only triggered when the context has no request yet.

To get rid of this notice, we simply set the request before setting the controller context.