### PR TITLE
[BUGFIX] Fallback to empty TS in request-less contexts

### DIFF
--- a/Classes/Service/TypoScriptService.php
+++ b/Classes/Service/TypoScriptService.php
@@ -12,6 +12,7 @@ use FluidTYPO3\Flux\Utility\ExtensionNamingUtility;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Configuration\Exception\NoServerRequestGivenException;
 
 class TypoScriptService implements SingletonInterface
 {
@@ -52,6 +53,10 @@ class TypoScriptService implements SingletonInterface
             $all = $this->configurationManager->getConfiguration(
                 ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT
             );
+        } catch (NoServerRequestGivenException $error) {
+            // This case may happen when trying to read TypoScript from a CLI context. In this case, rather than just
+            // giving up, we return an empty set of TypoScript.
+            $all = [];
         } catch (\RuntimeException $exception) {
             if ($exception->getCode() !== 1700841298) {
                 throw $exception;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,10 @@
 parameters:
     ignoreErrors:
         -
+            message: "#^Dead catch - RuntimeException is never thrown in the try block\\.$#"
+            count: 1
+            path: Classes/Service/TypoScriptService.php
+        -
             message: "#^Parameter \\#4 \\$_ of method TYPO3\\\\CMS\\\\Core\\\\DataHandling\\\\DataHandler\\:\\:log\\(\\) expects null, int given\\.$#"
             count: 1
             path: Classes/Integration/HookSubscribers/DataHandlerSubscriber.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -52,6 +52,7 @@ parameters:
         - "#^Class TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\Web\\\\Response not found\\.$#"
         - "#^Class TYPO3Fluid\\\\Fluid\\\\Component\\\\Argument\\\\ArgumentCollection not found\\.$#"
         - "#^Class TYPO3\\\\CMS\\\\Core\\\\View\\\\ViewFactoryData not found\\.$#"
+        - "#TYPO3\\\\CMS\\\\Extbase\\\\Configuration\\\\Exception\\\\NoServerRequestGivenException not found\\.$#"
 
         - "#TYPO3Fluid\\\\Fluid\\\\Component\\\\Argument\\\\ArgumentCollection#"
         - "#TYPO3Fluid\\\\Fluid\\\\Component\\\\Error\\\\ChildNotFoundException#"


### PR DESCRIPTION
Prevents issues with attempts to read FlexForm data structures in contexts that don't carry a ServerRequest, e.g. CLI context.

Falls back to an empty array.