### PR TITLE
[BUGFIX] Fix localization record merging logic

### DIFF
--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -583,15 +583,18 @@ abstract class AbstractFluxController extends ActionController
             );
         }
 
-        if ($record['_LOCALIZED_UID'] ?? false) {
-            $record = array_merge(
-                $record,
-                $this->recordService->getSingle(
-                    (string) $this->getFluxTableName(),
-                    '*',
-                    $record['_LOCALIZED_UID']
-                ) ?? $record
+        if ($contentObject->data['_LOCALIZED_UID'] ?? false) {
+            $localized = $this->recordService->getSingle(
+                (string) $this->getFluxTableName(),
+                '*',
+                $contentObject->data['_LOCALIZED_UID']
             );
+            if ($localized) {
+                $record = array_merge(
+                    $record,
+                    $localized
+                );
+            }
         }
         return $record;
     }


### PR DESCRIPTION
Updated the logic to correctly merge localized records by checking for the existence of '_LOCALIZED_UID' in the $contentObject data. The $record was missing the '_LOCALIZED_UID' field, and therefore proper data localization never occurred.

This change ensures that records are only merged if a valid localized version is available.

I extracted $this->recoredService->getSingle(...) from the array_merge function because on my system this never merged the localized record. Therefore, getSingle is stored in a separate variable and then, if available, merged.

