### PR TITLE
[BUGFIX] Prevent array key exception in FieldViewHelper

### DIFF
--- a/Classes/ViewHelpers/FieldViewHelper.php
+++ b/Classes/ViewHelpers/FieldViewHelper.php
@@ -97,8 +97,8 @@ class FieldViewHelper extends AbstractFieldViewHelper
         /** @var array $arguments */
         $parent = static::getContainerFromRenderingContext($renderingContext);
         $field = Field::create($arguments instanceof ArgumentCollection ? $arguments->getArrayCopy() : $arguments);
-        $field->setClearable($arguments['clear']);
-        $field->setProtectable($arguments['protect']);
+        $field->setClearable($arguments['clear'] ?? false);
+        $field->setProtectable($arguments['protect'] ?? false);
 
         if (!$parent instanceof FieldContainerInterface) {
             return $field;


### PR DESCRIPTION
Thie PR prevents the following exception being thrown.

```
Uncaught TYPO3 Exception FluidTYPO3\Flux\Form\AbstractFormField::setProtectable(): Argument #1 ($protectable) must be of type bool, null given.
```