### PR TITLE
[BUGFIX] Use ExpressionBuilder::and when available, andX as fallback

### DIFF
--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -149,7 +149,7 @@ class DataHandlerSubscriber
         if ($newColumnPosition > 0) {
             $queryBuilder = $this->createQueryBuilderForTable($table);
             $expr = $queryBuilder->expr();
-            $andMethodName = method_exists($expr, 'andX') ? 'andX' : 'and';
+            $andMethodName = method_exists($expr, 'and') ? 'and' : 'andX';
             $queryBuilder->update($table)->set('colPos', $newColumnPosition, true, Connection::PARAM_INT)->where(
                 $expr->eq(
                     'uid',


### PR DESCRIPTION
TYPO3v12 brings a deprecation warning when copying a container with nested content elements:
> TYPO3 Deprecation Notice:
> ExpressionBuilder::andX() will be removed in TYPO3 v13.0.
> Use ExpressionBuilder::and() instead. in
> vendor/typo3/cms-core/Classes/Database/Query/Expression/ExpressionBuilder.php
> line 72

The `and` method was introduced in TYPO3v11, and in v12 it was deprecated.

This patch switches the order: When `and` is available, it is used, and the code falls back to `andX` for TYPO3v10.

Changelog:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-97354-ExpressionBuilderMethodsAndXAndOrX.html

Resolves: https://github.com/FluidTYPO3/flux/issues/2233
Related: f3826ca0d5509d17b16b4a0209507ec144524c0c.