### PR TITLE
[TASK] Prevent deprecation warnings

### DIFF
--- a/Classes/Builder/RenderingContextBuilder.php
+++ b/Classes/Builder/RenderingContextBuilder.php
@@ -39,19 +39,15 @@ class RenderingContextBuilder implements SingletonInterface
 
         $renderingContext = $this->createRenderingContextInstance();
 
-        /** @var RequestInterface&Request $request */
-        $request = $this->requestBuilder->buildRequestFor(
-            $extensionIdentity,
-            $controllerName,
-            $controllerActionName,
-            $pluginName
-        );
-
-        if (method_exists($renderingContext, 'setRequest')) {
-            $renderingContext->setRequest($request);
-        }
-
         if (method_exists($renderingContext, 'getControllerContext')) {
+            /** @var RequestInterface&Request $request */
+            $request = $this->requestBuilder->buildRequestFor(
+                $extensionIdentity,
+                $controllerName,
+                $controllerActionName,
+                $pluginName
+            );
+
             /** @var ControllerContext $controllerContext */
             $controllerContext = $this->buildControllerContext($request);
             try {

--- a/Classes/Builder/ViewBuilder.php
+++ b/Classes/Builder/ViewBuilder.php
@@ -11,18 +11,28 @@ namespace FluidTYPO3\Flux\Builder;
 
 use FluidTYPO3\Flux\Integration\PreviewView;
 use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+use TYPO3\CMS\Core\View\ViewFactoryData;
+use TYPO3\CMS\Core\View\ViewFactoryInterface;
+use TYPO3\CMS\Extbase\Mvc\Request;
+use TYPO3\CMS\Extbase\Mvc\RequestInterface;
 use TYPO3\CMS\Fluid\View\TemplatePaths;
 use TYPO3\CMS\Fluid\View\TemplateView;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\View\ViewInterface;
 
 class ViewBuilder
 {
     protected RenderingContextBuilder $renderingContextBuilder;
+    protected RequestBuilder $requestBuilder;
 
-    public function __construct(RenderingContextBuilder $renderingContextBuilder)
+    public function __construct(RenderingContextBuilder $renderingContextBuilder, RequestBuilder $requestBuilder)
     {
         $this->renderingContextBuilder = $renderingContextBuilder;
+        $this->requestBuilder = $requestBuilder;
     }
 
     public function buildPreviewView(
@@ -42,24 +52,32 @@ class ViewBuilder
             $pluginName
         );
 
-        $templatePaths = $this->buildTemplatePaths($extensionIdentity);
-        if ($templatePathAndFilename) {
-            $templatePaths->setTemplatePathAndFilename($templatePathAndFilename);
-        }
-        $renderingContext->setTemplatePaths($templatePaths);
-
         /** @var PreviewView $view */
-        $view = GeneralUtility::makeInstance($viewClassName);
-        $view->setRenderingContext($renderingContext);
+        $view = $this->createViewInstance(
+            $viewClassName,
+            $extensionIdentity,
+            $renderingContext,
+            $templatePathAndFilename,
+            $this->requestBuilder->buildRequestFor(
+                $extensionIdentity,
+                $controllerName,
+                $controllerAction,
+                $pluginName
+            )
+        );
         return $view;
     }
 
+    /**
+     * @param ServerRequestInterface|RequestInterface|null $request
+     */
     public function buildTemplateView(
         string $extensionIdentity,
         string $controllerName,
         string $controllerAction,
         string $pluginName,
-        ?string $templatePathAndFilename = null
+        ?string $templatePathAndFilename = null,
+        $request = null
     ): ViewInterface {
         /** @var class-string $viewClassName */
         $viewClassName = TemplateView::class;
@@ -71,16 +89,13 @@ class ViewBuilder
             $pluginName
         );
 
-        $templatePaths = $this->buildTemplatePaths($extensionIdentity);
-        if ($templatePathAndFilename) {
-            $templatePaths->setTemplatePathAndFilename($templatePathAndFilename);
-        }
-        $renderingContext->setTemplatePaths($templatePaths);
-
-        /** @var TemplateView $view */
-        $view = GeneralUtility::makeInstance($viewClassName);
-        $view->setRenderingContext($renderingContext);
-        return $view;
+        return $this->createViewInstance(
+            $viewClassName,
+            $extensionIdentity,
+            $renderingContext,
+            $templatePathAndFilename,
+            $request
+        );
     }
 
     /**
@@ -91,6 +106,18 @@ class ViewBuilder
     {
         /** @var TemplatePaths $paths */
         $paths = GeneralUtility::makeInstance(TemplatePaths::class);
+
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '13.4', '>=')) {
+            if (!is_array($extensionKeyOrConfiguration)) {
+                $extensionKey = ExtensionNamingUtility::getExtensionKey($extensionKeyOrConfiguration);
+                $resources = ExtensionManagementUtility::extPath($extensionKey) . 'Resources/Private/';
+                $extensionKeyOrConfiguration = [
+                    TemplatePaths::CONFIG_TEMPLATEROOTPATHS => [$resources . 'Templates/'],
+                    TemplatePaths::CONFIG_PARTIALROOTPATHS => [$resources . 'Partials/'],
+                    TemplatePaths::CONFIG_LAYOUTROOTPATHS => [$resources . 'Layouts/'],
+                ];
+            }
+        }
 
         if (is_array($extensionKeyOrConfiguration)) {
             $paths->setTemplateRootPaths($extensionKeyOrConfiguration[TemplatePaths::CONFIG_TEMPLATEROOTPATHS]);
@@ -119,6 +146,53 @@ class ViewBuilder
         return $paths;
     }
 
