### PR TITLE
[BUGFIX] Do not attempt parent resolution for missing colPos

### DIFF
--- a/Classes/Integration/HookSubscribers/ColumnPositionItems.php
+++ b/Classes/Integration/HookSubscribers/ColumnPositionItems.php
@@ -27,7 +27,7 @@ class ColumnPositionItems
      */
     public function colPosListItemProcFunc(array &$parameters): void
     {
-        if (!isset($parameters['row']['colPos'])) {
+        if (!isset($parameters['row']['colPos']) || ((string) $parameters['row']['colPos']) === '') {
             return;
         }
         $parentRecordUid = ColumnNumberUtility::calculateParentUid($parameters['row']['colPos']);


### PR DESCRIPTION
Adds a case that catches a defined but incompatibly-typed `colPos` value in a record when trying to read parent column positions. Some cases will pass an empty string to the function, but the current guard clause only checks if the value is undefined. So a check is added to early return in case the `colPos` value equates to an empty string.

Close: #2277