### PR TITLE
[BUGFIX] Fix error due to undefined array key "colPos" in colPosListItemProcFunc

### DIFF
--- a/Classes/Integration/HookSubscribers/ColumnPositionItems.php
+++ b/Classes/Integration/HookSubscribers/ColumnPositionItems.php
@@ -27,6 +27,9 @@ class ColumnPositionItems
      */
     public function colPosListItemProcFunc(array &$parameters): void
     {
+        if (!isset($parameters['row']['colPos'])) {
+            return;
+        }
         $parentRecordUid = ColumnNumberUtility::calculateParentUid($parameters['row']['colPos']);
         $parentRecord = $this->recordService->getSingle('tt_content', '*', $parentRecordUid);
         $provider = $this->providerResolver->resolvePrimaryConfigurationProvider('tt_content', null, $parentRecord);


### PR DESCRIPTION
When viewing the history in TYPO3 backend, colPosListItemProcFunc is called with parameters that don't include "colPos". Trying to calculate the parent uid caused an error in these cases.

Fixes #2241.