### PR TITLE
[BUGFIX] Always fetch ContentObject from request in TYPO3v12+

### DIFF
--- a/Classes/Utility/ContentObjectFetcher.php
+++ b/Classes/Utility/ContentObjectFetcher.php
@@ -22,16 +22,15 @@ class ContentObjectFetcher
             ? $configurationManager->getRequest()
             : ($GLOBALS['TYPO3_REQUEST'] ?? null);
 
-        if ($request && $configurationManager === null) {
+        if ($request) {
             $contentObject = static::resolveFromRequest($request);
         }
 
-        if ($contentObject === null) {
-            if ($configurationManager !== null && method_exists($configurationManager, 'getContentObject')) {
-                $contentObject = $configurationManager->getContentObject();
-            } else {
-                $contentObject = static::resolveFromRequest($request);
-            }
+        if ($contentObject === null
+            && $configurationManager !== null
+            && method_exists($configurationManager, 'getContentObject')
+        ) {
+            $contentObject = $configurationManager->getContentObject();
         }
 
         return $contentObject;
@@ -39,6 +38,9 @@ class ContentObjectFetcher
 
     protected static function resolveFromRequest(ServerRequestInterface $request): ?ContentObjectRenderer
     {
+        if (($cObject = $request->getAttribute('currentContentObject')) instanceof ContentObjectRenderer) {
+            return $cObject;
+        }
         /** @var TypoScriptFrontendController $controller */
         $controller = $request->getAttribute('frontend.controller');
         return $controller instanceof TypoScriptFrontendController ? $controller->cObj : null;

--- a/Tests/Unit/Integration/NormalizedData/DataAccessTraitTest.php
+++ b/Tests/Unit/Integration/NormalizedData/DataAccessTraitTest.php
@@ -139,12 +139,10 @@ class DataAccessTraitTest extends AbstractTestCase
         $configurationManager = $this->getMockBuilder(ConfigurationManagerInterface::class)
             ->getMockForAbstractClass();
         $configurationManager->method('getConfiguration')->willReturn(['foo' => 'bar']);
-        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '13.4', '<')) {
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '12.4', '<')) {
             $configurationManager->method('getContentObject')->willReturn($contentObject);
         } else {
-            $tsfe = $this->getMockBuilder(TypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
-            $tsfe->cObj = $contentObject;
-            $GLOBALS['TYPO3_REQUEST']->method('getAttribute')->with('frontend.controller')->willReturn($tsfe);
+            $GLOBALS['TYPO3_REQUEST']->method('getAttribute')->with('currentContentObject')->willReturn($contentObject);
         }
 
         $converter = $this->getMockBuilder(InlineRecordDataConverter::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
The ContentObjectFetcher was introduced in #2190 to have a common API for fetching the current content object across different TYPO3 versions.

This class logs a deprecation notice in TYPO3v12:
> TYPO3 Deprecation Notice:
> ConfigurationManager->getContentObject() is deprecated since TYPO3 v12.4
> and will be removed in v13.0.
> Fetch the current content object from request attribute
> "currentContentObject" instead in
> vendor/typo3/cms-extbase/Classes/Configuration/ConfigurationManager.php
> line 96

To prevent this from happening, we check for the TYPO3 version and always use the request instead of the configuration manager in TYPO3v12+.

Note: In TYPO3v12, "$request->getAttribute('currentContentObject')" does not always return the content object.
We thus fall back to TypoScriptFrontendController, which always has it.

Related: https://github.com/FluidTYPO3/flux/pull/2190
https://github.com/FluidTYPO3/vhs/issues/1920
https://github.com/FluidTYPO3/vhs/issues/1921
https://github.com/FluidTYPO3/vhs/pull/1931

Documentation: https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/RequestLifeCycle/RequestAttributes/CurrentContentObject.html