### PR TITLE
[BUGFIX] Use associative array for TCA items

### DIFF
--- a/Classes/Form/AbstractMultiValueFormField.php
+++ b/Classes/Form/AbstractMultiValueFormField.php
@@ -8,6 +8,7 @@ namespace FluidTYPO3\Flux\Form;
  * LICENSE.md file that was distributed with this source code.
  */
 
+use FluidTYPO3\Flux\Integration\FormEngine\SelectOption;
 use FluidTYPO3\Flux\Service\TypoScriptService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
@@ -193,7 +194,7 @@ abstract class AbstractMultiValueFormField extends AbstractFormField implements 
             }
             if (!$this->getTranslateCsvItems()) {
                 foreach ($itemNames as $itemName) {
-                    array_push($items, [$itemName, $itemName]);
+                    array_push($items, (new SelectOption((string) $itemName, $itemName))->toArray());
                 }
             } else {
                 foreach ($itemNames as $itemName) {
@@ -201,7 +202,7 @@ abstract class AbstractMultiValueFormField extends AbstractFormField implements 
                         '',
                         $this->getPath() . '.option.' . $itemName
                     );
-                    array_push($items, [$resolvedLabel, $itemName]);
+                    array_push($items, (new SelectOption((string) $resolvedLabel, $itemName))->toArray());
                 }
             }
         } elseif (true === is_array($this->items) || true === $this->items instanceof \Traversable) {
@@ -209,7 +210,7 @@ abstract class AbstractMultiValueFormField extends AbstractFormField implements 
                 if (true === is_array($itemValue) || true === $itemValue instanceof \ArrayObject) {
                     array_push($items, $itemValue);
                 } else {
-                    array_push($items, [$itemValue, $itemIndex]);
+                    array_push($items, (new SelectOption($itemValue, $itemIndex))->toArray());
                 }
             }
         }
@@ -218,9 +219,10 @@ abstract class AbstractMultiValueFormField extends AbstractFormField implements 
             if (is_array($emptyOption)) {
                 array_unshift($items, $emptyOption);
             } else {
-                array_unshift($items, [$emptyOption, '']);
+                array_unshift($items, (new SelectOption((string) $emptyOption, ''))->toArray());
             }
         }
+
         return $items;
     }
 

--- a/Tests/Unit/Content/TypeDefinition/RecordBased/RecordBasedContentGridProviderTest.php
+++ b/Tests/Unit/Content/TypeDefinition/RecordBased/RecordBasedContentGridProviderTest.php
@@ -14,6 +14,7 @@ use FluidTYPO3\Flux\Content\TypeDefinition\ContentTypeDefinitionInterface;
 use FluidTYPO3\Flux\Content\TypeDefinition\RecordBased\RecordBasedContentGridProvider;
 use FluidTYPO3\Flux\Form;
 use FluidTYPO3\Flux\Form\Transformation\FormDataTransformer;
+use FluidTYPO3\Flux\Integration\FormEngine\SelectOption;
 use FluidTYPO3\Flux\Service\CacheService;
 use FluidTYPO3\Flux\Service\TypoScriptService;
 use FluidTYPO3\Flux\Service\WorkspacesAwareRecordService;
