### PR TITLE
[TASK] Add TCA "required" config option for TYPO3v12+

### DIFF
--- a/Classes/Form/AbstractFormField.php
+++ b/Classes/Form/AbstractFormField.php
@@ -12,6 +12,7 @@ namespace FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\Form\Container\Section;
 use FluidTYPO3\Flux\UserFunction\ClearValueWizard;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 abstract class AbstractFormField extends AbstractFormComponent implements FieldInterface
 {
@@ -125,11 +126,17 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
 
     protected function prepareConfiguration(string $type): array
     {
-        return [
+        $config = [
             'type' => $type,
             'transform' => $this->getTransform(),
             'default' => $this->getDefault(),
         ];
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '12.0', '>=')
+            && $this->getRequired()
+        ) {
+            $config['required'] = $this->getRequired();
+        }
+        return $config;
     }
 
     public function isNative(): bool
@@ -229,6 +236,10 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
 
     public function getValidate(): ?string
     {
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '12.0', '>=')) {
+            return $this->validate;
+        }
+
         if (!$this->getRequired()) {
             $validate = $this->validate;
         } else {

--- a/Configuration/TCA/content_types.php
+++ b/Configuration/TCA/content_types.php
@@ -1,6 +1,6 @@
 <?php
 
-return [
+$table = [
     'ctrl' => [
         'title' => 'LLL:EXT:flux/Resources/Private/Language/locallang.xlf:content_types',
         'descriptionColumn' => 'description',
@@ -177,3 +177,11 @@ return [
     ],
     'palettes' => []
 ];
+
+if (version_compare(\TYPO3\CMS\Core\Utility\VersionNumberUtility::getCurrentTypo3Version(), '12.0', '>=')) {
+    unset($table['ctrl']['cruser_id']);
+    unset($table['columns']['title']['config']['eval']);
+    unset($table['columns']['content_type']['config']['eval']);
+}
+
+return $table;

--- a/Configuration/TCA/content_types.php
+++ b/Configuration/TCA/content_types.php
@@ -79,6 +79,7 @@ return [
                 'type' => 'input',
                 'size' => 60,
                 'eval' => 'required',
+                'required' => true,
             ],
         ],
         'content_type' => [
@@ -87,6 +88,7 @@ return [
                 'type' => 'input',
                 'size' => 60,
                 'eval' => 'required',
+                'required' => true,
                 'placeholder' => 'flux_newtype',
             ],
         ],

--- a/Tests/Unit/Form/Field/InputTest.php
+++ b/Tests/Unit/Form/Field/InputTest.php
@@ -8,6 +8,8 @@ namespace FluidTYPO3\Flux\Tests\Unit\Form\Field;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+
 class InputTest extends AbstractFieldTest
 {
     protected array $chainProperties = [
@@ -29,7 +31,12 @@ class InputTest extends AbstractFieldTest
     {
         $instance = $this->canChainAllChainableSetters();
         $instance->setRequired(true);
-        $this->assertEquals('trim,int,required', $instance->getValidate());
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '12.0', '>=')) {
+            $this->assertEquals('trim,int', $instance->getValidate());
+            $this->assertTrue($instance->build()['config']['required']);
+        } else {
+            $this->assertEquals('trim,int,required', $instance->getValidate());
+        }
     }
 
     /**
@@ -40,6 +47,11 @@ class InputTest extends AbstractFieldTest
         $instance = $this->canChainAllChainableSetters();
         $instance->setValidate(null);
         $instance->setRequired(true);
-        $this->assertEquals('required', $instance->getValidate());
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '12.0', '>=')) {
+            $this->assertEquals('', $instance->getValidate());
+            $this->assertTrue($instance->build()['config']['required']);
+        } else {
+            $this->assertEquals('required', $instance->getValidate());
+        }
     }
 }


### PR DESCRIPTION
"eval=required" is not used anymore in TYPO3v12+, as described in the TCA migration message:
> The TCA field 'title' of table 'content_types' defines "required"
> in its "eval" list.
> This is not evaluated anymore and should be replaced
> by `'required' => true`.

To keep backwards compatibility with TYPO3v10 and 11, "eval=required" is kept.

Changelog entries:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-97035-RequiredOptionInEvalKeyword.html
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97035-UtilizeRequiredDirectlyInTCAFieldConfiguration.html

This change is necessary for the flux own content_types table, as well as configuration generated for flux form fields.