### PR TITLE
Backend error on creating / editing any content element

### DIFF
--- a/Classes/Integration/FormEngine/ProviderProcessor.php
+++ b/Classes/Integration/FormEngine/ProviderProcessor.php
@@ -40,11 +40,15 @@ class ProviderProcessor implements FormDataProviderInterface
                 try {
                     $site = $this->siteFinder->getSiteByPageId($pageUid);
                     $siteConfiguration = $site->getConfiguration();
-                    $enabledContentTypes = GeneralUtility::trimExplode(
-                        ',',
-                        $siteConfiguration['flux_content_types'] ?? '',
-                        true
-                    );
+                    if (is_array($siteConfiguration['flux_content_types'])) {
+                        $enabledContentTypes = $siteConfiguration['flux_content_types'];
+                    } else {
+                        $enabledContentTypes = GeneralUtility::trimExplode(
+                            ',',
+                            $siteConfiguration['flux_content_types'] ?? '',
+                            true
+                        );
+                    }
                 } catch (SiteNotFoundException $exception) {
                     // Suppressed; sites not being found isn't a fatal problem here.
                 }

--- a/Classes/Integration/WizardItemsManipulator.php
+++ b/Classes/Integration/WizardItemsManipulator.php
@@ -36,11 +36,15 @@ class WizardItemsManipulator
         try {
             $site = $this->siteFinder->getSiteByPageId($pageUid);
             $siteConfiguration = $site->getConfiguration();
-            $enabledContentTypes = GeneralUtility::trimExplode(
-                ',',
-                $siteConfiguration['flux_content_types'] ?? '',
-                true
-            );
+            if (is_array($siteConfiguration['flux_content_types'])) {
+                $enabledContentTypes = $siteConfiguration['flux_content_types'];
+            } else {
+                $enabledContentTypes = GeneralUtility::trimExplode(
+                    ',',
+                    $siteConfiguration['flux_content_types'] ?? '',
+                    true
+                );
+            }
             if (!empty($enabledContentTypes)) {
                 $fluxContentTypeNames = (array) $this->contentTypeManager->fetchContentTypeNames();
                 $items = array_filter(


### PR DESCRIPTION
In an LTS 13 (13.4.18) system, the ‘activated content types’ from the site configuration are stored as an array. However, the code expects a string.
I fixed the problem with a simple is_array check in ProviderProcessor.php.

<img width="1017" height="532" alt="Bildschirmfoto 2025-09-24 um 14 29 28" src="https://github.com/user-attachments/assets/5a303394-591c-440d-b052-d3ea24282448" />