@@ -88,6 +89,11 @@ class RecordBasedContentGridProviderTest extends AbstractTestCase
 
     public function testPostProcessDataStructureReturnsStructureFromContentGridForm(): void
     {
+        $gridModeItems = [
+            (new SelectOption('rows', 'rows'))->toArray(),
+            (new SelectOption('columns', 'columns'))->toArray(),
+        ];
+
         $expected = [
             'meta' => [
                 'langDisable' => 1,
@@ -113,10 +119,7 @@ class RecordBasedContentGridProviderTest extends AbstractTestCase
                                     'minitems' => 0,
                                     'multiple' => false,
                                     'renderType' => 'selectSingle',
-                                    'items' => [
-                                        ['rows' ,'rows'],
-                                        ['columns', 'columns'],
-                                    ],
+                                    'items' => $gridModeItems,
                                 ],
                             ],
                             'autoColumns' => [

--- a/Tests/Unit/Form/Container/SectionTest.php
+++ b/Tests/Unit/Form/Container/SectionTest.php
@@ -11,6 +11,7 @@ namespace FluidTYPO3\Flux\Tests\Unit\Form\Container;
 use FluidTYPO3\Flux\Form\Container\Section;
 use FluidTYPO3\Flux\Form\Container\SectionObject;
 use FluidTYPO3\Flux\Form\Field\Input;
+use FluidTYPO3\Flux\Integration\FormEngine\SelectOption;
 
 class SectionTest extends AbstractContainerTest
 {
@@ -40,6 +41,21 @@ class SectionTest extends AbstractContainerTest
 
     public function testCreateSectionWithContentContainer(): void
     {
+        $colspanItems = [
+            (new SelectOption(1, 1))->toArray(),
+            (new SelectOption(2, 2))->toArray(),
+            (new SelectOption(3, 3))->toArray(),
+            (new SelectOption(4, 4))->toArray(),
+            (new SelectOption(5, 5))->toArray(),
+            (new SelectOption(6, 6))->toArray(),
+            (new SelectOption(7, 7))->toArray(),
+            (new SelectOption(8, 8))->toArray(),
+            (new SelectOption(9, 9))->toArray(),
+            (new SelectOption(10, 10))->toArray(),
+            (new SelectOption(11, 11))->toArray(),
+            (new SelectOption(12, 12))->toArray(),
+        ];
+
         $expected = [
             'type' => 'array',
             'title' => 'LLL:EXT:flux/Resources/Private/Language/locallang.xlf:flux.test.sections.test',
@@ -76,20 +92,7 @@ class SectionTest extends AbstractContainerTest
                                 'minitems' => 0,
                                 'multiple' => false,
                                 'renderType' => 'selectSingle',
-                                'items' => [
-                                    [1, 1],
-                                    [2, 2],
-                                    [3, 3],
-                                    [4, 4],
-                                    [5, 5],
-                                    [6, 6],
-                                    [7, 7],
-                                    [8, 8],
-                                    [9, 9],
-                                    [10, 10],
-                                    [11, 11],
-                                    [12, 12],
-                                ],
+                                'items' => $colspanItems
                             ],
                         ],
                     ],

--- a/Tests/Unit/Form/Field/SelectTest.php
+++ b/Tests/Unit/Form/Field/SelectTest.php
@@ -9,6 +9,7 @@ namespace FluidTYPO3\Flux\Form\Field;
  */
 
 use FluidTYPO3\Flux\Form;
+use FluidTYPO3\Flux\Integration\FormEngine\SelectOption;
 use FluidTYPO3\Flux\Service\TypoScriptService;
 use FluidTYPO3\Flux\Tests\Unit\Form\Field\AbstractFieldTest;
 use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
@@ -173,12 +174,24 @@ class SelectTest extends AbstractFieldTest
         $form->add($instance);
 
         $instance->setItems('foo,bar');
-        $this->assertEquals([['foo', 'foo'], ['bar', 'bar']], $instance->getItems());
+        $expected = [
+            (new SelectOption('foo', 'foo'))->toArray(),
+            (new SelectOption('bar', 'bar'))->toArray()
+        ];
+        $this->assertEquals($expected, $instance->getItems());
         $instance->setTranslateCsvItems(true);
 
         $expected = [
-            ['LLL:EXT:flux/Resources/Private/Language/locallang.xlf:flux.parent.fields.child.option.foo', 'foo'],
-            ['LLL:EXT:flux/Resources/Private/Language/locallang.xlf:flux.parent.fields.child.option.bar', 'bar']
+            (new SelectOption(
+                'LLL:EXT:flux/Resources/Private/Language/locallang.xlf'
+                    . ':flux.parent.fields.child.option.foo',
+                'foo'
+            ))->toArray(),
+            (new SelectOption(
+                'LLL:EXT:flux/Resources/Private/Language/locallang.xlf'
+                    . ':flux.parent.fields.child.option.bar',
+                'bar'
+            ))->toArray()
         ];
 
         $this->assertEquals($expected, $instance->getItems());


### PR DESCRIPTION
TYPO3v12 introduced associative array keys for items in TCA select fields: label, value, icon, group.
The indexed item arrays were deprecated at the same time, throwing warnings in TYPO3v12+:

> TYPO3 Deprecation Notice:
> FlexFormTools did an on-the-fly migration of a flex form data structure.
> This is deprecated and will be removed.
> Merge the following changes into the flex form definition "content.field":
> The TCA field 'dummyField' of table 'dummyTable' uses the legacy way of
> defining 'items'.
> Please switch to associated array keys:
> label, value, icon, group, description.
> in vendor/typo3/cms-core/Classes/Configuration/FlexForm/FlexFormTools.php
> line 1127

Changelog:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Feature-99739-AssociativeArrayKeysForTCAItems.html#feature-99739-associative-array-keys-for-tca-items https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Deprecation-99739-IndexedArrayKeysForTCAItems.html#deprecation-99739-indexed-array-keys-for-tca-items