### PR TITLE
[BUGFIX] Fixed processCmdmap_postProcess hook implementation

### DIFF
--- a/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
+++ b/Classes/Integration/HookSubscribers/DataHandlerSubscriber.php
@@ -369,7 +369,7 @@ class DataHandlerSubscriber
      */
     // @phpcs:ignore PSR1.Methods.CamelCapsMethodName
     public function processCmdmap_postProcess(
-        &$command,
+        $command,
         $table,
         $id,
         &$relativeTo,


### PR DESCRIPTION
The `$command` argument can not be passed by reference.

Refs #2250