+    /**
+     * @param string&class-string $viewClassName
+     * @param ServerRequestInterface|RequestInterface|null $request
+     */
+    protected function createViewInstance(
+        string $viewClassName,
+        string $extensionIdentity,
+        RenderingContextInterface $renderingContext,
+        ?string $templatePathAndFilename,
+        $request = null
+    ): ViewInterface {
+        if (interface_exists(ViewFactoryInterface::class)) {
+            $templatePaths = $this->buildTemplatePaths($extensionIdentity);
+
+            $viewFactoryData = GeneralUtility::makeInstance(
+                ViewFactoryData::class,
+                $templatePaths->getTemplateRootPaths(),
+                $templatePaths->getPartialRootPaths(),
+                $templatePaths->getLayoutRootPaths(),
+                $templatePathAndFilename,
+                $request
+            );
+            /** @var ViewFactoryInterface $factory */
+            $factory = GeneralUtility::makeInstance(ViewFactoryInterface::class);
+            /** @var ViewInterface $view */
+            $view = $factory->create($viewFactoryData);
+        } else {
+            $templatePaths = $this->buildTemplatePaths($extensionIdentity);
+            if ($templatePathAndFilename) {
+                $templatePaths->setTemplatePathAndFilename($templatePathAndFilename);
+            }
+            $renderingContext->setTemplatePaths($templatePaths);
+
+            if ($request && method_exists($renderingContext, 'setRequest')) {
+                $renderingContext->setRequest($request);
+            }
+
+            /** @var ViewInterface $view */
+            $view = GeneralUtility::makeInstance($viewClassName);
+            if (method_exists($view, 'setRenderingContext')) {
+                $view->setRenderingContext($renderingContext);
+            }
+        }
+
+        return $view;
+    }
+    
     private function createFluidPathSet(string $extensionKey, string $subPath): array
     {
         return [

--- a/Classes/Controller/AbstractFluxController.php
+++ b/Classes/Controller/AbstractFluxController.php
@@ -40,7 +40,6 @@ use TYPO3\CMS\Extbase\Mvc\ResponseInterface;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
-use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 use TYPO3Fluid\Fluid\View\ViewInterface;
 
@@ -245,33 +244,27 @@ abstract class AbstractFluxController extends ActionController
                 1672082347
             );
         }
-        /** @var TemplateView $view */
-        $view = GeneralUtility::makeInstance(TemplateView::class);
+
         $record = $this->getRecord();
         $extensionKey = ExtensionNamingUtility::getExtensionKey(
             $this->provider->getControllerExtensionKeyFromRecord($record)
         );
-        $extensionName = ExtensionNamingUtility::getExtensionName($extensionKey);
-        $controllerActionName = $this->provider->getControllerActionFromRecord($record);
 
