### PR TITLE
[BUGFIX] Missing rendered children in preview workspace

### DIFF
--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -128,6 +128,7 @@ class GetViewHelper extends AbstractViewHelper
             if ($placeholder) {
                 // Use the move placeholder if one exists, ensuring that "pid" and "tx_flux_parent" values are taken
                 // from the workspace-only placeholder.
+                $liveRecord = $record;
                 /** @var array $record */
                 $record = $placeholder;
             }
@@ -137,6 +138,9 @@ class GetViewHelper extends AbstractViewHelper
         $provider = $renderingContext->getViewHelperVariableContainer()->get(FormViewHelper::class, 'provider');
         $grid = $provider->getGrid($record);
         $rows = static::getContentRecords($arguments, $record, $grid);
+        if (isset($liveRecord)) {
+            array_push($rows, ...static::getContentRecords($arguments, $liveRecord, $grid));
+        }
 
         $elements = false === (boolean) $arguments['render'] ? $rows : static::getRenderedRecords($rows);
         if (empty($arguments['as'])) {


### PR DESCRIPTION
As described in Issue #2158 children are not rendered when previewing changes made in the preview workspace:
I have encountered the same problem.
The Problem is that when rendering the content records of a workspace element, that they are identified by their colPos, which are based on the uid of the LIVE-element. 

As example, we have these Elements:
- a LIVE-version of a content element with the uid 42
- a PREVIEW-Version of **the same** content element with the uid 43
- The Live-Version contains 2 child column elements assigned with colPos 4201 and 4202 by the `ColumnNumberUtility::calculateColumnNumberForParentAndColumn` function.
- A Element in Preview Workspace that results in a third column child with colPos 4303.

With this set, we render the preview element:
We see that the "placeholder" (the preview element) is used instead the original:
```php
// Classes/ViewHelpers/Content/GetViewHelper.php
if ($workspaceId) {
    $placeholder = BackendUtility::getWorkspaceVersionOfRecord($workspaceId, 'tt_content', $record['uid'] ?? 0);
    if ($placeholder) {
        // Use the move placeholder if one exists, ensuring that "pid" and "tx_flux_parent" values are taken
        // from the workspace-only placeholder.
        /** @var array $record */
        $record = $placeholder;
    }
}
```
Rendering the preview results in the child elements being searched by colPos 4301, 4302, 4303, ... (Again, because of `ColumnNumberUtility::calculateColumnNumberForParentAndColumn`).
The Problem here is that we want to render also the live elements, which have the colPos 4201, 4201, ...

So as a solution, i kept that information about the original record and used it then to also check for rows in this live record.