### PR TITLE
[TASK] Remove Coveralls as direct dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,9 @@ jobs:
         run: vendor/bin/phpunit --coverage-clover=build/logs/clover.xml
 
       - name: Upload test coverage
-        run: vendor/bin/php-coveralls -vvv
+        run: |
+          composer global require php-coveralls/php-coveralls
+          php-coveralls --coverage_clover=build/logs/clover.xml -v
         env:
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: typo3-${{ matrix.typo3 }}-php-${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
     "require-dev": {
         "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^5.7 || ^9.5",
-        "php-coveralls/php-coveralls": "^2.5",
         "squizlabs/php_codesniffer": "^3.7",
         "mikey179/vfsstream": "^1.6",
         "phpspec/prophecy": "*"


### PR DESCRIPTION
Require it only while running CI job to avoid any dependency concerns.