### PR TITLE
[BUGFIX] Fix for colPos handling in ColumnPositionItems.php

### DIFF
--- a/Classes/Integration/HookSubscribers/ColumnPositionItems.php
+++ b/Classes/Integration/HookSubscribers/ColumnPositionItems.php
@@ -27,9 +27,12 @@ class ColumnPositionItems
      */
     public function colPosListItemProcFunc(array &$parameters): void
     {
-        $parentRecordUid = ColumnNumberUtility::calculateParentUid($parameters['row']['colPos']);
+        $colPos = isset($parameters['row']['colPos']) ? (int)$parameters['row']['colPos'] : 0;
+
+        $parentRecordUid = ColumnNumberUtility::calculateParentUid($colPos);
         $parentRecord = $this->recordService->getSingle('tt_content', '*', $parentRecordUid);
         $provider = $this->providerResolver->resolvePrimaryConfigurationProvider('tt_content', null, $parentRecord);
+
         if ($parentRecord && $provider instanceof GridProviderInterface) {
             $grid = $provider->getGrid($parentRecord);
             /** @var SelectOption $dividerItem */
@@ -39,6 +42,7 @@ class ColumnPositionItems
                 '--div--'
             );
             $parameters['items'][] = $dividerItem->toArray();
+
             foreach ($grid->getRows() as $row) {
                 foreach ($row->getColumns() as $column) {
                     /** @var SelectOption $item */


### PR DESCRIPTION
**Description**
This pull request fixes a bug in the colPosListItemProcFunc method of the ColumnPositionItems class. The issue occurred when the $parameters['row']['colPos'] value was not set, which led to incorrect or unexpected behavior when calculating the parent record UID. By ensuring that the colPos value is checked and cast to an integer (defaulting to 0 when not set), we prevent potential runtime errors and ensure consistent behavior.

**Motivation**
The bug was reported in scenarios where the colPos parameter was missing from the $parameters array. Since this value is critical for determining the parent record UID via the ColumnNumberUtility::calculateParentUid() method, missing or invalid data could lead to issues in rendering the backend layout columns. This fix enhances the robustness of the code by providing a reliable fallback and avoiding errors.

**Changes Made**
Added a check for the existence of $parameters['row']['colPos'].
Cast the value to an integer, defaulting to 0 if not set.
Updated the calculation of parentRecordUid to use the safe, validated colPos value.

**Testing**
Manually verified that the patch applies correctly.
Confirmed that the fix resolves the issue when the colPos parameter is missing.
All existing tests pass without modification.

**Backwards Compatibility**
This is a non-breaking bugfix. The change introduces a safe fallback for missing data without altering the intended behavior when the colPos is provided.

**Related Issues**
No related issue has been linked to this PR yet.