-        $templatePaths = $this->viewBuilder->buildTemplatePaths($extensionKey);
-
-        /** @var RenderingContextInterface $renderingContext */
-        $renderingContext = $view->getRenderingContext();
-
-        $renderingContext = $this->renderingContextBuilder->buildRenderingContextFor(
-            $extensionName,
-            $this->resolver->resolveControllerNameFromControllerClassName(get_class($this)),
-            $controllerActionName,
-            $this->provider->getPluginName() ?? $this->provider->getControllerNameFromRecord($record)
-        );
-        if (method_exists($renderingContext, 'setRequest')) {
-            $renderingContext->setRequest($this->request);
+        $templatePathAndFilename = null;
+        if ($this->provider instanceof FluidProviderInterface) {
+            $templatePathAndFilename = $this->provider->getTemplatePathAndFilename($record);
         }
-        $renderingContext->setTemplatePaths($templatePaths);
-        $renderingContext->setControllerAction($controllerActionName);
 
-        $view->setRenderingContext($renderingContext);
+        $view = $this->viewBuilder->buildTemplateView(
+            $extensionKey,
+            $this->resolver->resolveControllerNameFromControllerClassName(get_class($this)),
+            $this->provider->getControllerActionFromRecord($record),
+            $this->provider->getPluginName() ?? $this->provider->getControllerNameFromRecord($record),
+            $templatePathAndFilename,
+            $this->request
+        );
+
+        $renderingContext = $view->getRenderingContext();
 
         $this->initializeViewVariables($view);
         $this->initializeViewHelperVariableContainer($renderingContext->getViewHelperVariableContainer());
@@ -391,10 +384,6 @@ abstract class AbstractFluxController extends ActionController
                     $this->request = $this->request->withControllerExtensionName($vendorLessExtensionName);
                 }
 
-                if (method_exists($renderingContext, 'setRequest')) {
-                    $renderingContext->setRequest($this->request);
-                }
-
                 $this->configurationManager->setConfiguration(
                     array_merge(
                         (array) $this->configurationManager->getConfiguration(
@@ -405,9 +394,6 @@ abstract class AbstractFluxController extends ActionController
                             'extensionName' => $vendorLessExtensionName,
                         ]
                     )
-                );
-                $paths->fillDefaultsByPackageName(
-                    GeneralUtility::camelCaseToLowerCaseUnderscored($vendorLessExtensionName)
                 );
                 $paths->setTemplatePathAndFilename((string) $templatePathAndFilename);
             }

--- a/Classes/Service/PageService.php
+++ b/Classes/Service/PageService.php
@@ -28,7 +28,6 @@ use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Fluid\View\TemplatePaths;
-use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\Component\Error\ChildNotFoundException;
 use TYPO3Fluid\Fluid\View\Exception\InvalidSectionException;
 use TYPO3Fluid\Fluid\View\ViewInterface;
@@ -301,15 +300,13 @@ class PageService implements SingletonInterface, LoggerAwareInterface
         TemplatePaths $templatePaths,
         \SplFileInfo $file
     ): ViewInterface {
-        /** @var TemplateView $view */
-        $view = GeneralUtility::makeInstance(TemplateView::class);
+        $view = $this->viewBuilder->buildTemplateView($extensionName, 'Page', 'default', 'Page', $file->getPathname());
         $view->getRenderingContext()->setTemplatePaths($templatePaths);
         $view->getRenderingContext()->getViewHelperVariableContainer()->addOrUpdate(
             FormViewHelper::SCOPE,
             FormViewHelper::SCOPE_VARIABLE_EXTENSIONNAME,
             $extensionName
         );
-        $templatePaths->setTemplatePathAndFilename($file->getPathname());
         return $view;
     }
 

--- a/Classes/ViewHelpers/AbstractFormViewHelper.php
+++ b/Classes/ViewHelpers/AbstractFormViewHelper.php
@@ -15,7 +15,7 @@ use FluidTYPO3\Flux\Form\FormInterface;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3Fluid\Fluid\Component\Argument\ArgumentCollection;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use FluidTYPO3\Flux\ViewHelpers\AbstractViewHelper;
 
 /**
  * Base class for all FlexForm related ViewHelpers

--- a/Classes/ViewHelpers/AbstractViewHelper.php
+++ b/Classes/ViewHelpers/AbstractViewHelper.php
@@ -1,0 +1,19 @@
+<?php
+namespace FluidTYPO3\Flux\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Component\Argument\ArgumentCollection;
+
+class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper
+{
+    /**
+     * @return mixed
+     */
+    public function render()
+    {
+        return static::renderStatic(
+            $this->arguments instanceof ArgumentCollection ? $this->arguments->getArrayCopy() : $this->arguments,
+            $this->buildRenderChildrenClosure(),
+            $this->renderingContext
+        );
+    }
+}

