### PR TITLE
[BUGFIX] Fix flux content record not being overlayed properly inside active workspaces

### DIFF
--- a/Classes/Service/WorkspacesAwareRecordService.php
+++ b/Classes/Service/WorkspacesAwareRecordService.php
@@ -72,8 +72,7 @@ class WorkspacesAwareRecordService extends RecordService implements SingletonInt
     {
         $copy = false;
         if ($this->hasWorkspacesSupport($table)) {
-            $copy = $record;
-            $this->overlayRecordInternal($table, $copy);
+            $copy = $this->overlayRecordInternal($table, $record);
         }
         return $copy === false ? $record : $copy;
     }


### PR DESCRIPTION
Closes #2177

When trying to fetch singular records using `WorkspacesAwareRecordService->getSingle`, the records were not properly overlayed with data from workspace records.

This PR fixes that by properly using the return value of `WorkspacesAwareRecordService->overlayRecordInternal` which was assumed to be pass-by-reference. 