### PR TITLE
[BUGFIX] Remove TCA inline "showRemovedLocalizationRecords" property

### DIFF
--- a/Classes/Form/AbstractInlineFormField.php
+++ b/Classes/Form/AbstractInlineFormField.php
@@ -10,6 +10,7 @@ namespace FluidTYPO3\Flux\Form;
 
 use FluidTYPO3\Flux\Enum\InlineFieldControls;
 use FluidTYPO3\Flux\Enum\InlineFieldNewRecordButtonPosition;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 abstract class AbstractInlineFormField extends AbstractRelationFormField implements InlineRelationFieldInterface
 {
@@ -115,6 +116,10 @@ abstract class AbstractInlineFormField extends AbstractRelationFormField impleme
             'headerThumbnail' => $this->getHeaderThumbnail(),
             'levelLinksPosition' => $this->getLevelLinksPosition(),
         ];
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '12.0', '>=')) {
+            unset($configuration['appearance']['showRemovedLocalizationRecords']);
+        }
+
         $configuration['behaviour'] = [
             'localizationMode' => $this->getLocalizationMode(),
             'disableMovingChildrenWithParent' => $this->getDisableMovingChildrenWithParent(),


### PR DESCRIPTION
.. in TYPO3v12+ because that property has been removed.

Deprecation notice:
> TYPO3 Deprecation Notice:
> FlexFormTools did an on-the-fly migration of a flex form data
> structure.
> This is deprecated and will be removed.
> Merge the following changes into the flex form definition
> "content.fieldname":
> The TCA field 'dummyField' of table 'dummyTable' is defined as type
> 'inline' with the 'appearance.showRemovedLocalizationRecords' option
> set. As this option is not evaluated anymore and no replacement
> exists, it should be removed from TCA.

TYPO3 core patch:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/69665