--- a/Classes/ViewHelpers/Content/GetViewHelper.php
+++ b/Classes/ViewHelpers/Content/GetViewHelper.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use FluidTYPO3\Flux\ViewHelpers\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
 /**

--- a/Classes/ViewHelpers/Form/DataViewHelper.php
+++ b/Classes/ViewHelpers/Form/DataViewHelper.php
@@ -17,7 +17,7 @@ use FluidTYPO3\Flux\Service\WorkspacesAwareRecordService;
 use FluidTYPO3\Flux\Utility\RecursiveArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use FluidTYPO3\Flux\ViewHelpers\AbstractViewHelper;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
 /**

--- a/Classes/ViewHelpers/Form/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Form/RenderViewHelper.php
@@ -14,7 +14,7 @@ use FluidTYPO3\Flux\Form;
 use TYPO3\CMS\Backend\Form\NodeFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use FluidTYPO3\Flux\ViewHelpers\AbstractViewHelper;
 
 /**
  * ## Main form rendering ViewHelper

--- a/Classes/ViewHelpers/InlineViewHelper.php
+++ b/Classes/ViewHelpers/InlineViewHelper.php
@@ -11,7 +11,7 @@ namespace FluidTYPO3\Flux\ViewHelpers;
 
 use TYPO3Fluid\Fluid\Core\Parser\Source;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use FluidTYPO3\Flux\ViewHelpers\AbstractViewHelper;
 
 /**
  * Inline Fluid rendering ViewHelper

--- a/Tests/Unit/Builder/ViewBuilderTest.php
+++ b/Tests/Unit/Builder/ViewBuilderTest.php
@@ -9,10 +9,12 @@ namespace FluidTYPO3\Flux\Tests\Unit\Builder;
  */
 
 use FluidTYPO3\Flux\Builder\RenderingContextBuilder;
+use FluidTYPO3\Flux\Builder\RequestBuilder;
 use FluidTYPO3\Flux\Builder\ViewBuilder;
 use FluidTYPO3\Flux\Integration\PreviewView;
 use FluidTYPO3\Flux\Tests\Unit\AbstractTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\View\ViewInterface;
 use TYPO3\CMS\Fluid\View\TemplatePaths;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
