### PR TITLE
[REMOVAL] Remove feature to register Providers with TypoScript

### DIFF
--- a/Classes/Provider/ProviderResolver.php
+++ b/Classes/Provider/ProviderResolver.php
@@ -24,12 +24,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class ProviderResolver implements SingletonInterface
 {
     protected array $providers = [];
-    protected TypoScriptService $typoScriptService;
-
-    public function __construct(TypoScriptService $typoScriptService)
-    {
-        $this->typoScriptService = $typoScriptService;
-    }
 
     /**
      * Resolve fluidpages specific configuration provider. Always
@@ -123,34 +117,10 @@ class ProviderResolver implements SingletonInterface
     /**
      * @return ProviderInterface[]
      */
-    public function loadTypoScriptConfigurationProviderInstances(): array
-    {
-        /** @var array[] $providerConfigurations */
-        $providerConfigurations = (array) $this->typoScriptService->getTypoScriptByPath('plugin.tx_flux.providers');
-        $providers = [];
-        foreach ($providerConfigurations as $name => $providerSettings) {
-            $className = Provider::class;
-            if (isset($providerSettings['className']) && class_exists($providerSettings['className'])) {
-                $className = $providerSettings['className'];
-            }
-            /** @var ProviderInterface $provider */
-            $provider = GeneralUtility::makeInstance($className);
-            $provider->setName($name);
-            $provider->loadSettings($providerSettings);
-            $providers[$name] = $provider;
-        }
-        return $providers;
-    }
-
-    /**
-     * @return ProviderInterface[]
-     */
     protected function getAllRegisteredProviderInstances(): array
     {
         if (empty($this->providers)) {
             $providers = $this->loadCoreRegisteredProviders();
-            $typoScriptConfigurationProviders = $this->loadTypoScriptConfigurationProviderInstances();
-            $providers = array_merge($providers, $typoScriptConfigurationProviders);
             $this->providers = $this->validateAndInstantiateProviders($providers);
         }
         return $this->providers;

--- a/Tests/Unit/Provider/ProviderResolverTest.php
+++ b/Tests/Unit/Provider/ProviderResolverTest.php
@@ -38,10 +38,9 @@ class ProviderResolverTest extends AbstractTestCase
     public function testResolveConfigurationProvidersFiltersProviders(): void
     {
         $subject = $this->getMockBuilder(ProviderResolver::class)
-            ->onlyMethods(['loadTypoScriptConfigurationProviderInstances', 'validateAndInstantiateProviders'])
+            ->onlyMethods(['validateAndInstantiateProviders'])
             ->disableOriginalConstructor()
             ->getMock();
-        $subject->method('loadTypoScriptConfigurationProviderInstances')->willReturn([]);
         $subject->method('validateAndInstantiateProviders')->willReturnArgument(0);
 
         $provider1 = $this->getMockBuilder(DummyConfigurationProvider::class)->disableOriginalConstructor()->getMock();
@@ -66,49 +65,6 @@ class ProviderResolverTest extends AbstractTestCase
         self::assertSame([], $resolved);
 
         AccessibleCore::setRegisteredProviders([]);
-    }
-
-    /**
-     * @test
-     */
-    public function loadTypoScriptProvidersReturnsEmptyArrayEarlyIfSetupNotFound()
-    {
-        $this->typoScriptService->expects($this->once())->method('getTypoScriptByPath')->will($this->returnValue([]));
-
-        $instance = new ProviderResolver($this->typoScriptService);
-
-        $providers = $instance->loadTypoScriptConfigurationProviderInstances();
-        $this->assertIsArray($providers);
-        $this->assertEmpty($providers);
-    }
-
-    /**
-     * @test
-     */
-    public function loadTypoScriptProvidersSupportsCustomClassName()
-    {
-        $mockedTypoScript = [
-            'dummy.' => [
-                'className' => DummyConfigurationProvider::class,
-            ]
-        ];
-
-        $this->typoScriptService->expects($this->once())
-            ->method('getTypoScriptByPath')
-            ->willReturn($mockedTypoScript);
-
-        $instance = new ProviderResolver($this->typoScriptService);
-
-        $dummyProvider = $this->getMockBuilder(DummyConfigurationProvider::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        GeneralUtility::addInstance(DummyConfigurationProvider::class, $dummyProvider);
-
-        $providers = $instance->loadTypoScriptConfigurationProviderInstances();
-        $this->assertIsArray($providers);
-        $this->assertNotEmpty($providers);
-        $this->assertContains($dummyProvider, $providers);
-        $this->assertInstanceOf(DummyConfigurationProvider::class, reset($providers));
     }
 
     /**


### PR DESCRIPTION
To my knowledge, this feature has never been used except in my own proof-of-concept environments. Given that it would need a rather excessive workaround to function on v13 it's probably best to simply remove the feature.