### PR TITLE
[BUGFIX] Fix error when copying a page

### DIFF
--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -163,7 +163,7 @@ class DataHandlerSubscriber
                     )
                 )
             );
-            DoctrineQueryProxy::executeQueryOnQueryBuilder($queryBuilder);
+            DoctrineQueryProxy::executeStatementOnQueryBuilder($queryBuilder);
         }
 
         static::$copiedRecords[$fieldArray['t3_origuid']] = true;


### PR DESCRIPTION
When copying a page in TYPO3 v11.5.41, PHP 8.3.15 and flux 10.1.0 an exception occurs:

> (1/1) TypeError
> Cannot access offset of type string on string
> in typo3/sysext/core/Classes/Database/Query/QueryBuilder.php line 1368

Thanks to the following blog post for the solution: https://blog.wappler.systems/typo3-error-cannot-access-offset-of-type-string-on-string-at-querybuilder-update-command/

Resolves: https://github.com/FluidTYPO3/flux/issues/2196