@@ -20,12 +22,16 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 class ViewBuilderTest extends AbstractTestCase
 {
     protected RenderingContextBuilder $renderingContextBuilder;
+    protected RequestBuilder $requestBuilder;
 
     protected function setUp(): void
     {
         $renderingContext = $this->getMockBuilder(RenderingContextInterface::class)->getMockForAbstractClass();
         $this->renderingContextBuilder = $this->getMockBuilder(RenderingContextBuilder::class)
             ->setMethods(['buildRenderingContextFor'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->requestBuilder = $this->getMockBuilder(RequestBuilder::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->renderingContextBuilder->method('buildRenderingContextFor')->willReturn($renderingContext);
@@ -39,10 +45,13 @@ class ViewBuilderTest extends AbstractTestCase
         GeneralUtility::addInstance(TemplateView::class, $view);
 
         $subject = $this->getMockBuilder(ViewBuilder::class)
-            ->onlyMethods(['buildTemplatePaths'])
-            ->setConstructorArgs([$this->renderingContextBuilder])
+            ->onlyMethods(['buildTemplatePaths', 'createViewInstance'])
+            ->setConstructorArgs([$this->renderingContextBuilder, $this->requestBuilder])
             ->getMock();
         $subject->method('buildTemplatePaths')->willReturn(new TemplatePaths());
+        $subject->method('createViewInstance')->willReturn(
+            $this->getMockBuilder(TemplateView::class)->disableOriginalConstructor()->getMockForAbstractClass()
+        );
 
         $view = $subject->buildTemplateView('FluidTYPO3.Flux', 'Default', 'default', 'defaut');
         self::assertInstanceOf(TemplateView::class, $view);
@@ -54,10 +63,13 @@ class ViewBuilderTest extends AbstractTestCase
         GeneralUtility::addInstance(PreviewView::class, $view);
 
         $subject = $this->getMockBuilder(ViewBuilder::class)
-            ->onlyMethods(['buildTemplatePaths'])
-            ->setConstructorArgs([$this->renderingContextBuilder])
+            ->onlyMethods(['buildTemplatePaths', 'createViewInstance'])
+            ->setConstructorArgs([$this->renderingContextBuilder, $this->requestBuilder])
             ->getMock();
         $subject->method('buildTemplatePaths')->willReturn(new TemplatePaths());
+        $subject->method('createViewInstance')->willReturn(
+            $this->getMockBuilder(PreviewView::class)->disableOriginalConstructor()->getMockForAbstractClass()
+        );
 
         $view = $subject->buildPreviewView('FluidTYPO3.Flux', 'Default', 'default', 'default');
         self::assertInstanceOf(PreviewView::class, $view);

--- a/Tests/Unit/Controller/AbstractFluxControllerTestCase.php
+++ b/Tests/Unit/Controller/AbstractFluxControllerTestCase.php
@@ -105,10 +105,22 @@ abstract class AbstractFluxControllerTestCase extends AbstractTestCase
 
         $this->resolver = new Resolver();
 
-        $this->viewBuilder = $this->getMockBuilder(ViewBuilder::class)
-            ->onlyMethods(['buildTemplatePaths'])
+        $viewHelperVariableContainer = $this->getMockBuilder(ViewHelperVariableContainer::class)->getMock();
+
+        $renderingContext = $this->getMockBuilder(RenderingContextInterface::class)->getMock();
+        $renderingContext->method('getViewHelperVariableContainer')->willReturn($viewHelperVariableContainer);
+
+        $view = $this->getMockBuilder(TemplateView::class)
+            ->onlyMethods(['getRenderingContext'])
             ->disableOriginalConstructor()
             ->getMock();
+        $view->method('getRenderingContext')->willReturn($renderingContext);
+
+        $this->viewBuilder = $this->getMockBuilder(ViewBuilder::class)
+            ->onlyMethods(['buildTemplatePaths', 'buildTemplateView'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->viewBuilder->method('buildTemplateView')->willReturn($view);
 
         parent::setUp();
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,7 @@ parameters:
         - "#^Call to an undefined method TYPO3\\\\CMS\\\\Core\\\\Page\\\\PageRenderer\\:\\:loadRequireJsModule\\(\\)\\.$#"
         - "#^Call to an undefined method TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface\\:\\:getRenderingContext\\(\\)\\.$#"
         - "#^Call to an undefined method TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface\\:\\:renderSection\\(\\)\\.$#"
+        - "#^Call to an undefined static method FluidTYPO3\\\\Flux\\\\ViewHelpers\\\\AbstractViewHelper\\:\\:renderStatic\\(\\)\\.$#"
 
         - "#(invalid (return )?type|unknown class) Doctrine\\\\DBAL\\\\FetchMode#"
         - "#(invalid (return )?type|unknown class) TYPO3\\\\CMS\\\\Backend\\\\Controller\\\\Event\\\\AfterPageColumnsSelectedForLocalizationEvent#"
@@ -47,6 +48,8 @@ parameters:
         - "#^Class TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\ResponseInterface not found\\.$#"
         - "#^Class TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\Web\\\\Request not found\\.$#"
         - "#^Class TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\Web\\\\Response not found\\.$#"
+        - "#^Class TYPO3Fluid\\\\Fluid\\\\Component\\\\Argument\\\\ArgumentCollection not found\\.$#"
+        - "#^Class TYPO3\\\\CMS\\\\Core\\\\View\\\\ViewFactoryData not found\\.$#"
 
         - "#TYPO3Fluid\\\\Fluid\\\\Component\\\\Argument\\\\ArgumentCollection#"
         - "#TYPO3Fluid\\\\Fluid\\\\Component\\\\Error\\\\ChildNotFoundException#"


### PR DESCRIPTION
Adds a backwards compatible base VH class and uses the ViewBuilder in more places, which now has a condition to use the ViewFactoryInterface to avoid constructing TemplateView instances on v13.