### PR TITLE
"description" attribute support

### DIFF
--- a/Classes/Form/AbstractFormField.php
+++ b/Classes/Form/AbstractFormField.php
@@ -102,6 +102,9 @@ abstract class AbstractFormField extends AbstractFormComponent implements FieldI
             'exclude' => intval($this->getExclude()),
             'config' => $configuration
         ];
+        if (($description = $this->getDescription()) && $description !== null) {
+            $fieldStructureArray['description'] = $this->getDescription();
+        }
         if (($displayCondition = $this->getDisplayCondition())) {
             $fieldStructureArray['displayCond'] = $displayCondition;
         }

--- a/Classes/ViewHelpers/Field/AbstractFieldViewHelper.php
+++ b/Classes/ViewHelpers/Field/AbstractFieldViewHelper.php
@@ -30,6 +30,7 @@ abstract class AbstractFieldViewHelper extends AbstractFormViewHelper
             'the name of the field.'
         );
         $this->registerArgument('default', 'string', 'Default value for this attribute');
+        $this->registerArgument('description', 'string', 'Field description', false);
         $this->registerArgument(
             'native',
             'boolean',
@@ -161,6 +162,7 @@ abstract class AbstractFieldViewHelper extends AbstractFormViewHelper
             static::getExtensionNameFromRenderingContextOrArguments($renderingContext, $arguments)
         );
         $component->setDefault($arguments['default']);
+        $component->setDescription($arguments['description']);
         $component->setRequired($arguments['required']);
         $component->setExclude($arguments['exclude']);
         $component->setEnabled($arguments['enabled']);

--- a/Tests/Unit/Form/Field/TextTest.php
+++ b/Tests/Unit/Form/Field/TextTest.php
@@ -41,6 +41,15 @@ class TextTest extends InputTest
         $this->assertTrue($instance->getEnableRichText());
     }
 
+    public function testBuildDescription()
+    {
+        $subject = Text::create(['name' => 'test', 'description' => 'desc']);
+        $config = $subject->build();
+        $this->assertArrayHasKey('label', $config);
+        $this->assertArrayHasKey('description', $config);
+        $this->assertEquals('desc', $config['description']);
+    }
+
     public function testBuildConfigurationWithRteResolving(): void
     {
         $subject = $this->getMockBuilder(Text::class)

--- a/Tests/Unit/Form/FieldTest.php
+++ b/Tests/Unit/Form/FieldTest.php
@@ -60,6 +60,20 @@ class FieldTest extends AbstractTestCase
         );
     }
 
+    public function testBuildSupportsDescription(): void
+    {
+        $settings = [
+            'type' => 'input',
+            'name' => 'test',
+            'description' => 'desc',
+        ];
+        $subject = Field::create($settings);
+        $output = $subject->build();
+
+        self::assertArrayHasKey('description', $output);
+        self::assertEquals('desc', $output['description']);
+    }
+
     public function testCanGetAndSetType(): void
     {
         $this->assertGetterAndSetterWorks('type', 'sometype', null, true);

--- a/Tests/Unit/ViewHelpers/Field/Inline/FalViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Field/Inline/FalViewHelperTest.php
@@ -32,6 +32,23 @@ class FalViewHelperTest extends AbstractFieldViewHelperTestCase
     /**
      * @test
      */
+    public function supportsDescription()
+    {
+        $arguments = [
+            'name' => 'test',
+            'description' => 'testdesc'
+        ];
+        $instance = $this->buildViewHelperInstance($arguments, []);
+        $component = $instance->getComponent(
+            $this->renderingContext,
+            $this->buildViewHelperArguments($instance, $arguments)
+        );
+        $this->assertEquals($arguments['description'], $component->getDescription());
+    }
+
+    /**
+     * @test
+     */
     public function supportsHeaderThumbnail()
     {
         $arguments = [

--- a/Tests/Unit/ViewHelpers/Field/TextViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/Field/TextViewHelperTest.php
@@ -17,6 +17,20 @@ class TextViewHelperTest extends AbstractFieldViewHelperTestCase
     /**
      * @test
      */
+    public function supportsDescription()
+    {
+        $arguments = ['name' => 'test', 'description' => 'testdesc'];
+        $instance = $this->buildViewHelperInstance($arguments);
+        $component = $instance->getComponent(
+            $this->getInaccessiblePropertyValue($instance, 'renderingContext'),
+            $this->getInaccessiblePropertyValue($instance, 'arguments')
+        );
+        $this->assertSame($arguments['description'], $component->getDescription());
+    }
+
+    /**
+     * @test
+     */
     public function supportsPlaceholders()
     {
         $arguments = ['name' => 'test', 'placeholder' => 'test'];

--- a/Tests/Unit/ViewHelpers/FieldViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/FieldViewHelperTest.php
@@ -16,4 +16,18 @@ class FieldViewHelperTest extends AbstractFieldViewHelperTestCase
         'name' => 'test',
         'type' => 'input',
     ];
+
+    /**
+     * @test
+     */
+    public function supportsDescription()
+    {
+        $arguments = ['name' => 'test', 'type' => 'input', 'description' => 'testdesc'];
+        $instance = $this->buildViewHelperInstance($arguments);
+        $component = $instance->getComponent(
+            $this->getInaccessiblePropertyValue($instance, 'renderingContext'),
+            $this->getInaccessiblePropertyValue($instance, 'arguments')
+        );
+        $this->assertSame($arguments['description'], $component->getDescription());
+    }
 }


### PR DESCRIPTION
"description" has been supported in `<flux:field>` already, but not for the dedicated field types.
This patch adds support for the attribute in e.g. `<flux:field.input>`

Related: https://github.com/FluidTYPO3/flux/pull/1891