### PR TITLE
Fix #2289 Update pageUid assignment logic in PageProvider

### DIFF
--- a/Classes/Provider/PageProvider.php
+++ b/Classes/Provider/PageProvider.php
@@ -92,7 +92,7 @@ class PageProvider extends AbstractProvider implements ProviderInterface
             // The page inherits page layout from parent(s). Read the root line for the first page that defines a value
             // in the sub-action field, then use that record and resolve the Form used in the sub-configuration field.
             // If the row is a new page, use the inherited form from the parent page.
-            $pageUid = $row['uid'] ?? 0;
+            $pageUid = ($row['t3ver_oid'] > 0 ? $row['t3ver_oid'] : $row['uid'] ?? 0);
             $pageUidIsParent = false;
             if (is_string($pageUid) && substr($pageUid, 0, 3) === 'NEW') {
                 $pageUid = $row['pid'] ?? 0;


### PR DESCRIPTION
Assign live page uid when page record is a workspace record so that we can get Flux template root configuration.

@see: https://github.com/FluidTYPO3/flux/issues/2289