### PR TITLE
[FEATURE] Deliver fallback TemplatePaths if unable to read TypoScript

### DIFF
--- a/Classes/Builder/ViewBuilder.php
+++ b/Classes/Builder/ViewBuilder.php
@@ -10,7 +10,9 @@ namespace FluidTYPO3\Flux\Builder;
  */
 
 use FluidTYPO3\Flux\Integration\PreviewView;
+use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\View\TemplatePaths;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\View\ViewInterface;
 
@@ -69,5 +71,49 @@ class ViewBuilder
         $view = GeneralUtility::makeInstance($viewClassName);
         $view->setRenderingContext($renderingContext);
         return $view;
+    }
+
+    /**
+     * @param string|array $extensionKeyOrConfiguration
+     * @codeCoverageIgnore
+     */
+    public function buildTemplatePaths($extensionKeyOrConfiguration): TemplatePaths
+    {
+        /** @var TemplatePaths $paths */
+        $paths = GeneralUtility::makeInstance(TemplatePaths::class);
+
+        if (is_array($extensionKeyOrConfiguration)) {
+            $paths->setTemplateRootPaths($extensionKeyOrConfiguration[TemplatePaths::CONFIG_TEMPLATEROOTPATHS]);
+            $paths->setLayoutRootPaths($extensionKeyOrConfiguration[TemplatePaths::CONFIG_LAYOUTROOTPATHS]);
+            $paths->setPartialRootPaths($extensionKeyOrConfiguration[TemplatePaths::CONFIG_PARTIALROOTPATHS]);
+        } else {
+            $extensionKey = ExtensionNamingUtility::getExtensionKey($extensionKeyOrConfiguration);
+            try {
+                $paths->fillDefaultsByPackageName($extensionKey);
+            } catch (\RuntimeException $exception) {
+                if ($exception->getCode() !== 1700841298) {
+                    throw $exception;
+                }
+                $paths->setTemplateRootPaths(
+                    $this->createFluidPathSet($extensionKey, TemplatePaths::DEFAULT_TEMPLATES_DIRECTORY)
+                );
+                $paths->setLayoutRootPaths(
+                    $this->createFluidPathSet($extensionKey, TemplatePaths::DEFAULT_LAYOUTS_DIRECTORY)
+                );
+                $paths->setPartialRootPaths(
+                    $this->createFluidPathSet($extensionKey, TemplatePaths::DEFAULT_PARTIALS_DIRECTORY)
+                );
+            }
+        }
+
+        return $paths;
+    }
+
+    private function createFluidPathSet(string $extensionKey, string $subPath): array
+    {
+        return [
+            'EXT:flux/' . $subPath,
+            'EXT:' . $extensionKey . '/' . $subPath,
+        ];
     }
 }

--- a/Classes/Provider/AbstractProvider.php
+++ b/Classes/Provider/AbstractProvider.php
@@ -866,15 +866,4 @@ class AbstractProvider implements ProviderInterface
     {
         return $file === null ? null : GeneralUtility::getFileAbsFileName($file);
     }
-
-    /**
-     * @param string|array $extensionKeyOrConfiguration
-     * @codeCoverageIgnore
-     */
-    protected function createTemplatePaths($extensionKeyOrConfiguration): TemplatePaths
-    {
-        /** @var TemplatePaths $paths */
-        $paths = GeneralUtility::makeInstance(TemplatePaths::class, $extensionKeyOrConfiguration);
-        return $paths;
-    }
 }

--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -130,7 +130,7 @@ class PageProvider extends AbstractProvider implements ProviderInterface
         if (!empty($action)) {
             $pathsOrExtensionKey = $this->templatePaths
                 ?? ExtensionNamingUtility::getExtensionKey($this->getControllerExtensionKeyFromRecord($row, $forField));
-            $templatePaths = $this->createTemplatePaths($pathsOrExtensionKey);
+            $templatePaths = $this->viewBuilder->buildTemplatePaths($pathsOrExtensionKey);
             $action = ucfirst($action);
             $templatePathAndFilename = $templatePaths->resolveTemplateFileForControllerAndActionAndFormat(
                 $this->getControllerNameFromRecord($row),

--- a/Tests/Unit/Provider/PageProviderTest.php
+++ b/Tests/Unit/Provider/PageProviderTest.php
@@ -33,6 +33,7 @@ class PageProviderTest extends AbstractTestCase
     protected PageService $pageService;
     protected CacheService $cacheService;
     protected TypoScriptService $typoScriptService;
+    protected ViewBuilder $viewBuilder;
     protected string $configurationProviderClassName = PageProvider::class;
 
     protected function setUp(): void
@@ -61,6 +62,10 @@ class PageProviderTest extends AbstractTestCase
             ->onlyMethods(['getPageTemplateConfiguration'])
             ->disableOriginalConstructor()
             ->getMock();
+        $this->viewBuilder = $this->getMockBuilder(ViewBuilder::class)
+            ->onlyMethods(['buildTemplatePaths'])
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     protected function getConstructorArguments(): array
@@ -68,7 +73,7 @@ class PageProviderTest extends AbstractTestCase
         return [
             $this->formDataTransformer,
             $this->recordService,
-            $this->getMockBuilder(ViewBuilder::class)->disableOriginalConstructor()->getMock(),
+            $this->viewBuilder,
             $this->cacheService,
             $this->typoScriptService,
             $this->pageService,
@@ -172,9 +177,9 @@ class PageProviderTest extends AbstractTestCase
             ->willReturn('Tests/Fixtures/Templates/Page/Dummy.html');
         $instance = $this->getMockBuilder(PageProvider::class)
             ->setConstructorArgs($this->getConstructorArguments())
-            ->onlyMethods(['createTemplatePaths'])
+            ->addMethods(['dummy'])
             ->getMock();
-        $instance->method('createTemplatePaths')->willReturn($templatePaths);
+        $this->viewBuilder->method('buildTemplatePaths')->willReturn($templatePaths);
         $record = [
             $fieldName => 'Flux->dummy',
         ];

--- a/Tests/Unit/Provider/ProviderTest.php
+++ b/Tests/Unit/Provider/ProviderTest.php
@@ -970,10 +970,11 @@ XML;
         $templatePaths = $this->getMockBuilder(TemplatePaths::class)->disableOriginalConstructor()->getMock();
         $provider = $this->getMockBuilder($this->createInstanceClassName())
             ->setConstructorArgs($this->getConstructorArguments())
-            ->onlyMethods(['createTemplatePaths', 'resolveAbsolutePathToFile'])
+            ->onlyMethods(['resolveAbsolutePathToFile'])
             ->getMock();
-        $provider->method('createTemplatePaths')->willReturn($templatePaths);
         $provider->method('resolveAbsolutePathToFile')->willReturnArgument(0);
+
+        $this->viewBuilder->method('buildTemplatePaths')->willReturn($templatePaths);
 
         $record = $this->getBasicRecord();
 


### PR DESCRIPTION
Adds a fallback handling which delivers template path setup based on Flux and provider extensions' paths when TypoScript can not be resolved. If TypoScript can be resolved, the path setup is read from plugin.tx_yourext (where "yourext" is your provider extension key) as usual.